### PR TITLE
Added ORT workflow

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,0 +1,198 @@
+
+name: The OSS Review Toolkit (ORT)
+
+on:
+    schedule:
+      - cron: "0 0 * * *"
+    pull_request:
+      paths:
+        - .github/workflows/ort.yml
+        - .github/workflows/run-ort-tools/action.yml
+    workflow_dispatch:
+      inputs:
+        branch:
+          description: 'The branch to run against the ORT tool'     
+          required: true
+        version:
+          description: 'The release version of GLIDE'
+          required: true
+jobs:
+    run-ort:
+        name: Create attribution files
+        runs-on: ubuntu-latest
+        strategy:
+          fail-fast: false
+        env: 
+          PYTHON_ATTRIBUTIONS: "python/THIRD_PARTY_LICENSES_PYTHON"
+          NODE_ATTRIBUTIONS: "node/THIRD_PARTY_LICENSES_NODE"
+          RUST_ATTRIBUTIONS: "glide-core/THIRD_PARTY_LICENSES_RUST"
+        steps:
+            - name: Set the release version
+              shell: bash
+              run: |
+                  export version=`if ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' }}; then echo '255.255.255'; else echo ${{ github.event.inputs.version }}; fi`
+                  echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
+              
+            - name: Set the base branch
+              run: |
+                export BASE_BRANCH=`if ${{ github.event_name == 'schedule'}}; then echo 'main'; elif ${{ github.event_name == 'workflow_dispatch'}}; then echo ${{ github.event.inputs.branch }}; else echo "";fi`
+                echo "Base branch is: ${BASE_BRANCH}"
+                echo "BASE_BRANCH=${BASE_BRANCH}" >> $GITHUB_ENV
+
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  submodules: "true"
+                  ref: ${{ env.BASE_BRANCH }}
+
+            - name: Set up JDK 11 for the ORT package
+              uses: actions/setup-java@v3
+              with:
+                  distribution: "temurin"
+                  java-version: 11
+
+            - name: Cache ORT and Gradle packages
+              uses: actions/cache@v4
+              id: cache-ort
+              with:
+                path: |
+                  ./ort
+                  ~/.gradle/caches
+                  ~/.gradle/wrapper
+                key: ${{ runner.os }}-ort
+
+            - name: Checkout ORT Repository
+              if: steps.cache-ort.outputs.cache-hit != 'true'
+              uses: actions/checkout@v4
+              with: 
+                  repository: "oss-review-toolkit/ort"
+                  path: "./ort"
+                  ref: main
+                  submodules: recursive
+
+            - name: Checkout ORT latest release tag
+              if: steps.cache-ort.outputs.cache-hit != 'true'
+              working-directory: ./ort/
+              run: |
+                # Get new tags from remote
+                git fetch --tags
+                # Get latest tag name
+                LATEST_TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+                # Checkout latest tag
+                git checkout $LATEST_TAG
+
+            - name: Install ORT
+              if: steps.cache-ort.outputs.cache-hit != 'true'
+              working-directory: ./ort/
+              run: |
+                export JAVA_OPTS="$JAVA_OPTS -Xmx8g"
+                ./gradlew installDist
+
+            - name: Create ORT config file
+              run: |
+                mkdir -p ~/.ort/config
+                cat << EOF > ~/.ort/config/config.yml
+                ort:
+                  analyzer:
+                    allowDynamicVersions: true
+                    enabledPackageManagers: [Cargo, NPM, PIP]
+                EOF
+                cat ~/.ort/config/config.yml
+
+          ### NodeJS ###
+
+            - name: Set up Node.js 16.x
+              uses: actions/setup-node@v3
+              with:
+                  node-version: 16.x
+
+            - name: Create package.json file for the Node wrapper 
+              uses: ./.github/workflows/node-create-package-file
+              with:
+                release_version: ${{ env.RELEASE_VERSION }}
+                os: "ubuntu-latest"
+
+            - name: Fix Node base NPM package.json file for ORT
+              working-directory: ./node/npm/glide
+              run: |
+                # Remove the glide-rs dependency to avoid duplication 
+                sed -i '/ "glide-rs":/d' ../../package.json
+                export pkg_name=glide-for-redis-base
+                export package_version="${{ env.RELEASE_VERSION }}"
+                export scope=`if [ "$NPM_SCOPE" != ''  ]; then echo "$NPM_SCOPE/"; fi`
+                mv package.json package.json.tmpl
+                envsubst < package.json.tmpl > "package.json"
+                cat package.json
+            
+            - name: Run ORT tools for Node
+              uses: ./.github/workflows/run-ort-tools
+              with:
+                folder_path: "${{ github.workspace }}/node"
+            
+          ### Python ###
+
+            - name: Set up Python 3.10
+              uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+
+            - name: Install python-inspector
+              working-directory: ./python
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install git+https://github.com/nexB/python-inspector
+
+            - name: Run ORT tools for Python
+              uses: ./.github/workflows/run-ort-tools
+              with:
+                folder_path: "${{ github.workspace }}/python"
+
+            ### Rust ###
+
+            - name: Run ORT tools for Rust
+              uses: ./.github/workflows/run-ort-tools
+              with:
+                folder_path: "${{ github.workspace }}/glide-core"
+
+            ### Process results ###
+
+            - name: Check for diff
+              run: |
+                cp python/ort_results/NOTICE_DEFAULT $PYTHON_ATTRIBUTIONS
+                cp node/ort_results/NOTICE_DEFAULT $NODE_ATTRIBUTIONS
+                cp glide-core/ort_results/NOTICE_DEFAULT $RUST_ATTRIBUTIONS
+                GIT_DIFF=`git diff $PYTHON_ATTRIBUTIONS $NODE_ATTRIBUTIONS $RUST_ATTRIBUTIONS`
+                if [ -n "$GIT_DIFF" ]; then
+                echo "FOUND_DIFF=true" >> $GITHUB_ENV
+                else
+                echo "FOUND_DIFF=false" >> $GITHUB_ENV
+                fi
+
+            - name: Retrieve licenses list
+              if: ${{ env.FOUND_DIFF  == 'true'}}
+              working-directory: ./utils
+              run: |
+                {
+                  echo 'LICENSES_LIST<<EOF'
+                  python3 get_licenses_from_ort.py
+                  echo EOF
+                } >> "$GITHUB_ENV"
+
+            ### Create PR ###
+
+            - name: Create pull request
+              if: ${{ env.FOUND_DIFF  == 'true' && github.event_name != 'pull_request' }}
+              run: |
+                export BRANCH_NAME=`if ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' }}; then echo "scheduled-ort"; else echo "ort-v${{ github.event.inputs.version }}"; fi`
+                echo "Creating pull request from branch ${BRANCH_NAME} to branch ${{ env.BASE_BRANCH }}"
+                git config --global user.email "glide-for-redis@amazon.com"
+                git config --global user.name "ort-bot"
+                git checkout -b ${BRANCH_NAME}
+
+                git add $PYTHON_ATTRIBUTIONS $NODE_ATTRIBUTIONS $RUST_ATTRIBUTIONS
+                git commit -m "Updated attribution files"
+                git push --set-upstream origin ${BRANCH_NAME} -f
+                title="Updated attribution files for ${BRANCH_NAME}"
+                gh pr create -B ${{ env.BASE_BRANCH }} -H ${BRANCH_NAME} --title "${title}" --body 'Created by Github action.\n${{env.LICENSES_LIST}}'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-ort-tools/action.yml
+++ b/.github/workflows/run-ort-tools/action.yml
@@ -1,0 +1,23 @@
+name: Run the OSS review tool
+
+inputs:
+    folder_path:
+        description: "The root folder to run the ORT tool from"
+        required: true
+        type: string
+
+runs:
+    using: "composite"
+    steps:
+        - name: Run ORT tools
+          working-directory: ./ort/
+          shell: bash
+          run: |
+            echo "Running ORT tools for ${{ inputs.folder_path }}"
+            FOLDER=${{ inputs.folder_path }}
+            mkdir $FOLDER/ort_results
+            # Analyzer (analyzer-result.json)
+            ./gradlew cli:run --args="analyze -i $FOLDER -o $FOLDER/ort_results -f JSON"
+            
+            # NOTICE DEFAULT
+            ./gradlew cli:run --args="report -i $FOLDER/ort_results/analyzer-result.json -o $FOLDER/ort_results/ -f PlainTextTemplate"


### PR DESCRIPTION
Added an [OSS Review Tool (ORT)](https://github.com/oss-review-toolkit/ort) workflow as a github action. The ORT will analyze all package dependencies across the different languages and will create a NOTICE report to be used as the attribution files for each language.
The workflow is triggered by:
1. Scheduled event - the tool will run against the `main` branch once a day at 00:00. Any changes in the attribution files that will be found will be pushed to branch `scheduled-ort`, and a PR will be created to `main`.
2. Manual trigger: Use the [manually-running-a-workflow](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) guide to run the ORT workflow. The workflow requires two inputs: the branch to run the ort tool from, for example, if it's for v0.2.1 release pass `v0.2`, and the release version, for example `2.0.1`.
