### PR TITLE
Java - Add custom command interface; and BaseCommands

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -2,6 +2,8 @@ package glide.api;
 
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 
+import glide.api.commands.BaseCommands;
+import glide.api.commands.Command;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.connectors.handlers.CallbackDispatcher;
 import glide.connectors.handlers.ChannelHandler;
@@ -13,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
  * Async (non-blocking) client for Redis in Standalone mode. Use {@link
  * #CreateClient(RedisClientConfiguration)} to request a client to Redis.
  */
-public class RedisClient extends BaseClient {
+public class RedisClient extends BaseClient implements BaseCommands {
 
   /**
    * Request an async (non-blocking) Redis client in Standalone mode.
@@ -46,5 +48,18 @@ public class RedisClient extends BaseClient {
 
   protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
     super(connectionManager, commandManager);
+  }
+
+  /**
+   * Executes a single custom command, without checking inputs. Every part of the command, including
+   * subcommands, should be added as a separate value in args.
+   *
+   * @param args command and arguments for the custom command call
+   * @return CompletableFuture with the response
+   */
+  public CompletableFuture<Object> customCommand(String[] args) {
+    Command command =
+        Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).arguments(args).build();
+    return commandManager.submitNewCommand(command, BaseCommands::handleObjectResponse);
   }
 }

--- a/java/client/src/main/java/glide/api/commands/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommandResponseResolver.java
@@ -1,0 +1,70 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RedisException;
+import glide.api.models.exceptions.RequestException;
+import glide.api.models.exceptions.TimeoutException;
+import lombok.AllArgsConstructor;
+import response.ResponseOuterClass.RequestError;
+import response.ResponseOuterClass.Response;
+
+/**
+ * Response resolver responsible for evaluating the Redis response object with a success or failure.
+ */
+@AllArgsConstructor
+public class BaseCommandResponseResolver
+    implements RedisExceptionCheckedFunction<Response, Object> {
+
+  private RedisExceptionCheckedFunction<Long, Object> respPointerResolver;
+
+  /**
+   * Extracts value from the RESP pointer. <br>
+   * Throws errors when the response is unsuccessful.
+   *
+   * @return A generic Object with the Response | null if the response is empty
+   */
+  public Object apply(Response response) throws RedisException {
+    // TODO: handle object if the object is small
+    // TODO: handle RESP2 object if configuration is set
+    if (response.hasRequestError()) {
+      RequestError error = response.getRequestError();
+      String msg = error.getMessage();
+      switch (error.getType()) {
+        case Unspecified:
+          // Unspecified error on Redis service-side
+          throw new RequestException(msg);
+        case ExecAbort:
+          // Transactional error on Redis service-side
+          throw new ExecAbortException(msg);
+        case Timeout:
+          // Timeout from Glide to Redis service
+          throw new TimeoutException(msg);
+        case Disconnect:
+          // Connection problem between Glide and Redis
+          throw new ConnectionException(msg);
+        default:
+          // Request or command error from Redis
+          throw new RequestException(msg);
+      }
+    }
+    if (response.hasClosingError()) {
+      // A closing error is thrown when Rust-core is not connected to Redis
+      // We want to close shop and throw a ClosingException
+      // TODO: close the channel on a closing error
+      // channel.close();
+      throw new ClosingException(response.getClosingError());
+    }
+    if (response.hasConstantResponse()) {
+      // Return "OK"
+      return response.getConstantResponse().toString();
+    }
+    if (response.hasRespPointer()) {
+      // Return the shared value - which may be a null value
+      return respPointerResolver.apply(response.getRespPointer());
+    }
+    // if no response payload is provided, assume null
+    return null;
+  }
+}

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -1,0 +1,49 @@
+package glide.api.commands;
+
+import glide.ffi.resolvers.RedisValueResolver;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import response.ResponseOuterClass.Response;
+
+/** Base Commands interface to handle generic command and transaction requests. */
+public interface BaseCommands {
+
+  /**
+   * default Object handler from response
+   *
+   * @return BaseCommandResponseResolver to deliver the response
+   */
+  static BaseCommandResponseResolver applyBaseCommandResponseResolver() {
+    return new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer);
+  }
+
+  /**
+   * Extracts the response from the Protobuf response and either throws an exception or returns the
+   * appropriate response has an Object
+   *
+   * @param response Redis protobuf message
+   * @return Response Object
+   */
+  static Object handleObjectResponse(Response response) {
+    // return function to convert protobuf.Response into the response object by
+    // calling valueFromPointer
+    return BaseCommands.applyBaseCommandResponseResolver().apply(response);
+  }
+
+  public static List<Object> handleTransactionResponse(Response response) {
+    // return function to convert protobuf.Response into the response object by
+    // calling valueFromPointer
+
+    List<Object> transactionResponse =
+        (List<Object>) BaseCommands.applyBaseCommandResponseResolver().apply(response);
+    return transactionResponse;
+  }
+
+  /**
+   * Execute a @see{Command} by sending command via socket manager
+   *
+   * @param args arguments for the custom command
+   * @return a CompletableFuture with response result from Redis
+   */
+  CompletableFuture<Object> customCommand(String[] args);
+}

