### PR TITLE
Add IT with ping for java cluster client.

### DIFF
--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1,6 +1,7 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.cluster;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.TestConfiguration;
@@ -42,5 +43,12 @@ public class CommandTests {
         for (var info : data.getMultiValue().values()) {
             assertTrue(((String) info).contains("# Stats"));
         }
+    }
+
+    @Test
+    @SneakyThrows
+    public void custom_command_ping() {
+        var data = clusterClient.customCommand(new String[] {"ping"}).get(10, TimeUnit.SECONDS);
+        assertEquals("PONG", data.getSingleValue());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
as requested in https://github.com/aws/glide-for-redis/pull/864#discussion_r1473899153,
adding an IT for cluster client with `ping` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
