### PR TITLE
Java: Add PING command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import lombok.AllArgsConstructor;
-import response.ResponseOuterClass;
 import response.ResponseOuterClass.Response;
 
 /** Base Client class for Redis */

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -104,7 +104,9 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
      * @param <T> return type
      * @throws RedisException on a type mismatch
      */
-    private <T> T handleRedisResponse(Class classType, boolean isNullable, Response response) {
+    @SuppressWarnings("unchecked")
+    private <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response)
+            throws RedisException {
         Object value =
                 new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
         if (isNullable && (value == null)) {
@@ -118,7 +120,7 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
                 "Unexpected return type from Redis: got "
                         + className
                         + " expected "
-                        + classType.toGenericString());
+                        + classType.getSimpleName());
     }
 
     protected Object handleObjectResponse(Response response) {

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -16,7 +16,6 @@ import glide.ffi.resolvers.RedisValueResolver;
 import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
@@ -126,43 +125,6 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
                 "Unexpected return type from Redis: got "
                         + value.getClass().getSimpleName()
                         + " expected String");
-    }
-
-    /**
-     * Extracts the response value from the Redis response and either throws an exception or returns
-     * the value as an <code>Object[]</code>.
-     *
-     * @param response Redis protobuf message
-     * @return Response as an <code>Object[]</code>
-     * @throws RedisException if there's a type mismatch
-     */
-    protected Object[] handleArrayResponse(Response response) {
-        Object value = handleObjectResponse(response);
-        if (value instanceof Object[]) {
-            return (Object[]) value;
-        }
-        String className = (value == null) ? "null" : value.getClass().getSimpleName();
-        throw new RedisException(
-                "Unexpected return type from Redis: got " + className + " expected Object[]");
-    }
-
-    /**
-     * Extracts the response value from the Redis response and either throws an exception or returns
-     * the value as a <code>Map</code>.
-     *
-     * @param response Redis protobuf message
-     * @return Response as a <code>Map</code>
-     * @throws RedisException if there's a type mismatch
-     */
-    @SuppressWarnings("unchecked")
-    protected Map<Object, Object> handleMapResponse(Response response) {
-        Object value = handleObjectResponse(response);
-        if (value instanceof Map) {
-            return (Map<Object, Object>) value;
-        }
-        String className = (value == null) ? "null" : value.getClass().getSimpleName();
-        throw new RedisException(
-                "Unexpected return type from Redis: got " + className + " expected Map");
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -123,8 +123,8 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
                         + classType.getSimpleName());
     }
 
