### PR TITLE
Use jemalloc as default allocator.

### DIFF
--- a/benchmarks/rust/Cargo.toml
+++ b/benchmarks/rust/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4.3.8", features = ["derive"] }
 chrono = "0.4.26"
 serde_json = "1.0.99"
 statistical = "1.0.0"
+tikv-jemallocator = "0.5.4"
 
 [profile.release]
 debug = true

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -1,3 +1,10 @@
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 use clap::Parser;
 use futures::{self, future::join_all, stream, StreamExt};
 use glide_core::{

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -20,6 +20,8 @@ logger_core = {path = "../../logger_core"}
 byteorder = "1.4.3"
 num-traits = "0.2.17"
 num-bigint = { version = "0.4.4", optional = true }
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = {version = "0.5.4", features = ["disable_initial_exec_tls"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,3 +1,10 @@
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 use byteorder::{LittleEndian, WriteBytesExt};
 use glide_core::start_socket_listener;
 use glide_core::MAX_REQUEST_ARGS_LENGTH;
@@ -11,7 +18,6 @@ use redis::{aio::MultiplexedConnection, AsyncCommands, FromRedisValue, Value};
 use std::collections::HashMap;
 use std::str;
 use tokio::runtime::{Builder, Runtime};
-
 #[napi]
 pub enum Level {
     Debug = 3,


### PR DESCRIPTION
This brings a significant perf improvement in Rust & Node. This replaces the allocator only for GLIDE in the Node library, and replaces the allocator for the whole Rust benchmarking application.
[jemalloc.xlsx](https://github.com/aws/glide-for-redis/files/14011810/jemalloc.xlsx)
Python jemalloc results are for code that isn't added here, where I used jemalloc in a similar way to the Node system. Since there wasn't an improvement, that change isn't a part of this PR.

*Issue #, if available:*

*Description of changes:*



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
