### PR TITLE
Update Python's protobuf compiler prerequisite to >= 3.20.0

### DIFF
--- a/python/DEVELOPER.md
+++ b/python/DEVELOPER.md
@@ -16,7 +16,7 @@ Software Dependencies
 -   git
 -   GCC
 -   pkg-config
--   protoc (protobuf compiler)
+-   protoc (protobuf compiler) >= v3.20.0
 -   openssl
 -   openssl-dev
 -   rustup
@@ -25,29 +25,51 @@ Software Dependencies
 
 ```bash
 sudo apt update -y
-sudo apt install -y python3 python3-venv git gcc pkg-config protobuf-compiler openssl libssl-dev
+sudo apt install -y python3 python3-venv git gcc pkg-config openssl libssl-dev unzip
+# Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
+# Check that the Rust compiler is installed
+rustc --version
+# Install protobuf compiler
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
+unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
+# Check that the protobuf compiler is installed
+protoc --version
 ```
 
 **Dependencies installation for CentOS**
 
 ```bash
 sudo yum update -y
-sudo yum install -y python3 git gcc pkgconfig protobuf-compiler openssl openssl-devel
+sudo yum install -y python3 git gcc pkgconfig openssl openssl-devel unzip
 pip3 install virtualenv
+# Install rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
+# Check that the Rust compiler is installed
+rustc --version
+# Install protobuf compiler
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip
+unzip protoc-3.20.3-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
+# Check that the protobuf compiler is installed
+protoc --version
 ```
 
 **Dependencies installation for MacOS**
 
 ```bash
 brew update
-brew install python3 git gcc pkgconfig protobuf openssl
+brew install python3 git gcc pkgconfig protobuf@3 openssl
 pip3 install virtualenv
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 source "$HOME/.cargo/env"
+# Check that the Rust compiler is installed
+rustc --version
 ```
 
 #### Building and installation steps

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -178,15 +178,13 @@ class CoreCommands(Protocol):
         request_type: RequestType.ValueType,
         args: List[str],
         route: Optional[Route] = ...,
-    ) -> TResult:
-        ...
+    ) -> TResult: ...
 
     async def execute_transaction(
         self,
         commands: List[Tuple[RequestType.ValueType, List[str]]],
         route: Optional[Route] = None,
-    ) -> List[TResult]:
-        ...
+    ) -> List[TResult]: ...
 
     async def set(
         self,

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -127,9 +127,9 @@ async def create_client(
     else:
         assert type(pytest.standalone_cluster) is RedisCluster
         config = RedisClientConfiguration(
-            addresses=pytest.standalone_cluster.nodes_addr
-            if addresses is None
-            else addresses,
+            addresses=(
+                pytest.standalone_cluster.nodes_addr if addresses is None else addresses
+            ),
             use_tls=use_tls,
             credentials=credentials,
             database_id=database_id,


### PR DESCRIPTION
Rebased over #866 
Fixes this python issue:
```

[Container] 2024/01/25 09:58:11.348983 Running command python3 -m pytest ${TESTS_TO_RUN} --asyncio-mode=auto --client Glide --timeout=3600 --capture=tee-sys -n 10 --dist loadscope --html=report.html --self-contained-html --junitxml=report.xml -m "not serverless and not memdb"
--
586 | ConftestImportFailure: TypeError: Descriptors cannot be created directly.
587 | If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
588 | If you cannot immediately regenerate your protos, some other possible workarounds are:
589 | 1. Downgrade the protobuf package to 3.20.x or lower.
590 | 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
591 |  
592 | More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates (from /codebuild/output/src3048699478/src/git-codecommit.us-east-1.amazonaws.com/v1/repos/RedisClientsCompatibilityTesting/Python/tests/conftest.py)
593 | For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
594 | config = pluginmanager.hook.pytest_cmdline_parse(
595 | ImportError while loading conftest '/.../RedisClientsCompatibilityTesting/Python/tests/conftest.py'.
596 | tests/conftest.py:3: in <module>
597 | from utils.client_factory import ClientType
598 | utils/__init__.py:1: in <module>
599 | from utils.client_utils import *
600 | utils/client_utils.py:11: in <module>
601 | from utils.client_factory import ClientFactory, ClientType
602 | utils/client_factory.py:9: in <module>
603 | from glide import (
604 | ../glide-for-redis/python/python/glide/__init__.py:1: in <module>
605 | from glide.async_commands.core import (
606 | ../glide-for-redis/python/python/glide/async_commands/__init__.py:1: in <module>
607 | from .core import CoreCommands
608 | ../glide-for-redis/python/python/glide/async_commands/core.py:17: in <module>
609 | from glide.constants import TOK, TResult
610 | ../glide-for-redis/python/python/glide/constants.py:3: in <module>
611 | from glide.protobuf.connection_request_pb2 import ConnectionRequest
612 | ../glide-for-redis/python/python/glide/protobuf/connection_request_pb2.py:33: in <module>
613 | _descriptor.EnumValueDescriptor(
614 | ../glide-for-redis/python/.env/lib/python3.12/site-packages/google/protobuf/descriptor.py:789: in __new__
615 | _message.Message._CheckCalledFromGeneratedFile()
616 | E   TypeError: Descriptors cannot be created directly.
617 | E   If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
618 | E   If you cannot immediately regenerate your protos, some other possible workarounds are:
619 | E    1. Downgrade the protobuf package to 3.20.x or lower.
620 | E    2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
621 | E
622 | E   More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates

