### PR TITLE
Make Node & Python's READMEs better for package managers.

### DIFF
--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -6,17 +6,111 @@ This document describes how to set up your development environment to build and 
 
 The GLIDE Node wrapper consists of both TypeScript and Rust code. Rust bindings for Node.js are implemented using [napi-rs](https://github.com/napi-rs/napi-rs). The Node and Rust components communicate using the [protobuf](https://github.com/protocolbuffers/protobuf) protocol.
 
+### Build from source
 
-### Build
+#### Prerequisites
 
-- Follow the building instructions for the Node wrapper in the [Build from source](https://github.com/aws/glide-for-redis/blob/main/node/README.md#build-from-source) section to clone the code and build the wrapper.
-- For a fast build, execute `npm run build`. This will perform a full,  unoptimized build, which is suitable for developing tests. Keep in mind that performance is significantly affected in an unoptimized build, so it's required to build with the `build:release` or `build:benchmark` option when measuring performance.
-- If your modifications are limited to the TypeScript code, run `npm run build-external` to build the external package without rebuilding the internal package.
-- If your modifications are limited to the Rust code, execute `npm run build-internal` to build the internal package and generate TypeScript code.
-- To generate Node's protobuf files, execute `npm run build-protobuf`. Keep in mind that protobuf files are generated as part of full builds (e.g., `build`, `build:release`, etc.).
+Software Dependencies
+
+> Note: Currently, we only support npm major version 8. f you have a later version installed, you can downgrade it with `npm i -g npm@8`.
+
+-   npm v8
+-   git
+-   GCC
+-   pkg-config
+-   protoc (protobuf compiler)
+-   openssl
+-   openssl-dev
+-   rustup
+
+**Dependencies installation for Ubuntu**
+
+```bash
+sudo apt update -y
+sudo apt install -y nodejs npm git gcc pkg-config protobuf-compiler openssl libssl-dev
+npm i -g npm@8
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+**Dependencies installation for CentOS**
+
+```bash
+sudo yum update -y
+sudo yum install -y nodejs git gcc pkgconfig protobuf-compiler openssl openssl-devel gettext
+npm i -g npm@8
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+**Dependencies installation for MacOS**
+
+```bash
+brew update
+brew install nodejs git gcc pkgconfig protobuf openssl
+npm i -g npm@8
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+#### Building and installation steps
+
+Before starting this step, make sure you've installed all software requirments.
+
+1.  Clone the repository:
+    ```bash
+    VERSION=0.1.0 # You can modify this to other released version or set it to "main" to get the unstable branch
+    git clone --branch ${VERSION} https://github.com/aws/glide-for-redis.git
+    cd glide-for-redis
+    ```
+2.  Initialize git submodule:
+    ```bash
+    git submodule update --init --recursive
+    ```
+3.  Install all node dependencies:
+    ```bash
+    cd node
+    npm i
+    cd rust-client
+    npm i
+    cd ..
+    ```
+4.  Build the Node wrapper:
+    Choose a build option from the following and run it from the `node` folder:
+
+        1. Build in release mode, stripped from all debug symbols (optimized and minimized binary size):
+
+            ```bash
+            npm run build:release
+            ```
+
+        2. Build in release mode with debug symbols (optimized but large binary size):
+
+            ```bash
+            npm run build:benchmark
+            ```
+
+        3. For testing purposes, you can execute an unoptimized but fast build using:
+           `bash
+
+    npm run build
+    `       Once building completed, you'll find the compiled JavaScript code in the`./build-ts` folder.
+
+5.  Run tests:
+    1. Ensure that you have installed redis-server and redis-cli on your host. You can find the Redis installation guide at the following link: [Redis Installation Guide](https://redis.io/docs/install/install-redis/install-redis-on-linux/).
+    2. Execute the following command from the node folder:
+        ```bash
+        npm test
+        ```
+6.  Integrating the built GLIDE package into your project:
+    Add the package to your project using the folder path with the command `npm install <path to GLIDE>/node`.
+
+-   For a fast build, execute `npm run build`. This will perform a full, unoptimized build, which is suitable for developing tests. Keep in mind that performance is significantly affected in an unoptimized build, so it's required to build with the `build:release` or `build:benchmark` option when measuring performance.
+-   If your modifications are limited to the TypeScript code, run `npm run build-external` to build the external package without rebuilding the internal package.
+-   If your modifications are limited to the Rust code, execute `npm run build-internal` to build the internal package and generate TypeScript code.
+-   To generate Node's protobuf files, execute `npm run build-protobuf`. Keep in mind that protobuf files are generated as part of full builds (e.g., `build`, `build:release`, etc.).
 
 > Note: Once building completed, you'll find the compiled JavaScript code in the `node/build-ts` folder.
-
 
 ### Test
 
@@ -35,19 +129,23 @@ git submodule update
 ```
 
 ### Linters
+
 Development on the Node wrapper may involve changes in either the TypeScript or Rust code. Each language has distinct linter tests that must be passed before committing changes.
 
 #### Language-specific Linters
 
-__TypeScript:__
-- ESLint
-- Prettier
+**TypeScript:**
 
-__Rust:__
-- clippy
-- fmt
+-   ESLint
+-   Prettier
+
+**Rust:**
+
+-   clippy
+-   fmt
 
 #### Running the linters
+
 1. TypeScript
     ```bash
     # Run from the `node` folder
@@ -64,8 +162,9 @@ __Rust:__
     ```
 
 ### Recommended extensions for VS Code
-- [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - JavaScript / TypeScript formatter.
-- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - linter.
-- [Jest Runner](https://marketplace.visualstudio.com/items?itemName=firsttris.vscode-jest-runner) - in-editor test runner.
-- [Jest Test Explorer](https://marketplace.visualstudio.com/items?itemName=kavod-io.vscode-jest-test-adapter) - adapter to the VSCode testing UI.
+
+-   [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - JavaScript / TypeScript formatter.
+-   [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - linter.
+-   [Jest Runner](https://marketplace.visualstudio.com/items?itemName=firsttris.vscode-jest-runner) - in-editor test runner.
+-   [Jest Test Explorer](https://marketplace.visualstudio.com/items?itemName=kavod-io.vscode-jest-test-adapter) - adapter to the VSCode testing UI.
 -   [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) - Rust language support for VSCode.

--- a/node/README.md
+++ b/node/README.md
@@ -1,3 +1,17 @@
+# GLIDE for Redis
+
+General Language Independent Driver for the Enterprise (GLIDE) for Redis, is an AWS-sponsored, open-source Redis client. GLIDE for Redis works with any Redis distribution that adheres to the Redis Serialization Protocol (RESP) specification, including open-source Redis, Amazon ElastiCache for Redis, and Amazon MemoryDB for Redis.
+Strategic, mission-critical Redis-based applications have requirements for security, optimized performance, minimal downtime, and observability. GLIDE for Redis is designed to provide a client experience that helps meet these objectives. It is sponsored and supported by AWS, and comes pre-configured with best practices learned from over a decade of operating Redis-compatible services used by hundreds of thousands of customers. To help ensure consistency in development and operations, GLIDE for Redis is implemented using a core driver framework, written in Rust, with extensions made available for each supported programming language. This design ensures that updates easily propagate to each language and reduces overall complexity. In this Preview release, GLIDE for Redis is available for Python and Javascript (Node.js), with support for Java actively under development.
+
+## Supported Redis Versions
+
+GLIDE for Redis is API-compatible with open source Redis version 6 and 7.
+
+## Current Status
+
+We've made GLIDE for Redis an open-source project, and are releasing it in Preview to the community to gather feedback, and actively collaborate on the project roadmap. We welcome questions and contributions from all Redis stakeholders.
+This preview release is recommended for testing purposes only.
+
 # Getting Started - Node Wrapper
 
 ## System Requirements
@@ -5,8 +19,8 @@
 The beta release of GLIDE for Redis was tested on Intel x86_64 using Ubuntu 22.04.1, Amazon Linux 2023 (AL2023), and macOS 12.7.
 
 ## NodeJS supported version
+
 Node.js 16.20 or higher.
-> Note: Currently, we only support npm major version 8. f you have a later version installed, you can downgrade it with `npm i -g npm@8`.
 
 ## Installation and Setup
 
@@ -16,102 +30,15 @@ To install GLIDE for Redis using `npm`, follow these steps:
 
 1. Open your terminal.
 2. Execute the command below:
-   ```bash
-   $ npm install glide-for-redis
-   ```
+    ```bash
+    $ npm install @aws/glide-for-redis
+    ```
 3. After installation, confirm the client is installed by running:
     ```bash
     $ npm list
     myApp@ /home/ubuntu/myApp
-    └── glide-for-redis@0.1.0
+    └── @aws/glide-for-redis@0.1.0
     ```
-
-### Build from source
-
-#### Prerequisites
-
-Software Dependencies
--   npm v8
--   git
--   GCC
--   pkg-config
--   protoc (protobuf compiler)
--   openssl
--   openssl-dev
--   rustup
-
-**Dependencies installation for Ubuntu**
-```bash
-sudo apt update -y
-sudo apt install -y nodejs npm git gcc pkg-config protobuf-compiler openssl libssl-dev
-npm i -g npm@8
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-**Dependencies installation for CentOS**
-``` bash
-sudo yum update -y
-sudo yum install -y nodejs git gcc pkgconfig protobuf-compiler openssl openssl-devel gettext
-npm i -g npm@8
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-**Dependencies installation for MacOS**
-```bash
-brew update
-brew install nodejs git gcc pkgconfig protobuf openssl 
-npm i -g npm@8
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-#### Building and installation steps
-Before starting this step, make sure you've installed all software requirments. 
-1. Clone the repository:
-    ```bash
-    VERSION=0.1.0 # You can modify this to other released version or set it to "main" to get the unstable branch
-    git clone --branch ${VERSION} https://github.com/aws/glide-for-redis.git
-    cd glide-for-redis
-    ```
-2. Initialize git submodule:
-    ```bash
-    git submodule update --init --recursive
-    ```
-3. Install all node dependencies:
-    ```bash
-    cd node
-    npm i
-    cd rust-client
-    npm i
-    cd ..
-    ```
-4. Build the Node wrapper: 
-    Choose a build option from the following and run it from the `node` folder:
-    1. Build in release mode, stripped from all debug symbols (optimized and minimized binary size):
-        ```bash
-        npm run build:release
-        ```
-
-    2. Build in release mode with debug symbols (optimized but large binary size):
-        ```bash
-        npm run build:benchmark
-        ```
-
-    3. For testing purposes, you can execute an unoptimized but fast build using:
-        ```bash
-        npm run build
-        ```
-    Once building completed, you'll find the compiled JavaScript code in the `./build-ts` folder.
-5. Run tests:
-    1. Ensure that you have installed redis-server and redis-cli on your host. You can find the Redis installation guide at the following link: [Redis Installation Guide](https://redis.io/docs/install/install-redis/install-redis-on-linux/).
-    2. Execute the following command from the node folder:
-        ```bash
-        npm test
-        ```
-6. Integrating the built GLIDE package into your project:
-    Add the package to your project using the folder path with the command `npm install <path to GLIDE>/node`.
 
 ## Basic Examples
 
@@ -133,7 +60,6 @@ await client.set("foo", "bar");
 const value = await client.get("foo");
 client.close();
 ```
-
 
 #### Standalone Redis:
 
@@ -157,6 +83,11 @@ await client.set("foo", "bar");
 const value = await client.get("foo");
 client.close();
 ```
+
 ## Documenation
 
 Visit our [wiki](https://github.com/aws/glide-for-redis/wiki/NodeJS-wrapper) for examples and further details on TLS, Read strategy, Timeouts and various other configurations.
+
+### Building & Testing
+
+Development instructions for local building & testing the package are in the [DEVELOPER.md](https://github.com/aws/glide-for-redis/blob/main/node/DEVELOPER.md#build-from-source) file.

--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -6,19 +6,103 @@ This document describes how to set up your development environment to build and 
 
 The GLIDE for Redis Python wrapper consists of both Python and Rust code. Rust bindings for Python are implemented using [PyO3](https://github.com/PyO3/pyo3), and the Python package is built using [maturin](https://github.com/PyO3/maturin). The Python and Rust components communicate using the [protobuf](https://github.com/protocolbuffers/protobuf) protocol.
 
+### Build from source
 
-### Build
+#### Prerequisites
 
-- Follow the building instructions for the Python wrapper in the [Build from source](https://github.com/aws/glide-for-redis/blob/main/python/README.md#build-from-source) section to clone the code and build the wrapper.
+Software Dependencies
 
-- Install Python development requirements with:
+-   python3 virtualenv
+-   git
+-   GCC
+-   pkg-config
+-   protoc (protobuf compiler)
+-   openssl
+-   openssl-dev
+-   rustup
+
+**Dependencies installation for Ubuntu**
+
+```bash
+sudo apt update -y
+sudo apt install -y python3 python3-venv git gcc pkg-config protobuf-compiler openssl libssl-dev
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+**Dependencies installation for CentOS**
+
+```bash
+sudo yum update -y
+sudo yum install -y python3 git gcc pkgconfig protobuf-compiler openssl openssl-devel
+pip3 install virtualenv
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+**Dependencies installation for MacOS**
+
+```bash
+brew update
+brew install python3 git gcc pkgconfig protobuf openssl
+pip3 install virtualenv
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+#### Building and installation steps
+
+Before starting this step, make sure you've installed all software requirments.
+
+1. Clone the repository:
+    ```bash
+    VERSION=0.1.0 # You can modify this to other released version or set it to "main" to get the unstable branch
+    git clone --branch ${VERSION} https://github.com/aws/glide-for-redis.git
+    cd glide-for-redis
+    ```
+2. Initialize git submodule:
+    ```bash
+    git submodule update --init --recursive
+    ```
+3. Generate protobuf files:
+    ```bash
+    GLIDE_ROOT_FOLDER_PATH=.
+    protoc -Iprotobuf=${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/ --python_out=${GLIDE_ROOT_FOLDER_PATH}/python/python/glide ${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/*.proto
+    ```
+4. Create a virtual environment:
+    ```bash
+    cd python
+    python3 -m venv .env
+    ```
+5. Activate the virtual environment:
+    ```bash
+    source .env/bin/activate
+    ```
+6. Install requirements:
+    ```bash
+    pip install -r requirements.txt
+    ```
+7. Build the Python wrapper in release mode:
+    ```
+    maturin develop --release --strip
+    ```
+    > **Note:** To build the wrapper binary with debug symbols remove the --strip flag.
+8. Run tests:
+    1. Ensure that you have installed redis-server and redis-cli on your host. You can find the Redis installation guide at the following link: [Redis Installation Guide](https://redis.io/docs/install/install-redis/install-redis-on-linux/).
+    2. Validate the activation of the virtual environment from step 4 by ensuring its name (`.env`) is displayed next to your command prompt.
+    3. Execute the following command from the python folder:
+        ```bash
+        pytest --asyncio-mode=auto
+        ```
+        > **Note:** To run redis modules tests, add -k "test_redis_modules.py".
+
+-   Install Python development requirements with:
 
     ```bash
     pip install -r python/dev_requirements.txt
     ```
 
-- For a fast build, execute `maturin develop` without the release flag. This will perform an unoptimized build, which is suitable for developing tests. Keep in mind that performance is significantly affected in an unoptimized build, so it's required to include the "--release" flag when measuring performance.
-
+-   For a fast build, execute `maturin develop` without the release flag. This will perform an unoptimized build, which is suitable for developing tests. Keep in mind that performance is significantly affected in an unoptimized build, so it's required to include the "--release" flag when measuring performance.
 
 ### Test
 
@@ -43,14 +127,16 @@ git submodule update
 ```
 
 ### Generate protobuf files
+
 During the initial build, Python protobuf files were created in `python/python/glide/protobuf`. If modifications are made to the protobuf definition files (.proto files located in `glide-core/src/protofuf`), it becomes necessary to regenerate the Python protobuf files. To do so, run:
 
 ```bash
 GLIDE_ROOT_FOLDER_PATH=. # e.g. /home/ubuntu/glide-for-redis
 protoc -Iprotobuf=${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/ --python_out=${GLIDE_ROOT_FOLDER_PATH}/python/python/glide ${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/*.proto
-``` 
+```
 
 #### Protobuf interface files
+
 To generate the protobuf files with Python Interface files (pyi) for type-checking purposes, ensure you have installed `mypy-protobuf` with pip, and then execute the following command:
 
 ```bash
@@ -60,22 +146,27 @@ protoc --plugin=protoc-gen-mypy=${MYPY_PROTOC_PATH} -Iprotobuf=${GLIDE_ROOT_FOLD
 ```
 
 ### Linters
+
 Development on the Python wrapper may involve changes in either the Python or Rust code. Each language has distinct linter tests that must be passed before committing changes.
 
 #### Language-specific Linters
 
-__Python:__
-- flake8
-- isort
-- black
-- mypy
+**Python:**
 
-__Rust:__
-- clippy
-- fmt
+-   flake8
+-   isort
+-   black
+-   mypy
+
+**Rust:**
+
+-   clippy
+-   fmt
 
 #### Running the linters
+
 Run from the main `/python` folder
+
 1. Python
     > Note: make sure to [generate protobuf with interface files]("#protobuf-interface-files") before running mypy linter
     ```bash
@@ -88,6 +179,7 @@ Run from the main `/python` folder
     mypy .
     ```
 2. Rust
+
     ```bash
     rustup component add clippy rustfmt
     cargo clippy --all-features --all-targets -- -D warnings
@@ -96,6 +188,7 @@ Run from the main `/python` folder
     ```
 
 ### Recommended extensions for VS Code
+
 -   [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 -   [isort](https://marketplace.visualstudio.com/items?itemName=ms-python.isort)
 -   [Black Formetter](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,17 @@
+# GLIDE for Redis
+
+General Language Independent Driver for the Enterprise (GLIDE) for Redis, is an AWS-sponsored, open-source Redis client. GLIDE for Redis works with any Redis distribution that adheres to the Redis Serialization Protocol (RESP) specification, including open-source Redis, Amazon ElastiCache for Redis, and Amazon MemoryDB for Redis.
+Strategic, mission-critical Redis-based applications have requirements for security, optimized performance, minimal downtime, and observability. GLIDE for Redis is designed to provide a client experience that helps meet these objectives. It is sponsored and supported by AWS, and comes pre-configured with best practices learned from over a decade of operating Redis-compatible services used by hundreds of thousands of customers. To help ensure consistency in development and operations, GLIDE for Redis is implemented using a core driver framework, written in Rust, with extensions made available for each supported programming language. This design ensures that updates easily propagate to each language and reduces overall complexity. In this Preview release, GLIDE for Redis is available for Python and Javascript (Node.js), with support for Java actively under development.
+
+## Supported Redis Versions
+
+GLIDE for Redis is API-compatible with open source Redis version 6 and 7.
+
+## Current Status
+
+We've made GLIDE for Redis an open-source project, and are releasing it in Preview to the community to gather feedback, and actively collaborate on the project roadmap. We welcome questions and contributions from all Redis stakeholders.
+This preview release is recommended for testing purposes only.
+
 # Getting Started - Python Wrapper
 
 ## System Requirements
@@ -5,6 +19,7 @@
 The beta release of GLIDE for Redis was tested on Intel x86_64 using Ubuntu 22.04.1, Amazon Linux 2023 (AL2023), and macOS 12.7.
 
 ## Python supported version
+
 Python 3.8 or higher.
 
 ## Installation and Setup
@@ -15,99 +30,14 @@ To install GLIDE for Redis using `pip`, follow these steps:
 
 1. Open your terminal.
 2. Execute the command below:
-   ```bash
-   $ pip install glide-for-redis
-   ```
+    ```bash
+    $ pip install glide-for-redis
+    ```
 3. After installation, confirm the client is accessible by running:
     ```bash
     $ python3
     >>> import glide
     ```
-
-### Build from source
-
-#### Prerequisites
-
-Software Dependencies
-
--   python3 virtualenv
--   git
--   GCC
--   pkg-config
--   protoc (protobuf compiler)
--   openssl
--   openssl-dev
--   rustup
-
-**Dependencies installation for Ubuntu**
-```bash
-sudo apt update -y
-sudo apt install -y python3 python3-venv git gcc pkg-config protobuf-compiler openssl libssl-dev
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-**Dependencies installation for CentOS**
-```bash 
-sudo yum update -y
-sudo yum install -y python3 git gcc pkgconfig protobuf-compiler openssl openssl-devel
-pip3 install virtualenv
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-**Dependencies installation for MacOS**
-```bash
-brew update
-brew install python3 git gcc pkgconfig protobuf openssl 
-pip3 install virtualenv
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-source "$HOME/.cargo/env"
-```
-
-#### Building and installation steps
-Before starting this step, make sure you've installed all software requirments. 
-1. Clone the repository:
-    ```bash
-    VERSION=0.1.0 # You can modify this to other released version or set it to "main" to get the unstable branch
-    git clone --branch ${VERSION} https://github.com/aws/glide-for-redis.git
-    cd glide-for-redis
-    ```
-2. Initialize git submodule:
-    ```bash
-    git submodule update --init --recursive
-    ```
-3. Generate protobuf files:
-    ```bash
-    GLIDE_ROOT_FOLDER_PATH=.
-    protoc -Iprotobuf=${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/ --python_out=${GLIDE_ROOT_FOLDER_PATH}/python/python/glide ${GLIDE_ROOT_FOLDER_PATH}/glide-core/src/protobuf/*.proto
-    ```
-4. Create a virtual environment:
-    ```bash
-    cd python
-    python3 -m venv .env
-    ```
-5. Activate the virtual environment:
-    ```bash
-    source .env/bin/activate
-    ```
-6. Install requirements:
-    ```bash
-    pip install -r requirements.txt
-    ```
-7. Build the Python wrapper in release mode:
-    ```
-    maturin develop --release --strip
-    ```
-     > **Note:** To build the wrapper binary with debug symbols remove the --strip flag.
-8. Run tests:
-    1. Ensure that you have installed redis-server and redis-cli on your host. You can find the Redis installation guide at the following link: [Redis Installation Guide](https://redis.io/docs/install/install-redis/install-redis-on-linux/).
-    2. Validate the activation of the virtual environment from step 4 by ensuring its name (`.env`) is displayed next to your command prompt. 
-    3. Execute the following command from the python folder:
-        ```bash
-        pytest --asyncio-mode=auto
-        ```
-        > **Note:** To run redis modules tests, add -k "test_redis_modules.py".
 
 ## Basic Examples
 
@@ -153,3 +83,6 @@ Before starting this step, make sure you've installed all software requirments.
 
 Visit our [wiki](https://github.com/aws/glide-for-redis/wiki/Python-wrapper) for examples and further details on TLS, Read strategy, Timeouts and various other configurations.
 
+### Building & Testing
+
+Development instructions for local building & testing the package are in the [DEVELOPER.md](https://github.com/aws/glide-for-redis/blob/main/python/DEVELOPER.md#build-from-source) file.


### PR DESCRIPTION
Package managers show the READMEs as the main text describes the package. Thus, the README should contain the header explaining what the project is. Additionally, removed the developer-oriented build explanation, and moved it to the DEVELOPER section, with a matching link.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