-    protected Object handleObjectResponse(Response response) {
-        return handleRedisResponse(Object.class, false, response);
+    protected Object handleObjectOrNullResponse(Response response) {
+        return handleRedisResponse(Object.class, true, response);
     }
 
     protected String handleStringResponse(Response response) {

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -93,34 +93,40 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
     }
 
     /**
-     * Extracts the response from the Protobuf response and either throws an exception or returns the
-     * appropriate response as an <code>Object</code>.
+     * Extracts the value from a Redis response message and either throws an exception or returns the
+     * value as an object of type {@link T}. If <code>isNullable</code>, than also returns <code>null
+     * </code>.
      *
      * @param response Redis protobuf message
-     * @return Response <code>Object</code>
+     * @param classType Parameter {@link T} class type
+     * @param isNullable Accepts null values in the protobuf message
+     * @return Response as an object of type {@link T} or <code>null</code>
+     * @param <T> return type
+     * @throws RedisException on a type mismatch
      */
-    protected Object handleObjectResponse(Response response) {
-        // convert protobuf response into Object
-        return new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
-    }
-
-    /**
-     * Extracts the response value from the Redis response and either throws an exception or returns
-     * the value as a <code>String</code>.
-     *
-     * @param response Redis protobuf message
-     * @return Response as a <code>String</code>
-     * @throws RedisException if there's a type mismatch
-     */
-    protected String handleStringResponse(Response response) {
-        Object value = handleObjectResponse(response);
-        if (value instanceof String || value == null) {
-            return (String) value;
+    private <T> T handleRedisResponse(Class classType, boolean isNullable, Response response) {
+        Object value =
+                new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
+        if (isNullable && (value == null)) {
+            return null;
         }
+        if (classType.isInstance(value)) {
+            return (T) value;
+        }
+        String className = value == null ? "null" : value.getClass().getSimpleName();
         throw new RedisException(
                 "Unexpected return type from Redis: got "
-                        + value.getClass().getSimpleName()
-                        + " expected String");
+                        + className
+                        + " expected "
+                        + classType.toGenericString());
+    }
+
+    protected Object handleObjectResponse(Response response) {
+        return handleRedisResponse(Object.class, false, response);
+    }
+
+    protected String handleStringResponse(Response response) {
+        return handleRedisResponse(String.class, false, response);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import response.ResponseOuterClass.Response;
 
 /** Base Client class for Redis */
@@ -128,7 +129,7 @@ public abstract class BaseClient implements AutoCloseable, ConnectionManagementC
     }
 
     @Override
-    public CompletableFuture<String> ping(String str) {
+    public CompletableFuture<String> ping(@NonNull String str) {
         return commandManager.submitNewCommand(Ping, new String[] {str}, this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -26,10 +26,6 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient implements AutoCloseable, ConnectionManagementCommands {
-
-    /** Redis simple string response with "OK" */
-    public static final String OK = ResponseOuterClass.ConstantResponse.OK.toString();
-
     protected final ConnectionManager connectionManager;
     protected final CommandManager commandManager;
 

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -26,8 +26,7 @@ public class RedisClient extends BaseClient implements GenericCommands {
      * @param config Redis client Configuration
      * @return A Future to connect and return a RedisClient
      */
-    public static CompletableFuture<RedisClient> CreateClient(
-            @NonNull RedisClientConfiguration config) {
+    public static CompletableFuture<RedisClient> CreateClient(RedisClientConfiguration config) {
         return CreateClient(config, RedisClient::new);
     }
 

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -8,6 +8,7 @@ import glide.api.models.configuration.RedisClientConfiguration;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
 
 /**
  * Async (non-blocking) client for Redis in Standalone mode. Use {@link #CreateClient} to request a
@@ -25,12 +26,13 @@ public class RedisClient extends BaseClient implements GenericCommands {
      * @param config Redis client Configuration
      * @return A Future to connect and return a RedisClient
      */
-    public static CompletableFuture<RedisClient> CreateClient(RedisClientConfiguration config) {
+    public static CompletableFuture<RedisClient> CreateClient(
+            @NonNull RedisClientConfiguration config) {
         return CreateClient(config, RedisClient::new);
     }
 
     @Override
-    public CompletableFuture<Object> customCommand(String[] args) {
+    public CompletableFuture<Object> customCommand(@NonNull String[] args) {
         return commandManager.submitNewCommand(CustomCommand, args, this::handleObjectResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -32,6 +32,6 @@ public class RedisClient extends BaseClient implements GenericCommands {
 
     @Override
     public CompletableFuture<Object> customCommand(@NonNull String[] args) {
-        return commandManager.submitNewCommand(CustomCommand, args, this::handleObjectResponse);
+        return commandManager.submitNewCommand(CustomCommand, args, this::handleObjectOrNullResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -41,7 +41,7 @@ public class RedisClusterClient extends BaseClient
     public CompletableFuture<ClusterValue<Object>> customCommand(String[] args) {
         // TODO if a command returns a map as a single value, ClusterValue misleads user
         return commandManager.submitNewCommand(
-                CustomCommand, args, response -> ClusterValue.of(handleObjectResponse(response)));
+                CustomCommand, args, response -> ClusterValue.of(handleObjectOrNullResponse(response)));
     }
 
     @Override
@@ -53,8 +53,9 @@ public class RedisClusterClient extends BaseClient
                 route,
                 response ->
                         route.isSingleNodeRoute()
-                                ? ClusterValue.ofSingleValue(handleObjectResponse(response))
-                                : ClusterValue.ofMultiValue((Map<String, Object>) handleObjectResponse(response)));
+                                ? ClusterValue.ofSingleValue(handleObjectOrNullResponse(response))
+                                : ClusterValue.ofMultiValue(
+                                        (Map<String, Object>) handleObjectOrNullResponse(response)));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -33,12 +33,12 @@ public class RedisClusterClient extends BaseClient
      * @return A Future to connect and return a RedisClusterClient
      */
     public static CompletableFuture<RedisClusterClient> CreateClient(
-            RedisClusterClientConfiguration config) {
+            @NonNull RedisClusterClientConfiguration config) {
         return CreateClient(config, RedisClusterClient::new);
     }
 
     @Override
-    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args) {
         // TODO if a command returns a map as a single value, ClusterValue misleads user
         return commandManager.submitNewCommand(
                 CustomCommand, args, response -> ClusterValue.of(handleObjectResponse(response)));
@@ -46,7 +46,8 @@ public class RedisClusterClient extends BaseClient
 
     @Override
     @SuppressWarnings("unchecked")
-    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(
+            @NonNull String[] args, @NonNull Route route) {
         return commandManager.submitNewCommand(
                 CustomCommand,
                 args,

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -2,7 +2,9 @@
 package glide.api;
 
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 
+import glide.api.commands.ConnectionManagementClusterCommands;
 import glide.api.commands.GenericClusterCommands;
 import glide.api.models.ClusterValue;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
@@ -11,12 +13,14 @@ import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
 
 /**
  * Async (non-blocking) client for Redis in Cluster mode. Use {@link #CreateClient} to request a
  * client to Redis.
  */
-public class RedisClusterClient extends BaseClient implements GenericClusterCommands {
+public class RedisClusterClient extends BaseClient
+        implements ConnectionManagementClusterCommands, GenericClusterCommands {
 
     protected RedisClusterClient(ConnectionManager connectionManager, CommandManager commandManager) {
         super(connectionManager, commandManager);
@@ -51,5 +55,16 @@ public class RedisClusterClient extends BaseClient implements GenericClusterComm
                         route.isSingleNodeRoute()
                                 ? ClusterValue.ofSingleValue(handleObjectResponse(response))
                                 : ClusterValue.ofMultiValue((Map<String, Object>) handleObjectResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<String> ping(@NonNull Route route) {
+        return commandManager.submitNewCommand(Ping, new String[0], route, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> ping(@NonNull String str, @NonNull Route route) {
+        return commandManager.submitNewCommand(
+                Ping, new String[] {str}, route, this::handleStringResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -33,12 +33,12 @@ public class RedisClusterClient extends BaseClient
      * @return A Future to connect and return a RedisClusterClient
      */
     public static CompletableFuture<RedisClusterClient> CreateClient(
-            @NonNull RedisClusterClientConfiguration config) {
+            RedisClusterClientConfiguration config) {
         return CreateClient(config, RedisClusterClient::new);
     }
 
     @Override
-    public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args) {
         // TODO if a command returns a map as a single value, ClusterValue misleads user
         return commandManager.submitNewCommand(
                 CustomCommand, args, response -> ClusterValue.of(handleObjectResponse(response)));
@@ -46,8 +46,7 @@ public class RedisClusterClient extends BaseClient
 
     @Override
     @SuppressWarnings("unchecked")
-    public CompletableFuture<ClusterValue<Object>> customCommand(
-            @NonNull String[] args, @NonNull Route route) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route) {
         return commandManager.submitNewCommand(
                 CustomCommand,
                 args,

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -28,7 +28,8 @@ public interface ConnectionManagementClusterCommands {
      * @param str The ping argument that will be returned.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
-     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>str</code>.
+     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>
+     *     str</code>.
      */
     CompletableFuture<String> ping(String str, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -1,0 +1,34 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import glide.api.models.configuration.RequestRoutingConfiguration.Route;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Connection Management Commands interface.
+ *
+ * @see: <a href="https://redis.io/commands/?group=connection">Connection Management Commands</a>
+ */
+public interface ConnectionManagementClusterCommands {
+
+    /**
+     * Ping the Redis server.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @param route Routing configuration for the command. Client will route the command to the nodes
+     *     defined.
+     * @return Response from Redis containing a <code>String</code>.
+     */
+    CompletableFuture<String> ping(Route route);
+
+    /**
+     * Ping the Redis server.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @param str The ping argument that will be returned.
+     * @param route Routing configuration for the command. Client will route the command to the nodes
+     *     defined.
+     * @return Response from Redis containing a <code>String</code>.
+     */
+    CompletableFuture<String> ping(String str, Route route);
+}

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -17,7 +17,7 @@ public interface ConnectionManagementClusterCommands {
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
-     * @return Response from Redis containing a <code>String</code>.
+     * @return Response from Redis containing a <code>String</code> with "PONG".
      */
     CompletableFuture<String> ping(Route route);
 
@@ -28,7 +28,7 @@ public interface ConnectionManagementClusterCommands {
      * @param str The ping argument that will be returned.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
-     * @return Response from Redis containing a <code>String</code>.
+     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>str</code>.
      */
     CompletableFuture<String> ping(String str, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -23,7 +23,8 @@ public interface ConnectionManagementCommands {
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param str The ping argument that will be returned.
-     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>str</code>.
+     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>
+     *     str</code>.
      */
     CompletableFuture<String> ping(String str);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -23,7 +23,7 @@ public interface ConnectionManagementCommands {
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param str The ping argument that will be returned.
-     * @return Response from Redis containing a <code>String</code> with a copy of the argument.
+     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>str</code>.
      */
     CompletableFuture<String> ping(String str);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -1,0 +1,29 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Connection Management Commands interface.
+ *
+ * @see: <a href="https://redis.io/commands/?group=connection">Connection Management Commands</a>
+ */
+public interface ConnectionManagementCommands {
+
+    /**
+     * Ping the Redis server.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @return Response from Redis containing a <code>String</code> with "PONG".
+     */
+    CompletableFuture<String> ping();
+
+    /**
+     * Ping the Redis server.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @param str The ping argument that will be returned.
+     * @return Response from Redis containing a <code>String</code> with a copy of the argument.
+     */
+    CompletableFuture<String> ping(String str);
+}

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -39,7 +39,7 @@ public class CommandManager {
      * @return A result promise of type T
      */
     public <T> CompletableFuture<T> submitNewCommand(
-            RedisRequestOuterClass.RequestType requestType,
+            RequestType requestType,
             String[] arguments,
             RedisExceptionCheckedFunction<Response, T> responseHandler) {
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
+import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
@@ -52,5 +53,47 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void ping_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn("PONG");
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(Ping), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.ping();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals("PONG", payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void ping_with_message_returns_success() {
+        // setup
+        String message = "RETURN OF THE PONG";
+        String[] arguments = new String[] {message};
+        CompletableFuture<String> testResponse = new CompletableFuture();
+        testResponse.complete(message);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(Ping), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.ping(message);
+        String pong = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(message, pong);
     }
 }

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -105,7 +105,7 @@ public class RedisClusterClientTest {
         }
 
         @Override
-        protected Object handleObjectResponse(Response response) {
+        protected Object handleObjectOrNullResponse(Response response) {
             return object;
         }
     }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3,7 +3,6 @@ package glide;
 
 import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.TestConfiguration.STANDALONE_PORTS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import glide.api.BaseClient;
@@ -17,10 +16,12 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@Timeout(10)
 public class SharedCommandTests {
 
     private static RedisClient standaloneClient = null;
@@ -36,7 +37,7 @@ public class SharedCommandTests {
                                 RedisClientConfiguration.builder()
                                         .address(NodeAddress.builder().port(STANDALONE_PORTS[0]).build())
                                         .build())
-                        .get(10, SECONDS);
+                        .get();
 
         clusterClient =
                 RedisClusterClient.CreateClient(
@@ -44,7 +45,7 @@ public class SharedCommandTests {
                                         .address(NodeAddress.builder().port(CLUSTER_PORTS[0]).build())
                                         .requestTimeout(5000)
                                         .build())
-                        .get(10, SECONDS);
+                        .get();
 
         clients = List.of(Arguments.of(standaloneClient), Arguments.of(clusterClient));
     }
@@ -60,15 +61,15 @@ public class SharedCommandTests {
     @ParameterizedTest
     @MethodSource("getClients")
     public void ping(BaseClient client) {
-        var data = client.ping("H3LL0").get(10, SECONDS);
-        assertEquals("H3LL0", data);
+        String data = client.ping().get();
+        assertEquals("PING", data);
     }
 
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
     public void ping_with_message(BaseClient client) {
-        var data = client.ping("H3LL0").get(10, SECONDS);
+        String data = client.ping("H3LL0").get();
         assertEquals("H3LL0", data);
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1,0 +1,73 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide;
+
+import static glide.TestConfiguration.CLUSTER_PORTS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import glide.api.BaseClient;
+import glide.api.RedisClient;
+import glide.api.RedisClusterClient;
+import glide.api.models.configuration.NodeAddress;
+import glide.api.models.configuration.RedisClientConfiguration;
+import glide.api.models.configuration.RedisClusterClientConfiguration;
+import java.util.List;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SharedCommandTests {
+
+    private static RedisClient standaloneClient = null;
+    private static RedisClusterClient clusterClient = null;
+
+    @Getter private static List<Arguments> clients;
+
+    @BeforeAll
+    @SneakyThrows
+    public static void init() {
+        standaloneClient =
+                RedisClient.CreateClient(
+                                RedisClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(STANDALONE_PORTS[0]).build())
+                                        .build())
+                        .get(10, SECONDS);
+
+        clusterClient =
+                RedisClusterClient.CreateClient(
+                                RedisClusterClientConfiguration.builder()
+                                        .address(NodeAddress.builder().port(CLUSTER_PORTS[0]).build())
+                                        .requestTimeout(5000)
+                                        .build())
+                        .get(10, SECONDS);
+
+        clients = List.of(Arguments.of(standaloneClient), Arguments.of(clusterClient));
+    }
+
+    @AfterAll
+    @SneakyThrows
+    public static void teardown() {
+        standaloneClient.close();
+        clusterClient.close();
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void ping(BaseClient client) {
+        var data = client.ping("H3LL0").get(10, SECONDS);
+        assertEquals("H3LL0", data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void ping_with_message(BaseClient client) {
+        var data = client.ping("H3LL0").get(10, SECONDS);
+        assertEquals("H3LL0", data);
+    }
+}

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -62,7 +62,7 @@ public class SharedCommandTests {
     @MethodSource("getClients")
     public void ping(BaseClient client) {
         String data = client.ping().get();
-        assertEquals("PING", data);
+        assertEquals("PONG", data);
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -2,6 +2,7 @@
 package glide;
 
 import static glide.TestConfiguration.CLUSTER_PORTS;
+import static glide.TestConfiguration.STANDALONE_PORTS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -4,7 +4,6 @@ package glide.cluster;
 import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_NODES;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,7 +16,9 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(10)
 public class CommandTests {
 
     private static RedisClusterClient clusterClient = null;
@@ -31,7 +32,7 @@ public class CommandTests {
                                         .address(NodeAddress.builder().port(CLUSTER_PORTS[0]).build())
                                         .requestTimeout(5000)
                                         .build())
-                        .get(10, SECONDS);
+                        .get();
     }
 
     @AfterAll
@@ -43,7 +44,7 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void custom_command_info() {
-        ClusterValue<Object> data = clusterClient.customCommand(new String[] {"info"}).get(10, SECONDS);
+        ClusterValue<Object> data = clusterClient.customCommand(new String[] {"info"}).get();
         assertTrue(data.hasMultiData());
         for (var info : data.getMultiValue().values()) {
             assertTrue(((String) info).contains("# Stats"));
@@ -60,14 +61,14 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void ping_with_route() {
-        String data = clusterClient.ping(ALL_NODES).get(10, SECONDS);
+        String data = clusterClient.ping(ALL_NODES).get();
         assertEquals("PONG", data);
     }
 
     @Test
     @SneakyThrows
     public void ping_with_message_with_route() {
-        String data = clusterClient.ping("H3LL0", ALL_PRIMARIES).get(10, SECONDS);
+        String data = clusterClient.ping("H3LL0", ALL_PRIMARIES).get();
         assertEquals("H3LL0", data);
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1,6 +1,8 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.cluster;
 
+import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_NODES;
+import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,7 +31,7 @@ public class CommandTests {
                                         .address(NodeAddress.builder().port(TestConfiguration.CLUSTER_PORTS[0]).build())
                                         .requestTimeout(5000)
                                         .build())
-                        .get(10, TimeUnit.SECONDS);
+                        .get(10, SECONDS);
     }
 
     @AfterAll
@@ -53,5 +55,33 @@ public class CommandTests {
     public void custom_command_ping() {
         var data = clusterClient.customCommand(new String[] {"ping"}).get(10, TimeUnit.SECONDS);
         assertEquals("PONG", data.getSingleValue());
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping() {
+        String data = clusterClient.ping().get(10, SECONDS);
+        assertEquals("PONG", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_message() {
+        String data = clusterClient.ping("H3LL0").get(10, SECONDS);
+        assertEquals("H3LL0", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_route() {
+        String data = clusterClient.ping(ALL_NODES).get(10, SECONDS);
+        assertEquals("PONG", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_message_with_route() {
+        String data = clusterClient.ping("H3LL0", ALL_PRIMARIES).get(10, SECONDS);
+        assertEquals("H3LL0", data);
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -1,13 +1,13 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.cluster;
 
+import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_NODES;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import glide.TestConfiguration;
 import glide.api.RedisClusterClient;
 import glide.api.models.ClusterValue;
 import glide.api.models.configuration.NodeAddress;
@@ -28,7 +28,7 @@ public class CommandTests {
         clusterClient =
                 RedisClusterClient.CreateClient(
                                 RedisClusterClientConfiguration.builder()
-                                        .address(NodeAddress.builder().port(TestConfiguration.CLUSTER_PORTS[0]).build())
+                                        .address(NodeAddress.builder().port(CLUSTER_PORTS[0]).build())
                                         .requestTimeout(5000)
                                         .build())
                         .get(10, SECONDS);
@@ -55,20 +55,6 @@ public class CommandTests {
     public void custom_command_ping() {
         var data = clusterClient.customCommand(new String[] {"ping"}).get(10, TimeUnit.SECONDS);
         assertEquals("PONG", data.getSingleValue());
-    }
-
-    @Test
-    @SneakyThrows
-    public void ping() {
-        String data = clusterClient.ping().get(10, SECONDS);
-        assertEquals("PONG", data);
-    }
-
-    @Test
-    @SneakyThrows
-    public void ping_with_message() {
-        String data = clusterClient.ping("H3LL0").get(10, SECONDS);
-        assertEquals("H3LL0", data);
     }
 
     @Test

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -2,7 +2,6 @@
 package glide.standalone;
 
 import static glide.TestConfiguration.STANDALONE_PORTS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.RedisClient;
@@ -12,7 +11,9 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+@Timeout(10)
 public class CommandTests {
     private static RedisClient regularClient = null;
 
@@ -24,7 +25,7 @@ public class CommandTests {
                                 RedisClientConfiguration.builder()
                                         .address(NodeAddress.builder().port(STANDALONE_PORTS[0]).build())
                                         .build())
-                        .get(10, SECONDS);
+                        .get();
     }
 
     @AfterAll
@@ -36,7 +37,7 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void custom_command_info() {
-        var data = regularClient.customCommand(new String[] {"info"}).get(10, SECONDS);
+        Object data = regularClient.customCommand(new String[] {"info"}).get();
         assertTrue(((String) data).contains("# Stats"));
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1,20 +1,20 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.standalone;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.TestConfiguration;
 import glide.api.RedisClient;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
-import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CommandTests {
-
     private static RedisClient regularClient = null;
 
     @BeforeAll
@@ -26,19 +26,33 @@ public class CommandTests {
                                         .address(
                                                 NodeAddress.builder().port(TestConfiguration.STANDALONE_PORTS[0]).build())
                                         .build())
-                        .get(10, TimeUnit.SECONDS);
+                        .get(10, SECONDS);
     }
 
     @AfterAll
     @SneakyThrows
-    public static void deinit() {
+    public static void teardown() {
         regularClient.close();
     }
 
     @Test
     @SneakyThrows
     public void custom_command_info() {
-        var data = regularClient.customCommand(new String[] {"info"}).get(10, TimeUnit.SECONDS);
+        var data = regularClient.customCommand(new String[] {"info"}).get(10, SECONDS);
         assertTrue(((String) data).contains("# Stats"));
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping() {
+        var data = regularClient.ping().get(10, SECONDS);
+        assertEquals("PONG", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_message() {
+        var data = regularClient.ping("H3LL0").get(10, SECONDS);
+        assertEquals("H3LL0", data);
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1,11 +1,10 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.standalone;
 
+import static glide.TestConfiguration.STANDALONE_PORTS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import glide.TestConfiguration;
 import glide.api.RedisClient;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
@@ -23,8 +22,7 @@ public class CommandTests {
         regularClient =
                 RedisClient.CreateClient(
                                 RedisClientConfiguration.builder()
-                                        .address(
-                                                NodeAddress.builder().port(TestConfiguration.STANDALONE_PORTS[0]).build())
+                                        .address(NodeAddress.builder().port(STANDALONE_PORTS[0]).build())
                                         .build())
                         .get(10, SECONDS);
     }
@@ -40,19 +38,5 @@ public class CommandTests {
     public void custom_command_info() {
         var data = regularClient.customCommand(new String[] {"info"}).get(10, SECONDS);
         assertTrue(((String) data).contains("# Stats"));
-    }
-
-    @Test
-    @SneakyThrows
-    public void ping() {
-        var data = regularClient.ping().get(10, SECONDS);
-        assertEquals("PONG", data);
-    }
-
-    @Test
-    @SneakyThrows
-    public void ping_with_message() {
-        var data = regularClient.ping("H3LL0").get(10, SECONDS);
-        assertEquals("H3LL0", data);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

This PR is dependent to: https://github.com/aws/glide-for-redis/pull/917

*Description of changes:*
This PR adds get/set/ping/info calls to the standalone, and cluster-mode:
* standalone
  * ping
  * ping with message
* cluster
  * ping
  * ping with message
  * ping with route
  * ping with message and route

### Examples: 

```java
// Single commands
RedisClient client = RedisClient.createClient(config).get();
String pingResult = client.ping().get();
String pingResult2 = client.ping("message").get();

// Cluster-mode single commands
RedisClusterClient clusterClient = RedisClusterClient.createClient(config).get();
String pingResult3 = clusterClient.ping(ALL_NODES).get();
String pingResult4 = clusterClient.ping("message", ALL_NODES).get();
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
