### PR TITLE
Use non-boolean enums for TLS mode.

### DIFF
--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -216,7 +216,7 @@ async function main(
         const clients = await createClients(clientCount, () =>
             clientClass.createClient({
                 addresses: [{ host, port }],
-                useTLS,
+                tlsMode: useTLS ? "auto" : undefined,
             })
         );
         await run_clients(

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -12,6 +12,8 @@ from typing import List
 
 import numpy as np
 import redis.asyncio as redispy  # type: ignore
+from glide.config import TlsMode
+
 from glide import (
     BaseClientConfiguration,
     Logger,
@@ -277,8 +279,9 @@ async def main(
     if clients_to_run == "all" or clients_to_run == "glide":
         # Glide Socket
         client_class = RedisClusterClient if is_cluster else RedisClient
+        tls_mode = TlsMode.Auto if use_tls else None
         config = BaseClientConfiguration(
-            [NodeAddress(host=host, port=port)], use_tls=use_tls
+            [NodeAddress(host=host, port=port)], tls_mode=tls_mode
         )
         clients = await create_clients(
             client_count,

--- a/examples/python/client_example.py
+++ b/examples/python/client_example.py
@@ -42,7 +42,7 @@ async def test_standalone_client(host: str = "localhost", port: int = 6379):
         addresses=addresses,
         client_name="test_standalone_client"
         # if the server use TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
-        # use_tls=True
+        # tls_mode=TlsMode.Auto
     )
     client = await RedisClient.create(config)
 
@@ -61,7 +61,7 @@ async def test_cluster_client(host: str = "localhost", port: int = 6379):
         addresses=addresses,
         client_name="test_cluster_client"
         # if the cluster nodes use TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
-        # use_tls=True
+        # tls_mode=TlsMode.Auto
     )
     client = await RedisClusterClient.create(config)
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -125,11 +125,11 @@ export type BaseClientConfiguration = {
         port?: number;
     }[];
     /**
-     * True if communication with the cluster should use Transport Level Security.
+     * `"auto"` if communication with the cluster should use Transport Level Security, with automatic loading of certificates.
      * Should match the TLS configuration of the server/cluster,
      * otherwise the connection attempt will fail.
      */
-    useTLS?: boolean;
+    tlsMode?: "auto";
     /**
      * Credentials for authentication process.
      * If none are set, the client will not authenticate itself with the server.
@@ -977,9 +977,10 @@ export class BaseClient {
             protocol,
             clientName: options.clientName,
             addresses: options.addresses,
-            tlsMode: options.useTLS
-                ? connection_request.TlsMode.SecureTls
-                : connection_request.TlsMode.NoTls,
+            tlsMode:
+                options.tlsMode == "auto"
+                    ? connection_request.TlsMode.SecureTls
+                    : connection_request.TlsMode.NoTls,
             requestTimeout: options.requestTimeout,
             clusterModeEnabled: false,
             readFrom,

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -126,10 +126,10 @@ export type BaseClientConfiguration = {
     }[];
     /**
      * `"auto"` if communication with the cluster should use Transport Level Security, with automatic loading of certificates.
-     * Should match the TLS configuration of the server/cluster,
-     * otherwise the connection attempt will fail.
+     * `"disabled"` if no TLS should be used.
+     * Should match the TLS configuration of the server/cluster, otherwise the connection attempt will fail.
      */
-    tlsMode?: "auto";
+    tlsMode?: "auto" | "disabled";
     /**
      * Credentials for authentication process.
      * If none are set, the client will not authenticate itself with the server.

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -53,6 +53,11 @@ class ProtocolVersion(Enum):
 
 class TlsMode(Enum):
     """
+    Disabled TLS mode.
+    """
+
+    Disabled = 0
+    """
     Enabled TLS mode, with automatic loading of certificates.
     """
 

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -8,6 +8,7 @@ from glide.config import (
     ProtocolVersion,
     RedisClientConfiguration,
     RedisCredentials,
+    TlsMode,
 )
 from glide.logger import Level as logLevel
 from glide.logger import Logger
@@ -111,14 +112,14 @@ async def create_client(
     protocol: ProtocolVersion = ProtocolVersion.RESP3,
 ) -> Union[RedisClient, RedisClusterClient]:
     # Create async socket client
-    use_tls = request.config.getoption("--tls")
+    tls_mode = TlsMode.Auto if request.config.getoption("--tls") else None
     if cluster_mode:
         assert type(pytest.redis_cluster) is RedisCluster
         assert database_id == 0
         seed_nodes = random.sample(pytest.redis_cluster.nodes_addr, k=3)
         cluster_config = ClusterClientConfiguration(
             addresses=seed_nodes if addresses is None else addresses,
-            use_tls=use_tls,
+            tls_mode=tls_mode,
             credentials=credentials,
             client_name=client_name,
             protocol=protocol,
@@ -130,7 +131,7 @@ async def create_client(
             addresses=pytest.standalone_cluster.nodes_addr
             if addresses is None
             else addresses,
-            use_tls=use_tls,
+            tls_mode=tls_mode,
             credentials=credentials,
             database_id=database_id,
             client_name=client_name,

--- a/python/python/tests/test_config.py
+++ b/python/python/tests/test_config.py
@@ -1,21 +1,21 @@
-from glide.config import BaseClientConfiguration, NodeAddress, ReadFrom
+from glide.config import BaseClientConfiguration, NodeAddress, ReadFrom, TlsMode
 from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.connection_request_pb2 import ReadFrom as ProtobufReadFrom
-from glide.protobuf.connection_request_pb2 import TlsMode
+from glide.protobuf.connection_request_pb2 import TlsMode as ProtobufTlsMode
 
 
 def test_default_client_config():
     config = BaseClientConfiguration([])
     assert len(config.addresses) == 0
     assert config.read_from.value == ProtobufReadFrom.Primary
-    assert config.use_tls is False
+    assert config.tls_mode is None
     assert config.client_name is None
 
 
 def test_convert_to_protobuf():
     config = BaseClientConfiguration(
         [NodeAddress("127.0.0.1")],
-        use_tls=True,
+        tls_mode=TlsMode.Auto,
         read_from=ReadFrom.PREFER_REPLICA,
         client_name="TEST_CLIENT_NAME",
     )
@@ -23,6 +23,6 @@ def test_convert_to_protobuf():
     assert isinstance(request, ConnectionRequest)
     assert request.addresses[0].host == "127.0.0.1"
     assert request.addresses[0].port == 6379
-    assert request.tls_mode is TlsMode.SecureTls
+    assert request.tls_mode is ProtobufTlsMode.SecureTls
     assert request.read_from == ProtobufReadFrom.PreferReplica
     assert request.client_name == "TEST_CLIENT_NAME"


### PR DESCRIPTION
This allows us forward compatibility, so that once we introduce more complex TLS usage schemes, such as loading specific credentials, we won't break the API.

*Issue #, if available:*
https://github.com/aws/glide-for-redis/issues/786

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
