### PR TITLE
Fix PyPi CD to publish python 3.8 3.9 wheels for macOS

### DIFF
--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -79,6 +79,11 @@ jobs:
               with:
                   python-version: "3.10"
 
+            - name: Set up Python older versions for MacOS
+              if: matrix.build.PYPI_PUBLISH == true && startsWith(matrix.build.NAMED_OS, 'darwin')
+              run: |
+                brew install python@3.8 python@3.9
+
             - name: Setup Python for self-hosted Ubuntu runners
               if: matrix.build.PYPI_PUBLISH == true && contains(matrix.build.OS, 'ubuntu') && contains(matrix.build.RUNNER, 'self-hosted')
               run: |
@@ -131,7 +136,7 @@ jobs:
               with:
                   working-directory: ./python
                   target: ${{ matrix.build.TARGET }}
-                  args: --release --strip --out wheels -i python3.10 python3.11 python3.12
+                  args: --release --strip --out wheels -i python3.8 python3.9 python3.10 python3.11 python3.12
 
             - name: Upload Python wheels
               if: matrix.build.PYPI_PUBLISH == true


### PR DESCRIPTION
*Issue #, if available:*
Fixes #839. Wheels for 0.1.1 macos py38 and py39 were published to PyPi:
[glide_for_redis-0.1.1-cp38-cp38-macosx_11_0_arm64.whl ](https://files.pythonhosted.org/packages/a2/a2/aea18072fda218423ac6b298eeb54edb8f9faf5b3ea9eb7e92077a334336/glide_for_redis-0.1.1-cp38-cp38-macosx_11_0_arm64.whl)(1.8 MB [view hashes](https://pypi.org/project/glide-for-redis/#copy-hash-modal-fe8622b5-8084-4766-9a6b-419666eb5285))

[glide_for_redis-0.1.1-cp38-cp38-macosx_10_7_x86_64.whl ](https://files.pythonhosted.org/packages/04/dd/77c385222735f5ac254dfc8be889fc5e07d3c68d17d59595b87cd3b802ab/glide_for_redis-0.1.1-cp38-cp38-macosx_10_7_x86_64.whl)(1.9 MB [view hashes](https://pypi.org/project/glide-for-redis/#copy-hash-modal-55d9cab8-3862-4b90-bb87-6bd8e4c98589))

Action run: https://github.com/aws/glide-for-redis/actions/runs/7600691496

After #819 is merged, should be pulled for mainline too.

