### PR TITLE
Java: Add @NonNull annotation to constructors and generic functions

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -26,7 +26,8 @@ public class RedisClient extends BaseClient implements GenericCommands {
      * @param config Redis client Configuration
      * @return A Future to connect and return a RedisClient
      */
-    public static CompletableFuture<RedisClient> CreateClient(@NonNull RedisClientConfiguration config) {
+    public static CompletableFuture<RedisClient> CreateClient(
+            @NonNull RedisClientConfiguration config) {
         return CreateClient(config, RedisClient::new);
     }
 

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -26,7 +26,7 @@ public class RedisClient extends BaseClient implements GenericCommands {
      * @param config Redis client Configuration
      * @return A Future to connect and return a RedisClient
      */
-    public static CompletableFuture<RedisClient> CreateClient(RedisClientConfiguration config) {
+    public static CompletableFuture<RedisClient> CreateClient(@NonNull RedisClientConfiguration config) {
         return CreateClient(config, RedisClient::new);
     }
 

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -33,7 +33,7 @@ public class RedisClusterClient extends BaseClient
      * @return A Future to connect and return a RedisClusterClient
      */
     public static CompletableFuture<RedisClusterClient> CreateClient(
-        @NonNull RedisClusterClientConfiguration config) {
+            @NonNull RedisClusterClientConfiguration config) {
         return CreateClient(config, RedisClusterClient::new);
     }
 
@@ -46,7 +46,8 @@ public class RedisClusterClient extends BaseClient
 
     @Override
     @SuppressWarnings("unchecked")
-    public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args, @NonNull Route route) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(
+            @NonNull String[] args, @NonNull Route route) {
         return commandManager.submitNewCommand(
                 CustomCommand,
                 args,

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -33,12 +33,12 @@ public class RedisClusterClient extends BaseClient
      * @return A Future to connect and return a RedisClusterClient
      */
     public static CompletableFuture<RedisClusterClient> CreateClient(
-            RedisClusterClientConfiguration config) {
+        @NonNull RedisClusterClientConfiguration config) {
         return CreateClient(config, RedisClusterClient::new);
     }
 
     @Override
-    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args) {
         // TODO if a command returns a map as a single value, ClusterValue misleads user
         return commandManager.submitNewCommand(
                 CustomCommand, args, response -> ClusterValue.of(handleObjectOrNullResponse(response)));
@@ -46,7 +46,7 @@ public class RedisClusterClient extends BaseClient
 
     @Override
     @SuppressWarnings("unchecked")
-    public CompletableFuture<ClusterValue<Object>> customCommand(String[] args, Route route) {
+    public CompletableFuture<ClusterValue<Object>> customCommand(@NonNull String[] args, @NonNull Route route) {
         return commandManager.submitNewCommand(
                 CustomCommand,
                 args,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds the `@NonNull` annotation to Java client constructors. 
Adds the `@NonNull` annotation to customCommand methods. 

The `@NonNull` annotation provide a runtime checker for null arguments, and throws a NullPointerException. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
