### PR TITLE
CI: improving ORT script to log unkown / not pre-approved licenses

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -8,6 +8,7 @@ on:
       paths:
         - .github/workflows/ort.yml
         - .github/workflows/run-ort-tools/action.yml
+        - utils/get_licenses_from_ort.py
     workflow_dispatch:
       inputs:
         branch:
@@ -172,9 +173,11 @@ jobs:
               if: ${{ env.FOUND_DIFF  == 'true'}}
               working-directory: ./utils
               run: |
+                list_result=`python3 get_licenses_from_ort.py`
+                echo $list_result
                 {
                   echo 'LICENSES_LIST<<EOF'
-                  python3 get_licenses_from_ort.py
+                  echo ${list_result}
                   echo EOF
                 } >> "$GITHUB_ENV"
 

--- a/utils/get_licenses_from_ort.py
+++ b/utils/get_licenses_from_ort.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from typing import List, Set
 
 """
 This script should be used after all specific langauge folders were scanned by the analyzer of the OSS review tool (ORT).
@@ -49,13 +50,24 @@ class OrtResults:
         self.name = name
 
 
+class PackageLicense:
+    def __init__(self, package_name: str, language: str, license: str) -> None:
+        self.package_name = package_name
+        self.language = language
+        self.license = license
+
+    def __str__(self):
+        return f"Package_name: {self.package_name}, Language: {self.language}, License: {self.license}"
+
+
 ort_results_per_lang = [
     OrtResults("Python", "python/ort_results"),
     OrtResults("Node", "node/ort_results"),
     OrtResults("Rust", "glide-core/ort_results"),
 ]
 
-licenses_set = set()
+all_licenses_set: Set = set()
+unkown_licenses: List[PackageLicense] = []
 
 for ort_result in ort_results_per_lang:
     with open(ort_result.analyzer_result_file, "r") as ort_results, open(
@@ -72,13 +84,19 @@ for ort_result in ort_results_per_lang:
             try:
                 for license in package["declared_licenses_processed"].values():
                     if isinstance(license, list) or isinstance(license, dict):
-                        license = (
-                            license.values() if isinstance(license, dict) else license
+                        final_licenses = (
+                            list(license.values())
+                            if isinstance(license, dict)
+                            else license
                         )
-                        for inner_license in license:
-                            licenses_set.add(inner_license)
                     else:
-                        licenses_set.add(license)
+                        final_licenses = [license]
+                    for license in final_licenses:
+                        if license not in APPROVED_LICENSES:
+                            unkown_licenses.append(
+                                PackageLicense(package["id"], ort_result.name, license)
+                            )
+                        all_licenses_set.add(license)
             except Exception:
                 print(
                     f"Received error for package {package} used by {ort_result.name}\n Found license={license}"
@@ -86,11 +104,10 @@ for ort_result in ort_results_per_lang:
                 raise
 
 print("\n\n#### Found Licenses #####\n")
-licenses_set = set(sorted(licenses_set))
-for license in licenses_set:
+all_licenses_set = set(sorted(all_licenses_set))
+for license in all_licenses_set:
     print(f"{license}")
 
-print("\n\n#### New / Not Approved Licenses #####\n")
-for license in licenses_set:
-    if license not in APPROVED_LICENSES:
-        print(f"{license}")
+print("\n\n#### Unkown / Not Pre-Approved Licenses #####\n")
+for package in unkown_licenses:
+    print(str(package))


### PR DESCRIPTION
The PR that will be created by the workflow will contain more informative list of the packages with unkown / not pre-approved licenses. For example:

#### Unkown / Not Pre-Approved Licenses ##### 
Package_name: Crate::ring:0.17.7, Language: Python, License: NOASSERTION 
Package_name: PyPI::certifi:2024.2.2, Language: Python, License: MPL-2.0 
Package_name: PyPI::pathspec:0.12.1, Language: Python, License: MPL-2.0 
Package_name: Crate::ring:0.17.7, Language: Node, License: NOASSERTION 
Package_name: Crate::ring:0.17.7, Language: Rust, License: NOASSERTION