### PR TITLE
Java: Add IT framework

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -64,11 +64,7 @@ jobs:
               with:
                   redis-version: ${{ matrix.redis }}
 
-            - name: Build rust part
-              working-directory: java
-              run: cargo build --release
-
-            - name: Build java part
+            - name: Build java client
               working-directory: java
               run: ./gradlew --continue build
 
@@ -77,10 +73,11 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-${{ matrix.java }}
+                  name: test-reports-java-${{ matrix.java }}-redis-${{ matrix.redis }}-${{ matrix.os }}
                   path: |
                       java/client/build/reports/**
                       java/integTest/build/reports/**
+                      utils/clusters/**
 
     build-amazonlinux-latest:
         if: github.repository_owner == 'aws'

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -110,7 +110,7 @@ tasks.register('buildAll') {
     finalizedBy 'build'
 }
 
-compileJava.dependsOn('protobuf', 'buildRustRelease')
+compileJava.dependsOn('protobuf')
 clean.dependsOn('cleanProtobuf', 'cleanRust')
 test.dependsOn('buildRust')
 testFfi.dependsOn('buildRust')
@@ -127,4 +127,3 @@ tasks.withType(Test) {
     }
     jvmArgs "-Djava.library.path=${projectDir}/../target/debug"
 }
-

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -1,0 +1,68 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // client
+    implementation project(':client')
+
+    // lombok
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    // junit
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
+    testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
+}
+
+tasks.register('stopAllAfterTests', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster', '--keep-folder'
+}
+
+// We need to call for stop before and after the test, but gradle doesn't support executing a task
+// twice. So there are two identical tasks with different names.
+// We need to call for stop in case if previous test run was interrupted/crashed and didn't stop.
+tasks.register('stopAllBeforeTests', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster'
+    ignoreExitValue true // ignore fail if servers are stopped before
+}
+
+// delete dirs if stop failed due to https://github.com/aws/glide-for-redis/issues/849
+tasks.register('clearDirs', Delete) {
+    delete "${project.rootDir}/../utils/clusters"
+}
+
+tasks.register('startCluster', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'start', '--cluster-mode', '-p', '7000', '7001', '7002', '7003', '7004', '7005'
+}
+
+tasks.register('startStandalone', Exec) {
+    workingDir "${project.rootDir}/../utils"
+    commandLine 'python3', 'cluster_manager.py', 'start', '-p', '6380', '-r', '0'
+}
+
+test.dependsOn 'stopAllBeforeTests'
+stopAllBeforeTests.finalizedBy 'clearDirs'
+clearDirs.finalizedBy 'startStandalone'
+clearDirs.finalizedBy 'startCluster'
+test.finalizedBy 'stopAllAfterTests'
+test.dependsOn ':client:buildRustRelease'
+
+tasks.withType(Test) {
+    systemProperty 'test.redis.standalone.port', '6380'
+    systemProperty 'test.redis.cluster.port', '7000'
+
+    testLogging {
+        exceptionFormat "full"
+        events "started", "skipped", "passed", "failed"
+        showStandardStreams true
+    }
+    jvmArgs "-Djava.library.path=${project.rootDir}/target/release"
+}

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -19,6 +19,22 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
 }
 
+def standaloneRedisPorts = []
+def clusterRedisPorts = []
+
+ext {
+    extractPortsFromClusterManagerOutput = { String output, ArrayList dest ->
+        for (def line : output.split("\n")) {
+            if (!line.startsWith("CLUSTER_NODES="))
+                continue
+
+            def addresses = line.split("=")[1].split(",")
+            for (def address : addresses)
+                dest << address.split(":")[1]
+        }
+    }
+}
+
 tasks.register('stopAllAfterTests', Exec) {
     workingDir "${project.rootDir}/../utils"
     commandLine 'python3', 'cluster_manager.py', 'stop', '--prefix', 'redis-cluster', '--keep-folder'
@@ -38,14 +54,30 @@ tasks.register('clearDirs', Delete) {
     delete "${project.rootDir}/../utils/clusters"
 }
 
-tasks.register('startCluster', Exec) {
-    workingDir "${project.rootDir}/../utils"
-    commandLine 'python3', 'cluster_manager.py', 'start', '--cluster-mode', '-p', '7000', '7001', '7002', '7003', '7004', '7005'
+tasks.register('startCluster') {
+    doLast {
+        new ByteArrayOutputStream().withStream { os ->
+            exec {
+                workingDir "${project.rootDir}/../utils"
+                commandLine 'python3', 'cluster_manager.py', 'start', '--cluster-mode'
+                standardOutput = os
+            }
+            extractPortsFromClusterManagerOutput(os.toString(), clusterRedisPorts)
+        }
+    }
 }
 
-tasks.register('startStandalone', Exec) {
-    workingDir "${project.rootDir}/../utils"
-    commandLine 'python3', 'cluster_manager.py', 'start', '-p', '6380', '-r', '0'
+tasks.register('startStandalone') {
+    doLast {
+        new ByteArrayOutputStream().withStream { os ->
+            exec {
+                workingDir "${project.rootDir}/../utils"
+                commandLine 'python3', 'cluster_manager.py', 'start', '-r', '0'
+                standardOutput = os
+            }
+            extractPortsFromClusterManagerOutput(os.toString(), standaloneRedisPorts)
+        }
+    }
 }
 
 test.dependsOn 'stopAllBeforeTests'
@@ -56,8 +88,12 @@ test.finalizedBy 'stopAllAfterTests'
 test.dependsOn ':client:buildRustRelease'
 
 tasks.withType(Test) {
-    systemProperty 'test.redis.standalone.port', '6380'
-    systemProperty 'test.redis.cluster.port', '7000'
+    doFirst {
+        println "Cluster ports = ${clusterRedisPorts}"
+        println "Standalone ports = ${standaloneRedisPorts}"
+        systemProperty 'test.redis.standalone.ports', standaloneRedisPorts.join(',')
+        systemProperty 'test.redis.cluster.ports', clusterRedisPorts.join(',')
+    }
 
     testLogging {
         exceptionFormat "full"

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -101,4 +101,7 @@ tasks.withType(Test) {
         showStandardStreams true
     }
     jvmArgs "-Djava.library.path=${project.rootDir}/target/release"
+    afterTest { desc, result ->
+        logger.quiet "${desc.className}.${desc.name}: ${result.resultType} ${(result.getEndTime() - result.getStartTime())/1000}s"
+    }
 }

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -1,0 +1,38 @@
+package glide;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class CommandTests {
+
+    private static RedisClient regularClient = null;
+
+    @BeforeAll
+    @SneakyThrows
+    public static void init() {
+        regularClient =
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .build())
+                        .get(10, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    @SneakyThrows
+    public static void deinit() {
+        regularClient.close();
+    }
+
+    @Test
+    @SneakyThrows
+    public void custom_command_info() {
+        regularClient.customCommand(new String[] {"info"}).get(10, TimeUnit.SECONDS);
+    }
+}

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -1,5 +1,7 @@
 package glide;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import glide.api.RedisClient;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
@@ -19,7 +21,8 @@ public class CommandTests {
         regularClient =
                 RedisClient.CreateClient(
                                 RedisClientConfiguration.builder()
-                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .address(
+                                                NodeAddress.builder().port(TestConfiguration.STANDALONE_PORTS[0]).build())
                                         .build())
                         .get(10, TimeUnit.SECONDS);
     }
@@ -33,6 +36,7 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void custom_command_info() {
-        regularClient.customCommand(new String[] {"info"}).get(10, TimeUnit.SECONDS);
+        var data = regularClient.customCommand(new String[] {"info"}).get(10, TimeUnit.SECONDS);
+        assertTrue(((String) data).contains("# Stats"));
     }
 }

--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -1,0 +1,25 @@
+package glide;
+
+import glide.api.RedisClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+
+public class ConnectionTests {
+
+    @Test
+    @SneakyThrows
+    public void basic_client() {
+        var regularClient =
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .build())
+                        .get(10, TimeUnit.SECONDS);
+        regularClient.close();
+    }
+
+    // TODO cluster client once implemented
+}

--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -15,7 +15,8 @@ public class ConnectionTests {
         var regularClient =
                 RedisClient.CreateClient(
                                 RedisClientConfiguration.builder()
-                                        .address(NodeAddress.builder().port(TestConfiguration.STANDALONE_PORT).build())
+                                        .address(
+                                                NodeAddress.builder().port(TestConfiguration.STANDALONE_PORTS[0]).build())
                                         .build())
                         .get(10, TimeUnit.SECONDS);
         regularClient.close();

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -1,0 +1,9 @@
+package glide;
+
+public class TestConfiguration {
+    // All redis servers are hosted on localhost
+    public static final int STANDALONE_PORT =
+            Integer.parseInt(System.getProperty("test.redis.standalone.port"));
+    public static final int CLUSTER_PORT =
+            Integer.parseInt(System.getProperty("test.redis.cluster.port"));
+}

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -1,9 +1,15 @@
 package glide;
 
-public class TestConfiguration {
+import java.util.Arrays;
+
+public final class TestConfiguration {
     // All redis servers are hosted on localhost
-    public static final int STANDALONE_PORT =
-            Integer.parseInt(System.getProperty("test.redis.standalone.port"));
-    public static final int CLUSTER_PORT =
-            Integer.parseInt(System.getProperty("test.redis.cluster.port"));
+    public static final int[] STANDALONE_PORTS = getPortsFromProperty("test.redis.standalone.ports");
+    public static final int[] CLUSTER_PORTS = getPortsFromProperty("test.redis.cluster.ports");
+
+    private static int[] getPortsFromProperty(String propName) {
+        return Arrays.stream(System.getProperty(propName).split(","))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+    }
 }

--- a/java/integTest/src/test/resources/junit-platform.properties
+++ b/java/integTest/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.displayname.generator.default = \
+    org.junit.jupiter.api.DisplayNameGenerator$ReplaceUnderscores

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import argparse
 import logging
 import os
@@ -258,7 +260,7 @@ def create_cluster_folder(path: str, prefix: str) -> str:
         str: The full path of the cluster folder
     """
     time = datetime.now(timezone.utc)
-    time_str = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    time_str = time.strftime("%Y-%m-%dT%H-%M-%SZ")
     cluster_folder = f"{path}/{prefix}-{time_str}-{get_random_string(6)}"
     logging.debug(f"## Creating cluster folder in {cluster_folder}")
     Path(cluster_folder).mkdir(exist_ok=True)


### PR DESCRIPTION
This PR adds IT test framework, some related script changes and sample tests.
IT test job starts redis in standalone mode on port 6380 in CI and a cluster on ports 7000-7006.

## When making your own test
To connect to standalone use:
```java
    var client =
        RedisClient.CreateClient(
                RedisClientConfiguration.builder()
                    .address(
                        NodeAddress.builder()
                            .port(TestConfiguration.STANDALONE_PORTS[0])
                            .build())
                    .build())
            .get(10, TimeUnit.SECONDS);
```
To connect to cluster use:
```java
    var clusterClient =
        ClusterClient.CreateClient(
                RedisClusterClientConfiguration.builder()
                    .address(
                        NodeAddress.builder()
                            .port(TestConfiguration.CLUSTER_PORTS[0])
                            .build())
                    .requestTimeout(3000)
                    .build())
            .get(10, TimeUnit.SECONDS);
```

## Running tests
Test can be started by
```
./gradlew :integTest:test
```
The test report is written to 
```
integTest/build/reports/tests/test/index.html
```
Redis server logs are stored in
```
<repo root>/utils/clusters
```
until next test start


## Running redis for tests
IT framework starts and stops redis automatically. If you want to start a redis server for you needs, you can re-use the script.

To start redis standalone instance IT uses
```
python3 <repo root>/utils/cluster_manager.py start -r 0
```
To start redis cluster
```
python3 <repo root>/utils/cluster_manager.py start --cluster-mode
```
To stop all
```
python3 <repo root>/utils/cluster_manager.py stop --prefix redis-cluster
```

The scripts assigns random ports for redis instances, so IT (gradle script) parses the output to get port numbers.

## Notes
1. Don't use `Future::get` in your tests without specifying a timeout, because it hangs IT/CI on an error!
2. `cluster_manager.py` script is updated for better compatibility with Linux and Windows. Colon symbol removed from file name, because Windows and [GHA](https://github.com/Bit-Quill/glide-for-redis/actions/runs/7645825241/job/20833302458#step:7:22) both don't like it.
3. Python and Node CI fails on main too, I tested it on this commit: https://github.com/Bit-Quill/glide-for-redis/commit/15d9f4e74de062ac24e95b51e2e480de5c7ae69f
4. `requestTimeout` may be needed for cluster client while testing locally