### PR TITLE
Configure spotless (linter for java) to check/add licence header

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -83,6 +83,7 @@ spotless {
             include '**/*.java'
             exclude '**/build/**', '**/build-*/**', '**/protobuf/**'
         }
+        licenseHeader('/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */')
         importOrder()
         removeUnusedImports()
         trimTrailingWhitespace()

--- a/java/integTest/src/test/java/glide/CommandTests.java
+++ b/java/integTest/src/test/java/glide/CommandTests.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/java/integTest/src/test/java/glide/ConnectionTests.java
+++ b/java/integTest/src/test/java/glide/ConnectionTests.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
 import glide.api.RedisClient;

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -1,3 +1,4 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
 import java.util.Arrays;


### PR DESCRIPTION
```
./gradlew spotlessApply
```
adds missing header automatically for all java files

Next step (next PR(s)):
- spotless for gradle files
- linter for rust for license header check
- license header check for all [source] files in CI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
