### PR TITLE
Java client: Fix how UDS connection established

### DIFF
--- a/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
@@ -28,7 +28,8 @@ public class ChannelHandler {
     private final CallbackDispatcher callbackDispatcher;
 
     /** Open a new channel for a new client. */
-    public ChannelHandler(CallbackDispatcher callbackDispatcher, String socketPath) {
+    public ChannelHandler(CallbackDispatcher callbackDispatcher, String socketPath)
+            throws InterruptedException {
         this(
                 ThreadPoolAllocator.createOrGetNettyThreadPool(THREAD_POOL_NAME, Optional.empty()),
                 Platform.getClientUdsNettyChannelType(),
@@ -51,14 +52,15 @@ public class ChannelHandler {
             Class<? extends DomainSocketChannel> domainSocketChannelClass,
             ChannelInitializer<UnixChannel> channelInitializer,
             DomainSocketAddress domainSocketAddress,
-            CallbackDispatcher callbackDispatcher) {
+            CallbackDispatcher callbackDispatcher)
+            throws InterruptedException {
         channel =
                 new Bootstrap()
                         .group(eventLoopGroup)
                         .channel(domainSocketChannelClass)
                         .handler(channelInitializer)
                         .connect(domainSocketAddress)
-                        .syncUninterruptibly()
+                        .sync()
                         .channel();
         this.callbackDispatcher = callbackDispatcher;
     }

--- a/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
@@ -58,7 +58,7 @@ public class ChannelHandler {
                         .channel(domainSocketChannelClass)
                         .handler(channelInitializer)
                         .connect(domainSocketAddress)
-                        // TODO call here .sync() if needed or remove this comment
+                        .syncUninterruptibly()
                         .channel();
         this.callbackDispatcher = callbackDispatcher;
     }


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Without this fix `ConnectionManager` sends a connection request before the channel established and this request get lost/ignored by netty.

`syncUninterruptibly` is actually `await` which throws no exceptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
