### PR TITLE
reconnecting_connection.rs: Fix spelling succesfully -> successfully

### DIFF
--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -217,7 +217,7 @@ impl ReconnectingConnection {
                         }
                         {
                             let mut guard = connection_clone.inner.state.lock().unwrap();
-                            log_debug("reconnect", "completed succesfully");
+                            log_debug("reconnect", "completed successfully");
                             connection_clone
                                 .inner
                                 .backend


### PR DESCRIPTION

*Description of changes:*
successfully has two `s`'s before the `f`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
