### PR TITLE
Node benchmark: benchmark the ioredis client.

### DIFF
--- a/benchmarks/node/package.json
+++ b/benchmarks/node/package.json
@@ -11,15 +11,16 @@
     "dependencies": {
         "@types/command-line-args": "^5.2.0",
         "@types/stats-lite": "^2.2.0",
-        "glide-for-redis": "file:../../node",
         "command-line-args": "^5.2.1",
+        "glide-for-redis": "file:../../node",
+        "ioredis": "^5.3.2",
+        "percentile": "^1.6.0",
         "redis": "^4.6.2",
-        "stats-lite": "^2.2.0",
-        "percentile": "^1.6.0"
+        "stats-lite": "^2.2.0"
     },
     "devDependencies": {
         "@types/node": "^18.7.9",
-        "typescript": "^4.8.4",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "typescript": "^4.8.4"
     }
 }


### PR DESCRIPTION
ioredis is currently the leading Node client, and so we should benchmark ourselves in comparison to it. Also kept the node-redis benchmark, since it's usually faster than ioredis.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
