### PR TITLE
Make all arguments to benchmarks optional.

### DIFF
--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -18,29 +18,29 @@ public static class MainClass
 
     public class CommandLineOptions
     {
-        [Option('r', "resultsFile", Required = true, HelpText = "Set the file to which the JSON results are written.")]
-        public string resultsFile { get; set; } = "";
+        [Option('r', "resultsFile", Required = false, HelpText = "Set the file to which the JSON results are written.")]
+        public string resultsFile { get; set; } = "../results/csharp-results.json";
 
-        [Option('d', "dataSize", Required = true, HelpText = "The size of the sent data in bytes.")]
-        public int dataSize { get; set; } = -1;
+        [Option('d', "dataSize", Required = false, HelpText = "The size of the sent data in bytes.")]
+        public int dataSize { get; set; } = 100;
 
-        [Option('c', "concurrentTasks", Required = true, HelpText = "The number of concurrent operations to perform.")]
-        public IEnumerable<int> concurrentTasks { get; set; } = Enumerable.Empty<int>();
+        [Option('c', "concurrentTasks", Required = false, HelpText = "The number of concurrent operations to perform.", Default = new[] { 1, 10, 100, 1000 })]
+        public IEnumerable<int> concurrentTasks { get; set; }
 
-        [Option('l', "clients", Required = true, HelpText = "Which clients should run")]
-        public string clientsToRun { get; set; } = "";
+        [Option('l', "clients", Required = false, HelpText = "Which clients should run")]
+        public string clientsToRun { get; set; } = "all";
 
-        [Option('h', "host", Required = true, HelpText = "What host to target")]
-        public string host { get; set; } = "";
+        [Option('h', "host", Required = false, HelpText = "What host to target")]
+        public string host { get; set; } = "localhost";
 
-        [Option('C', "clientCount", Required = true, HelpText = "Number of clients to run concurrently")]
-        public IEnumerable<int> clientCount { get; set; } = Enumerable.Empty<int>();
+        [Option('C', "clientCount", Required = false, HelpText = "Number of clients to run concurrently", Default = new[] { 1 })]
+        public IEnumerable<int> clientCount { get; set; }
 
-        [Option('t', "tls", Default = false, HelpText = "Should benchmark a TLS server")]
+        [Option('t', "tls", HelpText = "Should benchmark a TLS server")]
         public bool tls { get; set; } = false;
 
 
-        [Option('m', "minimal", Default = false, HelpText = "Should use a minimal number of actions")]
+        [Option('m', "minimal", HelpText = "Should use a minimal number of actions")]
         public bool minimal { get; set; } = false;
     }
 

--- a/benchmarks/python/python_benchmark.py
+++ b/benchmarks/python/python_benchmark.py
@@ -14,6 +14,7 @@ from typing import List
 
 import numpy as np
 import redis.asyncio as redispy  # type: ignore
+
 from glide import (
     BaseClientConfiguration,
     Logger,
@@ -36,47 +37,51 @@ arguments_parser = argparse.ArgumentParser()
 arguments_parser.add_argument(
     "--resultsFile",
     help="Where to write the results file",
-    required=True,
+    required=False,
+    default="../results/python-results.json",
 )
 arguments_parser.add_argument(
-    "--dataSize",
-    help="Size of data to set",
-    required=True,
+    "--dataSize", help="Size of data to set", required=False, default="100"
 )
 arguments_parser.add_argument(
     "--concurrentTasks",
     help="List of number of concurrent tasks to run",
     nargs="+",
-    required=True,
+    required=False,
+    default=("1", "10", "100", "1000"),
 )
 arguments_parser.add_argument(
-    "--clients",
-    help="Which clients should run",
-    required=True,
+    "--clients", help="Which clients should run", required=False, default="all"
 )
 arguments_parser.add_argument(
-    "--host",
-    help="What host to target",
-    required=True,
+    "--host", help="What host to target", required=False, default="localhost"
 )
 arguments_parser.add_argument(
     "--clientCount",
     help="Number of clients to run concurrently",
     nargs="+",
-    required=True,
+    required=False,
+    default=("1"),
 )
 arguments_parser.add_argument(
-    "--tls", help="Should benchmark a TLS server", action="store_true"
+    "--tls",
+    help="Should benchmark a TLS server",
+    action="store_true",
+    required=False,
+    default=False,
 )
 arguments_parser.add_argument(
     "--clusterModeEnabled",
     help="Should benchmark a cluster mode enabled cluster",
     action="store_true",
+    required=False,
+    default=False,
 )
 arguments_parser.add_argument(
     "--port",
     default=PORT,
     type=int,
+    required=False,
     help="Which port to connect to, defaults to `%(default)s`",
 )
 arguments_parser.add_argument(

--- a/benchmarks/rust/src/main.rs
+++ b/benchmarks/rust/src/main.rs
@@ -28,16 +28,20 @@ use std::{
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    #[arg(name = "resultsFile", long)]
+    #[arg(
+        name = "resultsFile",
+        long,
+        default_value = "../results/rust-results.json"
+    )]
     results_file: String,
 
-    #[arg(long)]
+    #[arg(long, default_value = "localhost")]
     host: String,
 
-    #[arg(name = "dataSize", long)]
+    #[arg(name = "dataSize", long, default_value_t = 100)]
     data_size: usize,
 
-    #[arg(name = "concurrentTasks", long)]
+    #[arg(name = "concurrentTasks", long, default_values_t = [1,10,100,1000])]
     concurrent_tasks: Vec<usize>,
 
     #[arg(name = "clientCount", long, default_value_t = 1)]

--- a/benchmarks/utilities/utils.ts
+++ b/benchmarks/utilities/utils.ts
@@ -42,12 +42,21 @@ export function createRedisClient(
 }
 
 const optionDefinitions = [
-    { name: "resultsFile", type: String },
-    { name: "dataSize", type: String },
-    { name: "concurrentTasks", type: String, multiple: true },
-    { name: "clients", type: String },
-    { name: "host", type: String },
-    { name: "clientCount", type: String, multiple: true },
+    {
+        name: "resultsFile",
+        type: String,
+        defaultValue: "../results/node-results.json",
+    },
+    { name: "dataSize", type: String, defaultValue: "100" },
+    {
+        name: "concurrentTasks",
+        type: String,
+        multiple: true,
+        defaultValue: ["1", "10", "100", "1000"],
+    },
+    { name: "clients", type: String, defaultValue: "all" },
+    { name: "host", type: String, defaultValue: "localhost" },
+    { name: "clientCount", type: String, multiple: true, defaultValue: ["1"] },
     { name: "tls", type: Boolean, defaultValue: false },
     { name: "minimal", type: Boolean, defaultValue: false },
     { name: "clusterModeEnabled", type: Boolean, defaultValue: false },


### PR DESCRIPTION
This will make it easier to run the benchmarks directly, instead of through the script. As https://github.com/aws/glide-for-redis/pull/890 shows, new contributors need help with running the benchmarks.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
