### PR TITLE
Update CI for java client

### DIFF
--- a/.github/workflows/java-benchmark.yml
+++ b/.github/workflows/java-benchmark.yml
@@ -11,11 +11,17 @@ run-name: ${{ inputs.name == '' && format('{0} @ {1}', github.ref_name, github.s
 
 jobs:
     java-benchmark:
+        timeout-minutes: 25
         strategy:
+            # Run all jobs
+            fail-fast: false
             matrix:
                 java:
                     - 11
                     - 17
+                redis:
+                    - 6.2.14
+                    - 7.2.3
         runs-on: ubuntu-latest
 
         steps:
@@ -29,12 +35,17 @@ jobs:
                   distribution: "temurin"
                   java-version: ${{ matrix.java }}
 
-            - name: Start Redis
-              run: docker run -p 6379:6379 -p 8001:8001 -d redis/redis-stack
+            - name: Install redis
+              uses: ./.github/workflows/install-redis
+              with:
+                  redis-version: ${{ matrix.redis }}
 
-            - name: Run benchmarks
-              working-directory: java
-              run: ./gradlew :benchmark:run
+            - name: benchmark
+              uses: ./.github/workflows/test-benchmark
+              #   TODO - enable once benchmark works
+              if: ${{ false }}
+              with:
+                  language-flag: -java
 
             - name: Upload test reports
               if: always()

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
     build-and-test-java-client:
+        timeout-minutes: 25
         strategy:
             # Run all jobs
             fail-fast: false
@@ -29,7 +30,14 @@ jobs:
                 java:
                     - 11
                     - 17
-        runs-on: ubuntu-latest
+                redis:
+                    - 6.2.14
+                    - 7.2.3
+                os:
+                    - ubuntu-latest
+                    - macos-latest
+
+        runs-on: ${{ matrix.os }}
 
         steps:
             - uses: actions/checkout@v4
@@ -37,7 +45,7 @@ jobs:
                   submodules: recursive
 
             - name: Set up JDK ${{ matrix.java }}
-              uses: actions/setup-java@v3
+              uses: actions/setup-java@v4
               with:
                   distribution: "temurin"
                   java-version: ${{ matrix.java }}
@@ -45,15 +53,20 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: "ubuntu-latest"
-                  target: "x86_64-unknown-linux-gnu"
+                  os: ${{ matrix.os }}
+                  target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install redis
+              # TODO: make this step macos compatible: https://github.com/aws/glide-for-redis/issues/781
+              if: ${{ matrix.os == 'ubuntu-latest' }}
+              uses: ./.github/workflows/install-redis
+              with:
+                  redis-version: ${{ matrix.redis }}
 
             - name: Build rust part
               working-directory: java
               run: cargo build --release
-
-            - name: Start Redis
-              run: docker run -p 6379:6379 -p 8001:8001 -d redis/redis-stack
 
             - name: Build java part
               working-directory: java
@@ -62,17 +75,75 @@ jobs:
             - name: Upload test reports
               if: always()
               continue-on-error: true
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: test-reports-${{ matrix.java }}
                   path: |
                       java/client/build/reports/**
                       java/integTest/build/reports/**
 
-                  #   TODO - enable once benchmark works
-            # - uses: ./.github/workflows/test-benchmark
-            #   with:
-            #       language-flag: -java
+    build-amazonlinux-latest:
+        if: github.repository_owner == 'aws'
+        strategy:
+            # Run all jobs
+            fail-fast: false
+            matrix:
+                java:
+                    - 11
+                    - 17
+        runs-on: ubuntu-latest
+        container: amazonlinux:latest
+        timeout-minutes: 15
+        steps:
+            - name: Install git
+              run: |
+                  yum -y remove git
+                  yum -y remove git-*
+                  yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+                  yum update
+                  yum install -y git
+                  git --version
+
+            - uses: actions/checkout@v4
+
+            - name: Checkout submodules
+              run: |
+                  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                  git submodule update --init --recursive
+
+            - name: Install shared software dependencies
+              uses: ./.github/workflows/install-shared-dependencies
+              with:
+                  os: "amazon-linux"
+                  target: "x86_64-unknown-linux-gnu"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create a symbolic Link for redis6 binaries
+              run: |
+                  ln -s /usr/bin/redis6-server /usr/bin/redis-server
+                  ln -s /usr/bin/redis6-cli /usr/bin/redis-cli
+
+            - name: Install Java
+              run: |
+                  yum install -y java-${{ matrix.java }}
+
+            - name: Build rust part
+              working-directory: java
+              run: cargo build --release
+
+            - name: Build java part
+              working-directory: java
+              run: ./gradlew --continue build
+
+            - name: Upload test reports
+              if: always()
+              continue-on-error: true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: test-reports-${{ matrix.java }}
+                  path: |
+                      java/client/build/reports/**
+                      java/integTest/build/reports/**
 
     lint-rust:
         timeout-minutes: 15

--- a/java/benchmarks/build.gradle
+++ b/java/benchmarks/build.gradle
@@ -20,13 +20,6 @@ dependencies {
 
 }
 
-// Apply a specific Java toolchain to ease working on different environments.
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
 application {
     // Define the main class for the application.
     mainClass = 'glide.benchmarks.BenchmarkingApp'

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -35,13 +35,6 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.9.2'
 }
 
-// Apply a specific Java toolchain to ease working on different environments.
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
 // JaCoCo section (code coverage by unit tests)
 jacoco {
     toolVersion = "0.8.9"


### PR DESCRIPTION
Update CI to match CI for node and python clients:
1. Test on different redis versions
2. Re-use redis installation script
3. Update benchmarking invocation
4. Add `macos` to CI
5. Add `amazonlinux` to CI (can't be tested outside of upstream)

Fixes https://github.com/aws/babushka/issues/7

Next step:
Split client test gradle tasks to UT and IT. Run UT once, but repeat IT on every platform/OS.