--- a/java/client/src/main/java/glide/api/commands/Command.java
+++ b/java/client/src/main/java/glide/api/commands/Command.java
@@ -1,0 +1,24 @@
+package glide.api.commands;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+/** Base Command class to send a single request to Redis. */
+@Builder
+@Getter
+@EqualsAndHashCode
+public class Command {
+
+  /** Redis command request type */
+  @NonNull final RequestType requestType;
+
+  /** List of Arguments for the Redis command request */
+  @Builder.Default final String[] arguments = new String[] {};
+
+  public enum RequestType {
+    /** Call a custom command with list of string arguments */
+    CUSTOM_COMMAND,
+  }
+}

--- a/java/client/src/main/java/glide/api/commands/RedisExceptionCheckedFunction.java
+++ b/java/client/src/main/java/glide/api/commands/RedisExceptionCheckedFunction.java
@@ -1,0 +1,18 @@
+package glide.api.commands;
+
+import glide.api.models.exceptions.RedisException;
+
+@FunctionalInterface
+public interface RedisExceptionCheckedFunction<R, T> {
+
+  /**
+   * Functional response handler that takes a protobuf Response object. <br>
+   * Returns a typed object on a successful Redis response. <br>
+   * Throws RedisException when receiving a Redis error response. <br>
+   *
+   * @param response - Redis Response
+   * @return T - response payload type
+   * @throws RedisException
+   */
+  T apply(R response) throws RedisException;
+}

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -1,0 +1,75 @@
+package glide.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import glide.managers.CommandManager;
+import glide.managers.ConnectionManager;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RedisClientTest {
+
+  RedisClient service;
+
+  ConnectionManager connectionManager;
+
+  CommandManager commandManager;
+
+  @BeforeEach
+  public void setUp() {
+    connectionManager = mock(ConnectionManager.class);
+    commandManager = mock(CommandManager.class);
+    service = new RedisClient(connectionManager, commandManager);
+  }
+
+  @Test
+  public void customCommand_success() throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    Object value = "testValue";
+    String cmd = "GETSTRING";
+    CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
+    when(testResponse.get()).thenReturn(value);
+    when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    CompletableFuture<Object> response = service.customCommand(new String[] {cmd, key});
+    String payload = (String) response.get();
+
+    // verify
+    assertEquals(testResponse, response);
+    assertEquals(value, payload);
+
+    // teardown
+  }
+
+  @Test
+  public void customCommand_interruptedException() throws ExecutionException, InterruptedException {
+    // setup
+    String key = "testKey";
+    Object value = "testValue";
+    String cmd = "GETSTRING";
+    CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
+    InterruptedException interruptedException = new InterruptedException();
+    when(testResponse.get()).thenThrow(interruptedException);
+    when(commandManager.submitNewCommand(any(), any())).thenReturn(testResponse);
+
+    // exercise
+    InterruptedException exception =
+        assertThrows(
+            InterruptedException.class,
+            () -> {
+              CompletableFuture<Object> response = service.customCommand(new String[] {cmd, key});
+              response.get();
+            });
+
+    // verify
+    assertEquals(interruptedException, exception);
+  }
+}

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -1,0 +1,271 @@
+package glide.managers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import glide.api.commands.BaseCommandResponseResolver;
+import glide.api.commands.Command;
+import glide.api.models.exceptions.ClosingException;
+import glide.api.models.exceptions.ConnectionException;
+import glide.api.models.exceptions.ExecAbortException;
+import glide.api.models.exceptions.RedisException;
+import glide.api.models.exceptions.TimeoutException;
+import glide.connectors.handlers.ChannelHandler;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import response.ResponseOuterClass.RequestError;
+import response.ResponseOuterClass.Response;
+
+public class CommandManagerTest {
+
+  ChannelHandler channelHandler;
+
+  CommandManager service;
+
+  Command command;
+
+  @BeforeEach
+  void init() {
+    command = Command.builder().requestType(Command.RequestType.CUSTOM_COMMAND).build();
+
+    channelHandler = mock(ChannelHandler.class);
+    service = new CommandManager(channelHandler);
+  }
+
+  @Test
+  public void submitNewCommand_returnObjectResult()
+      throws ExecutionException, InterruptedException {
+
+    // setup
+    long pointer = -1;
+    Response respPointerResponse = Response.newBuilder().setRespPointer(pointer).build();
+    Object respObject = mock(Object.class);
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(respPointerResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((ptr) -> ptr == pointer ? respObject : null));
+    Object respPointer = result.get();
+
+    // verify
+    assertEquals(respObject, respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_returnNullResult() throws ExecutionException, InterruptedException {
+    // setup
+    Response respPointerResponse = Response.newBuilder().build();
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(respPointerResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((p) -> new RuntimeException("")));
+    Object respPointer = result.get();
+
+    assertNull(respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_returnStringResult()
+      throws ExecutionException, InterruptedException {
+
+    // setup
+    long pointer = 123;
+    String testString = "TEST STRING";
+
+    Response respPointerResponse = Response.newBuilder().setRespPointer(pointer).build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(respPointerResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    CompletableFuture result =
+        service.submitNewCommand(
+            command, new BaseCommandResponseResolver((p) -> p == pointer ? testString : null));
+    Object respPointer = result.get();
+
+    // verify
+    assertTrue(respPointer instanceof String);
+    assertEquals(testString, respPointer);
+  }
+
+  @Test
+  public void submitNewCommand_throwClosingException() {
+
+    // setup
+    String errorMsg = "Closing";
+
+    Response closingErrorResponse = Response.newBuilder().setClosingError(errorMsg).build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(closingErrorResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              result.get();
+            });
+
+    // verify
+    assertTrue(e.getCause() instanceof ClosingException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwConnectionException() {
+
+    // setup
+    int disconnectedType = 3;
+    String errorMsg = "Disconnected";
+
+    Response respPointerResponse =
+        Response.newBuilder()
+            .setRequestError(
+                RequestError.newBuilder()
+                    .setTypeValue(disconnectedType)
+                    .setMessage(errorMsg)
+                    .build())
+            .build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(respPointerResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              result.get();
+            });
+
+    // verify
+    assertTrue(e.getCause() instanceof ConnectionException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwTimeoutException() {
+
+    // setup
+    int timeoutType = 2;
+    String errorMsg = "Timeout";
+
+    Response timeoutErrorResponse =
+        Response.newBuilder()
+            .setRequestError(
+                RequestError.newBuilder().setTypeValue(timeoutType).setMessage(errorMsg).build())
+            .build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(timeoutErrorResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              result.get();
+            });
+
+    // verify
+    assertTrue(e.getCause() instanceof TimeoutException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_throwExecAbortException() {
+    // setup
+    int execAbortType = 1;
+    String errorMsg = "ExecAbort";
+
+    Response execAbortErrorResponse =
+        Response.newBuilder()
+            .setRequestError(
+                RequestError.newBuilder().setTypeValue(execAbortType).setMessage(errorMsg).build())
+            .build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(execAbortErrorResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    ExecutionException e =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              result.get();
+            });
+
+    // verify
+    assertTrue(e.getCause() instanceof ExecAbortException);
+    assertEquals(errorMsg, e.getCause().getMessage());
+  }
+
+  @Test
+  public void submitNewCommand_handledUnspecifiedError() {
+    // setup
+    int unspecifiedType = 0;
+    String errorMsg = "Unspecified";
+
+    Response unspecifiedErrorResponse =
+        Response.newBuilder()
+            .setRequestError(
+                RequestError.newBuilder()
+                    .setTypeValue(unspecifiedType)
+                    .setMessage(errorMsg)
+                    .build())
+            .build();
+
+    CompletableFuture<Response> future = new CompletableFuture<>();
+    future.complete(unspecifiedErrorResponse);
+    when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
+
+    // exercise
+    ExecutionException executionException =
+        assertThrows(
+            ExecutionException.class,
+            () -> {
+              CompletableFuture result =
+                  service.submitNewCommand(
+                      command, new BaseCommandResponseResolver((ptr) -> new Object()));
+              result.get();
+            });
+
+    // verify
+    assertTrue(executionException.getCause() instanceof RedisException);
+    assertEquals(errorMsg, executionException.getCause().getMessage());
+  }
+}

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -209,7 +209,8 @@ public class ConnectionManagerTest {
 
     assertTrue(executionException.getCause() instanceof ClosingException);
     assertEquals("Unexpected empty data in response", executionException.getCause().getMessage());
-    verify(channel).close();
+    // TODO: channel may not be completed since we don't wait for the close to complete
+    // verify(channel).close();
   }
 
   @Test

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -209,8 +209,7 @@ public class ConnectionManagerTest {
 
     assertTrue(executionException.getCause() instanceof ClosingException);
     assertEquals("Unexpected empty data in response", executionException.getCause().getMessage());
-    // TODO: channel may not be completed since we don't wait for the close to complete
-    // verify(channel).close();
+    verify(channel).close();
   }
 
   @Test


### PR DESCRIPTION
*Issue #, if available:*

API layer for: https://github.com/aws/glide-for-redis/issues/589

*Description of changes:*

In this PR, we are adding basic infrastructure for commands, including the custom command that takes any command type and set of arguments, and returns an Object.  

The Redis `value_from_pointer` is called to convert the value form a Rust objects to Java objects, so the FFI calls for complex objects are necessary for converting from complex objects. 

_Example:_

```
CompletableFuture<RedisClient> createClientRequest = RedisClient.CreateClient(config); 

try (RedisClient client = createClientRequest.get()) 
{
      Object customGetMyKey = client.customCommand(new String[]{"get", "myKey"}).get();
      System.out.println("Glide CUSTOM_COMMAND(get, myKey): " + customGetMyKey);

      Object customGetInvalid = client.customCommand(new String[]{"get", "invalid"}).get();
      System.out.println("Glide CUSTOM_COMMAND(get, invalid): " + customGetInvalid);

} catch (ExecutionException executionException) {
    if (executionException.getCause() instanceOf RedisException) {
         // try again
  }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
