### PR TITLE
Add legal header to all source code files

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Linq;

--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { writeFileSync } from "fs";
 import { Logger, RedisClient, RedisClusterClient } from "glide-for-redis";
 import { Cluster, Redis } from "ioredis";

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import argparse
 import asyncio
 import functools

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 

--- a/benchmarks/utilities/csv_exporter.py
+++ b/benchmarks/utilities/csv_exporter.py
@@ -1,5 +1,7 @@
 #!/bin/python3
 
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import csv
 import json
 import os

--- a/benchmarks/utilities/fill_db.ts
+++ b/benchmarks/utilities/fill_db.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     SIZE_SET_KEYSPACE,
     createRedisClient,

--- a/benchmarks/utilities/flush_db.ts
+++ b/benchmarks/utilities/flush_db.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { RedisClientType, RedisClusterType } from "redis";
 import { createRedisClient, receivedOptions } from "./utils";
 

--- a/benchmarks/utilities/utils.ts
+++ b/benchmarks/utilities/utils.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import commandLineArgs from "command-line-args";
 import {
     RedisClientType,

--- a/csharp/lib/AsyncClient.cs
+++ b/csharp/lib/AsyncClient.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.InteropServices;
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
+using System.Runtime.InteropServices;
 
 namespace Glide
 {

--- a/csharp/lib/Logger.cs
+++ b/csharp/lib/Logger.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/csharp/lib/Message.cs
+++ b/csharp/lib/Message.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/csharp/lib/MessageContainer.cs
+++ b/csharp/lib/MessageContainer.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 using System.Collections.Concurrent;
 
 namespace Glide

--- a/csharp/lib/Properties/AssemblyInfo.cs
+++ b/csharp/lib/Properties/AssemblyInfo.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("tests")]

--- a/csharp/lib/src/lib.rs
+++ b/csharp/lib/src/lib.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use glide_core::connection_request;
 use glide_core::{client::Client as GlideClient, connection_request::NodeAddress};
 use redis::{Cmd, FromRedisValue, RedisResult};

--- a/csharp/tests/AsyncClientTests.cs
+++ b/csharp/tests/AsyncClientTests.cs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 namespace tests;
 
 using Glide;

--- a/csharp/tests/Usings.cs
+++ b/csharp/tests/Usings.cs
@@ -1,1 +1,5 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 global using NUnit.Framework;

--- a/examples/node/index.ts
+++ b/examples/node/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { Logger, RedisClient, RedisClusterClient } from "@aws/glide-for-redis";
 
 async function sendPingToNode() {

--- a/examples/python/client_example.py
+++ b/examples/python/client_example.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import asyncio
 from typing import Optional, Union
 

--- a/glide-core/benches/connections_benchmark.rs
+++ b/glide-core/benches/connections_benchmark.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::future::join_all;
 use redis::{

--- a/glide-core/benches/memory_benchmark.rs
+++ b/glide-core/benches/memory_benchmark.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use glide_core::{
     client::Client,
     connection_request::{ConnectionRequest, NodeAddress, TlsMode},

--- a/glide-core/benches/rotating_buffer_benchmark.rs
+++ b/glide-core/benches/rotating_buffer_benchmark.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use std::io::Write;
 
 use bytes::BufMut;

--- a/glide-core/build.rs
+++ b/glide-core/build.rs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 fn main() {
     let customization_options = protobuf_codegen::Customize::default()
         .lite_runtime(false)

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use crate::connection_request::{
     ConnectionRequest, NodeAddress, ProtocolVersion, ReadFrom, TlsMode,
 };

--- a/glide-core/src/client/reconnecting_connection.rs
+++ b/glide-core/src/client/reconnecting_connection.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use crate::connection_request::{NodeAddress, TlsMode};
 use crate::retry_strategies::RetryStrategy;
 use futures_intrusive::sync::ManualResetEvent;

--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use super::get_redis_connection_info;
 use super::reconnecting_connection::ReconnectingConnection;
 use crate::connection_request::{ConnectionRequest, NodeAddress, TlsMode};

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use redis::{cluster_routing::Routable, from_redis_value, Cmd, ErrorKind, RedisResult, Value};
 
 pub(crate) enum ExpectedReturnType {

--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -1,3 +1,7 @@
+/*
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 include!(concat!(env!("OUT_DIR"), "/protobuf/mod.rs"));
 pub mod client;
 mod retry_strategies;

--- a/glide-core/src/retry_strategies.rs
+++ b/glide-core/src/retry_strategies.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use crate::connection_request::ConnectionRetryStrategy;
 use std::time::Duration;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};

--- a/glide-core/src/rotating_buffer.rs
+++ b/glide-core/src/rotating_buffer.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use bytes::BytesMut;
 use integer_encoding::VarInt;
 use logger_core::log_error;

--- a/glide-core/src/scripts_container.rs
+++ b/glide-core/src/scripts_container.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use arcstr::ArcStr;
 use logger_core::log_info;
 use once_cell::sync::Lazy;

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use super::rotating_buffer::RotatingBuffer;
 use crate::client::Client;
 use crate::connection_request::ConnectionRequest;

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 mod utilities;
 
 #[cfg(test)]

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 mod utilities;
 
 #[cfg(test)]

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use glide_core::*;
 use rsevents::{Awaitable, EventState, ManualResetEvent};
 use std::io::prelude::*;

--- a/glide-core/tests/test_standalone_client.rs
+++ b/glide-core/tests/test_standalone_client.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 mod utilities;
 
 #[cfg(test)]

--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use super::{create_connection_request, ClusterMode, TestConfiguration};
 use futures::future::{join_all, BoxFuture};
 use futures::FutureExt;

--- a/glide-core/tests/utilities/mocks.rs
+++ b/glide-core/tests/utilities/mocks.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use futures_intrusive::sync::ManualResetEvent;
 use redis::{Cmd, ConnectionAddr, Value};
 use std::collections::HashMap;

--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -1,3 +1,7 @@
+/*
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 #![allow(dead_code)]
 use futures::Future;
 use glide_core::{

--- a/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/BenchmarkingApp.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks;
 
 import static glide.benchmarks.utils.Benchmarking.testClientSetGet;

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/AsyncClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/AsyncClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.clients;
 
 import java.util.concurrent.ExecutionException;

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/Client.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/Client.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.clients;
 
 import glide.benchmarks.utils.ConnectionSettings;

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/SyncClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/SyncClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.clients;
 
 /** A Redis client with sync capabilities */

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.clients.jedis;
 
 import glide.benchmarks.clients.SyncClient;

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/lettuce/LettuceAsyncClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/lettuce/LettuceAsyncClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.clients.lettuce;
 
 import glide.benchmarks.clients.AsyncClient;

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.utils;
 
 import glide.benchmarks.BenchmarkingApp;

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/ChosenAction.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/ChosenAction.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.utils;
 
 public enum ChosenAction {

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/ConnectionSettings.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/ConnectionSettings.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.utils;
 
 /** Redis-client settings */

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/JsonWriter.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/JsonWriter.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.utils;
 
 import com.google.gson.Gson;

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/LatencyResults.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/LatencyResults.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.benchmarks.utils;
 
 import java.util.Arrays;

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
 import glide.ffi.resolvers.RedisValueResolver;

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;

--- a/java/client/src/main/java/glide/api/commands/BaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BaseCommands.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.commands;
 
 import java.util.concurrent.CompletableFuture;

--- a/java/client/src/main/java/glide/api/models/configuration/BackoffStrategy.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BackoffStrategy.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import lombok.Builder;

--- a/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseClientConfiguration.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import java.util.List;

--- a/java/client/src/main/java/glide/api/models/configuration/NodeAddress.java
+++ b/java/client/src/main/java/glide/api/models/configuration/NodeAddress.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import lombok.Builder;

--- a/java/client/src/main/java/glide/api/models/configuration/ReadFrom.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ReadFrom.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 /** Represents the client's read from strategy. */

--- a/java/client/src/main/java/glide/api/models/configuration/RedisClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisClientConfiguration.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import lombok.Getter;

--- a/java/client/src/main/java/glide/api/models/configuration/RedisClusterClientConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisClusterClientConfiguration.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import lombok.experimental.SuperBuilder;

--- a/java/client/src/main/java/glide/api/models/configuration/RedisCredentials.java
+++ b/java/client/src/main/java/glide/api/models/configuration/RedisCredentials.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.configuration;
 
 import lombok.Builder;

--- a/java/client/src/main/java/glide/api/models/exceptions/ClosingException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ClosingException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /** Redis client error: Errors that report that the client has closed and is no longer usable. */

--- a/java/client/src/main/java/glide/api/models/exceptions/ConnectionException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ConnectionException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /**

--- a/java/client/src/main/java/glide/api/models/exceptions/ExecAbortException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/ExecAbortException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /** Redis client error: Errors that are thrown when a transaction is aborted. */

--- a/java/client/src/main/java/glide/api/models/exceptions/RedisException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/RedisException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /** Redis client error: Base class for errors. */

--- a/java/client/src/main/java/glide/api/models/exceptions/RequestException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/RequestException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /** Redis client error: Errors that were reported during a request. */

--- a/java/client/src/main/java/glide/api/models/exceptions/TimeoutException.java
+++ b/java/client/src/main/java/glide/api/models/exceptions/TimeoutException.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.models.exceptions;
 
 /** Redis client error: Errors that are thrown when a request times out. */

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
 import java.util.concurrent.CompletableFuture;

--- a/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ChannelHandler.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
 import connection_request.ConnectionRequestOuterClass.ConnectionRequest;

--- a/java/client/src/main/java/glide/connectors/handlers/ProtobufSocketChannelInitializer.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ProtobufSocketChannelInitializer.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
 import io.netty.channel.ChannelInitializer;

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
 import io.netty.channel.ChannelHandlerContext;

--- a/java/client/src/main/java/glide/connectors/resources/Platform.java
+++ b/java/client/src/main/java/glide/connectors/resources/Platform.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.resources;
 
 import io.netty.channel.epoll.Epoll;

--- a/java/client/src/main/java/glide/connectors/resources/ThreadPoolAllocator.java
+++ b/java/client/src/main/java/glide/connectors/resources/ThreadPoolAllocator.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.resources;
 
 import io.netty.channel.EventLoopGroup;

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
 import response.ResponseOuterClass.Response;

--- a/java/client/src/main/java/glide/ffi/resolvers/SocketListenerResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/SocketListenerResolver.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
 public class SocketListenerResolver {

--- a/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import glide.api.models.exceptions.ClosingException;

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import glide.connectors.handlers.ChannelHandler;

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import connection_request.ConnectionRequestOuterClass;

--- a/java/client/src/main/java/glide/managers/RedisExceptionCheckedFunction.java
+++ b/java/client/src/main/java/glide/managers/RedisExceptionCheckedFunction.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import glide.api.models.exceptions.RedisException;

--- a/java/client/src/main/java/glide/managers/models/Command.java
+++ b/java/client/src/main/java/glide/managers/models/Command.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers.models;
 
 import lombok.Builder;

--- a/java/client/src/test/java/glide/api/RedisClientCreateTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientCreateTest.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
 import static glide.api.RedisClient.CreateClient;

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi;
 
 import static org.junit.jupiter.api.Assertions.assertAll;

--- a/java/client/src/test/java/glide/managers/CommandManagerTest.java
+++ b/java/client/src/test/java/glide/managers/CommandManagerTest.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
 import static glide.api.models.configuration.NodeAddress.DEFAULT_HOST;

--- a/java/src/ffi_test.rs
+++ b/java/src/ffi_test.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use jni::{
     objects::{JClass, JLongArray},
     sys::jlong,

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use glide_core::start_socket_listener;
 
 use jni::objects::{JClass, JObject, JObjectArray, JThrowable};

--- a/logger_core/src/lib.rs
+++ b/logger_core/src/lib.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use once_cell::sync::OnceCell;
 use std::sync::RwLock;
 use tracing::{self, event};

--- a/logger_core/tests/test_logger.rs
+++ b/logger_core/tests/test_logger.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use test_env_helpers::*;
 
 #[cfg(test)]

--- a/node/index.ts
+++ b/node/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 export { Script } from "glide-rs";
 export * from "./src/BaseClient";
 export * from "./src/Commands";

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 const { platform, arch } = process;
 let nativeBinding = null;
 switch (platform) {

--- a/node/rust-client/build.rs
+++ b/node/rust-client/build.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 extern crate napi_build;
 
 fn main() {

--- a/node/rust-client/src/lib.rs
+++ b/node/rust-client/src/lib.rs
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     DEFAULT_TIMEOUT_IN_MILLISECONDS,
     Script,

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     MAX_REQUEST_ARGS_LEN,
     createLeakedStringVec,

--- a/node/src/Errors.ts
+++ b/node/src/Errors.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 /// Base class for errors.
 export abstract class RedisError extends Error {
     public message: string;

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { InitInternalLogger, Level, log } from "glide-rs";
 
 const LEVEL: Map<LevelOptions | undefined, Level | undefined> = new Map([

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import * as net from "net";
 import { BaseClient, BaseClientConfiguration, ReturnType } from "./BaseClient";
 import {

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import * as net from "net";
 import { BaseClient, BaseClientConfiguration, ReturnType } from "./BaseClient";
 import {

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     ExpireOptions,
     InfoOptions,

--- a/node/tests/AsyncClient.test.ts
+++ b/node/tests/AsyncClient.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { afterAll, afterEach, beforeAll, describe } from "@jest/globals";
 import { AsyncClient } from "glide-rs";
 import RedisServer from "redis-server";

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     afterAll,
     afterEach,

--- a/node/tests/RedisClientInternals.test.ts
+++ b/node/tests/RedisClientInternals.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { beforeAll, describe, expect, it } from "@jest/globals";
 import fs from "fs";
 import {

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     afterAll,
     afterEach,

--- a/node/tests/RedisModules.test.ts
+++ b/node/tests/RedisModules.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import {
     afterAll,
     afterEach,

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { expect, it } from "@jest/globals";
 import { exec } from "child_process";
 import { v4 as uuidv4 } from "uuid";

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -1,3 +1,7 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
+
 import { beforeAll, expect } from "@jest/globals";
 import { exec } from "child_process";
 import { v4 as uuidv4 } from "uuid";

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,

--- a/python/python/glide/async_commands/__init__.py
+++ b/python/python/glide/async_commands/__init__.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from .core import CoreCommands
 
 __all__ = ["CoreCommands"]

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Dict, List, Mapping, Optional, cast

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from datetime import datetime, timedelta
 from enum import Enum
 from typing import (

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from typing import Dict, List, Mapping, Optional, cast

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import threading
 from typing import List, Mapping, Optional, Tuple, Union
 

--- a/python/python/glide/config.py
+++ b/python/python/glide/config.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from enum import Enum
 from typing import List, Optional
 

--- a/python/python/glide/constants.py
+++ b/python/python/glide/constants.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from typing import Dict, List, Literal, Set, TypeVar, Union
 
 from glide.protobuf.connection_request_pb2 import ConnectionRequest

--- a/python/python/glide/exceptions.py
+++ b/python/python/glide/exceptions.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from typing import Optional
 
 

--- a/python/python/glide/logger.py
+++ b/python/python/glide/logger.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from __future__ import annotations
 
 from enum import Enum

--- a/python/python/glide/protobuf_codec.py
+++ b/python/python/glide/protobuf_codec.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import struct
 from typing import List, Tuple, Type
 

--- a/python/python/glide/redis_client.py
+++ b/python/python/glide/redis_client.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import asyncio
 import threading
 from typing import List, Optional, Set, Tuple, Union, cast

--- a/python/python/glide/routes.py
+++ b/python/python/glide/routes.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from enum import Enum
 from typing import Optional
 

--- a/python/python/tests/__init__.py
+++ b/python/python/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import random
 from typing import AsyncGenerator, List, Optional, Union
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import asyncio

--- a/python/python/tests/test_config.py
+++ b/python/python/tests/test_config.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from glide.config import BaseClientConfiguration, NodeAddress, ReadFrom
 from glide.protobuf.connection_request_pb2 import ConnectionRequest
 from glide.protobuf.connection_request_pb2 import ReadFrom as ProtobufReadFrom

--- a/python/python/tests/test_proto_coded.py
+++ b/python/python/tests/test_proto_coded.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import pytest
 from glide.protobuf.redis_request_pb2 import RedisRequest, RequestType
 from glide.protobuf.response_pb2 import Response

--- a/python/python/tests/test_redis_modules.py
+++ b/python/python/tests/test_redis_modules.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import pytest
 from glide.async_commands.core import InfoSection
 from glide.redis_client import TRedisClient

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from datetime import datetime, timezone
 from typing import List, Union
 

--- a/python/python/tests/test_utils.py
+++ b/python/python/tests/test_utils.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 from glide.logger import Level, Logger
 from tests.conftest import DEFAULT_TEST_LOG_LEVEL
 

--- a/python/python/tests/utils/cluster.py
+++ b/python/python/tests/utils/cluster.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import os
 import subprocess
 import sys

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,3 +1,6 @@
+/**
+ * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+ */
 use glide_core::start_socket_listener;
 use pyo3::exceptions::PyUnicodeDecodeError;
 use pyo3::prelude::*;

--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -1,3 +1,5 @@
+# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
 import argparse
 import logging
 import os


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Used the following script and minor manual corrections
```
#!/bin/bash

set -e
#set -o xtrace

DIRS=("./benchmarks" "./csharp" "./examples" "./glide-core" "./java" "./logger_core" "./node" "./python" "./utils")
PYTHON_EXT=(".py")
OTHER_EXT=(".rs" ".java" ".ts" ".cs")

PYTHON_LEGAL_FN="./python-legal.txt"
OTHER_LEGAL_FN="./others-legal.txt"


#process python
for ext in ${PYTHON_EXT[@]}; do
    #echo $ext
    for dir in ${DIRS[@]}; do
        #echo $dir
        for fn in `find $dir -not -path '*/.*' -name "*"$ext`; do
            echo $fn
            cat $PYTHON_LEGAL_FN $fn > $fn".new"; mv $fn{.new,}
        done
    done
done

# #process others
for ext in ${OTHER_EXT[@]}; do
    #echo $ext
    for dir in ${DIRS[@]}; do
        #echo $dir
        for fn in `find $dir -not -path '*/.*' -name "*"$ext`; do
            echo $fn
            cat $OTHER_LEGAL_FN $fn > $fn".new"; mv $fn{.new,}
        done
    done
done
```

**others-legal.txt**:
```
/**
 * Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 */

```

**python-legal.txt**:
```
# Copyright GLIDE Project Contributors - SPDX Identifier: Apache-2.0


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
