### PR TITLE
Core: Connection refused error shouldn't close the client

### DIFF
--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -206,35 +206,28 @@ async fn write_result(
         }
         Err(ClienUsageError::RedisError(err)) => {
             let error_message = err.to_string();
-            if err.is_connection_refusal() {
-                log_error("response error", &error_message);
-                Some(response::response::Value::ClosingError(
-                    error_message.into(),
-                ))
+            log_warn("received error", error_message.as_str());
+            log_debug("received error", format!("for callback {}", callback_index));
+            let mut request_error = response::RequestError::default();
+            if err.is_connection_dropped() {
+                request_error.type_ = response::RequestErrorType::Disconnect.into();
+                request_error.message = format!(
+                    "Received connection error `{error_message}`. Will attempt to reconnect"
+                )
+                .into();
+            } else if err.is_timeout() {
+                request_error.type_ = response::RequestErrorType::Timeout.into();
+                request_error.message = error_message.into();
             } else {
-                log_warn("received error", error_message.as_str());
-                log_debug("received error", format!("for callback {}", callback_index));
-                let mut request_error = response::RequestError::default();
-                if err.is_connection_dropped() {
-                    request_error.type_ = response::RequestErrorType::Disconnect.into();
-                    request_error.message = format!(
-                        "Received connection error `{error_message}`. Will attempt to reconnect"
-                    )
-                    .into();
-                } else if err.is_timeout() {
-                    request_error.type_ = response::RequestErrorType::Timeout.into();
-                    request_error.message = error_message.into();
-                } else {
-                    request_error.type_ = match err.kind() {
-                        redis::ErrorKind::ExecAbortError => {
-                            response::RequestErrorType::ExecAbort.into()
-                        }
-                        _ => response::RequestErrorType::Unspecified.into(),
-                    };
-                    request_error.message = error_message.into();
-                }
-                Some(response::response::Value::RequestError(request_error))
+                request_error.type_ = match err.kind() {
+                    redis::ErrorKind::ExecAbortError => {
+                        response::RequestErrorType::ExecAbort.into()
+                    }
+                    _ => response::RequestErrorType::Unspecified.into(),
+                };
+                request_error.message = error_message.into();
             }
+            Some(response::response::Value::RequestError(request_error))
         }
     };
     write_to_writer(response, writer).await


### PR DESCRIPTION
During node failures connection refused error can be raised. This error shouldn't result in closing the client, as the host might be under replacement / redis crashed or some temp reason for the connection to get refused. Removing this "if" fixes experienced downtime during failovers.