### PR TITLE
Update unit tests for java client

### DIFF
--- a/java/client/src/test/java/glide/api/RedisClientCreateTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientCreateTest.java
@@ -50,7 +50,7 @@ public class RedisClientCreateTest {
 
     @Test
     @SneakyThrows
-    public void createClient_withConfig_successfullyReturnsRedisClient() {
+    public void createClient_with_config_successfully_returns_RedisClient() {
 
         // setup
         CompletableFuture<Void> connectToRedisFuture = new CompletableFuture<>();
@@ -71,7 +71,7 @@ public class RedisClientCreateTest {
 
     @SneakyThrows
     @Test
-    public void createClient_errorOnConnectionThrowsExecutionException() {
+    public void createClient_error_on_connection_throws_ExecutionException() {
         // setup
         CompletableFuture<Void> connectToRedisFuture = new CompletableFuture<>();
         ClosingException exception = new ClosingException("disconnected");
@@ -84,8 +84,7 @@ public class RedisClientCreateTest {
         // exercise
         CompletableFuture<RedisClient> result = CreateClient(config);
 
-        ExecutionException executionException =
-                assertThrows(ExecutionException.class, () -> result.get());
+        ExecutionException executionException = assertThrows(ExecutionException.class, result::get);
 
         // verify
         assertEquals(exception, executionException.getCause());

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -21,6 +21,7 @@ import glide.connectors.handlers.ChannelHandler;
 import glide.managers.models.Command;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,8 +47,8 @@ public class CommandManagerTest {
     }
 
     @Test
-    public void submitNewCommand_returnObjectResult()
-            throws ExecutionException, InterruptedException {
+    @SneakyThrows
+    public void submitNewCommand_return_Object_result() {
 
         // setup
         long pointer = -1;
@@ -59,7 +60,7 @@ public class CommandManagerTest {
         when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
 
         // exercise
-        CompletableFuture result =
+        CompletableFuture<Object> result =
                 service.submitNewCommand(
                         command, new BaseCommandResponseResolver((ptr) -> ptr == pointer ? respObject : null));
         Object respPointer = result.get();
@@ -69,7 +70,8 @@ public class CommandManagerTest {
     }
 
     @Test
-    public void submitNewCommand_returnNullResult() throws ExecutionException, InterruptedException {
+    @SneakyThrows
+    public void submitNewCommand_return_Null_result() {
         // setup
         Response respPointerResponse = Response.newBuilder().build();
         CompletableFuture<Response> future = new CompletableFuture<>();
@@ -77,7 +79,7 @@ public class CommandManagerTest {
         when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
 
         // exercise
-        CompletableFuture result =
+        CompletableFuture<Object> result =
                 service.submitNewCommand(
                         command, new BaseCommandResponseResolver((p) -> new RuntimeException("")));
         Object respPointer = result.get();
@@ -87,8 +89,8 @@ public class CommandManagerTest {
     }
 
     @Test
-    public void submitNewCommand_returnStringResult()
-            throws ExecutionException, InterruptedException {
+    @SneakyThrows
+    public void submitNewCommand_return_String_result() {
 
         // setup
         long pointer = 123;
@@ -101,7 +103,7 @@ public class CommandManagerTest {
         when(channelHandler.write(any(), anyBoolean())).thenReturn(future);
 
         // exercise
-        CompletableFuture result =
+        CompletableFuture<Object> result =
                 service.submitNewCommand(
                         command, new BaseCommandResponseResolver((p) -> p == pointer ? testString : null));
         Object respPointer = result.get();
@@ -112,7 +114,7 @@ public class CommandManagerTest {
     }
 
     @Test
-    public void submitNewCommand_throwClosingException() {
+    public void submitNewCommand_throw_closing_exception() {
 
         // setup
         String errorMsg = "Closing";
@@ -128,7 +130,7 @@ public class CommandManagerTest {
                 assertThrows(
                         ExecutionException.class,
                         () -> {
-                            CompletableFuture result =
+                            CompletableFuture<Object> result =
                                     service.submitNewCommand(
                                             command, new BaseCommandResponseResolver((ptr) -> new Object()));
                             result.get();
@@ -163,7 +165,7 @@ public class CommandManagerTest {
                 assertThrows(
                         ExecutionException.class,
                         () -> {
-                            CompletableFuture result =
+                            CompletableFuture<Object> result =
                                     service.submitNewCommand(command, new BaseCommandResponseResolver((ptr) -> null));
                             result.get();
                         });

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -16,6 +16,7 @@ import connection_request.ConnectionRequestOuterClass;
 import connection_request.ConnectionRequestOuterClass.AuthenticationInfo;
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;
 import connection_request.ConnectionRequestOuterClass.ConnectionRetryStrategy;
+import connection_request.ConnectionRequestOuterClass.TlsMode;
 import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.ReadFrom;
@@ -31,6 +32,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import response.ResponseOuterClass;
+import response.ResponseOuterClass.ConstantResponse;
 import response.ResponseOuterClass.Response;
 
 public class ConnectionManagerTest {
@@ -53,7 +55,7 @@ public class ConnectionManagerTest {
     private static int REQUEST_TIMEOUT = 3;
 
     @BeforeEach
-    public void setUp() throws ExecutionException, InterruptedException {
+    public void setUp() {
         channel = mock(ChannelHandler.class);
         ChannelFuture closeFuture = mock(ChannelFuture.class);
         when(closeFuture.syncUninterruptibly()).thenReturn(closeFuture);
@@ -63,18 +65,17 @@ public class ConnectionManagerTest {
 
     @SneakyThrows
     @Test
-    public void ConnectionRequestProtobufGeneration_DefaultRedisClientConfiguration_returns() {
+    public void connection_request_protobuf_generation_default_standalone_configuration() {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         ConnectionRequest expectedProtobufConnectionRequest =
                 ConnectionRequest.newBuilder()
-                        .setTlsMode(ConnectionRequestOuterClass.TlsMode.NoTls)
+                        .setTlsMode(TlsMode.NoTls)
                         .setClusterModeEnabled(false)
                         .setReadFrom(ConnectionRequestOuterClass.ReadFrom.Primary)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ResponseOuterClass.ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -88,19 +89,18 @@ public class ConnectionManagerTest {
 
     @SneakyThrows
     @Test
-    public void ConnectionRequestProtobufGeneration_DefaultRedisClusterClientConfiguration_returns() {
+    public void connection_request_protobuf_generation_default_cluster_configuration() {
         // setup
         RedisClusterClientConfiguration redisClusterClientConfiguration =
                 RedisClusterClientConfiguration.builder().build();
         ConnectionRequest expectedProtobufConnectionRequest =
                 ConnectionRequest.newBuilder()
-                        .setTlsMode(ConnectionRequestOuterClass.TlsMode.NoTls)
+                        .setTlsMode(TlsMode.NoTls)
                         .setClusterModeEnabled(true)
                         .setReadFrom(ConnectionRequestOuterClass.ReadFrom.Primary)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ResponseOuterClass.ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -115,7 +115,7 @@ public class ConnectionManagerTest {
 
     @SneakyThrows
     @Test
-    public void ConnectionRequestProtobufGeneration_RedisClientAllFieldsSet_returns() {
+    public void connection_request_protobuf_generation_with_all_fields_set() {
         // setup
         RedisClientConfiguration redisClientConfiguration =
                 RedisClientConfiguration.builder()
@@ -145,7 +145,7 @@ public class ConnectionManagerTest {
                                         .setHost(DEFAULT_HOST)
                                         .setPort(DEFAULT_PORT)
                                         .build())
-                        .setTlsMode(ConnectionRequestOuterClass.TlsMode.SecureTls)
+                        .setTlsMode(TlsMode.SecureTls)
                         .setReadFrom(ConnectionRequestOuterClass.ReadFrom.PreferReplica)
                         .setClusterModeEnabled(false)
                         .setAuthenticationInfo(
@@ -160,8 +160,7 @@ public class ConnectionManagerTest {
                         .setDatabaseId(DATABASE_ID)
                         .build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ResponseOuterClass.ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -175,12 +174,11 @@ public class ConnectionManagerTest {
 
     @SneakyThrows
     @Test
-    public void CheckRedisResponse_ConstantResponse_returnsSuccessfully() {
+    public void response_validation_on_constant_response_returns_successfully() {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
-        Response response =
-                Response.newBuilder().setConstantResponse(ResponseOuterClass.ConstantResponse.OK).build();
+        Response response = Response.newBuilder().setConstantResponse(ConstantResponse.OK).build();
         completedFuture.complete(response);
 
         // execute
@@ -193,7 +191,7 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void onConnection_emptyResponse_throwsClosingException() {
+    public void connection_on_empty_response_throws_ClosingException() {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
@@ -213,7 +211,7 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void CheckRedisResponse_RequestError_throwsClosingException() {
+    public void connection_on_resp_pointer_throws_ClosingException() {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();
@@ -239,7 +237,7 @@ public class ConnectionManagerTest {
     }
 
     @Test
-    public void CheckRedisResponse_ClosingError_throwsClosingException() {
+    public void check_response_on_closing_error_throws_ClosingException() {
         // setup
         RedisClientConfiguration redisClientConfiguration = RedisClientConfiguration.builder().build();
         CompletableFuture<Response> completedFuture = new CompletableFuture<>();


### PR DESCRIPTION
Minor non-functional changed (code grooming).
Test cases are renamed because this thing replaces underscores by spaces, which makes test report more readable
https://github.com/aws/glide-for-redis/blob/e39f4ae12d1583a1d62d6cbce4aba5966ff270b8/java/client/src/test/resources/junit-platform.properties#L2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
