### PR TITLE
Fix java IT for linter

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -68,6 +68,10 @@ jobs:
               working-directory: java
               run: ./gradlew --continue build
 
+            - name: Ensure no skipped files by linter
+              working-directory: java
+              run: ./gradlew spotlessDiagnose | grep 'All formatters are well behaved for all files'
+
             - name: Upload test reports
               if: always()
               continue-on-error: true

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -3,9 +3,6 @@ package glide.cluster;
 
 import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.TestConfiguration.REDIS_VERSION;
-import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_NODES;
-import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
-import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.api.models.commands.InfoOptions.Section.CLIENTS;
 import static glide.api.models.commands.InfoOptions.Section.CLUSTER;
 import static glide.api.models.commands.InfoOptions.Section.COMMANDSTATS;
@@ -13,9 +10,10 @@ import static glide.api.models.commands.InfoOptions.Section.CPU;
 import static glide.api.models.commands.InfoOptions.Section.EVERYTHING;
 import static glide.api.models.commands.InfoOptions.Section.MEMORY;
 import static glide.api.models.commands.InfoOptions.Section.REPLICATION;
+import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_NODES;
+import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.ALL_PRIMARIES;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SimpleRoute.RANDOM;
 import static glide.api.models.configuration.RequestRoutingConfiguration.SlotType.PRIMARY;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,12 +39,49 @@ public class CommandTests {
 
     private static final String INITIAL_VALUE = "VALUE";
 
-    public static final List<String>
-        DEFAULT_INFO_SECTIONS = List.of("Server", "Clients", "Memory", "Persistence", "Stats", "Replication", "CPU", "Modules", "Errorstats", "Cluster", "Keyspace");
-    public static final List<String> EVERYTHING_INFO_SECTIONS = REDIS_VERSION.feature() >= 7
-        // Latencystats was added in redis 7
-        ? List.of("Server", "Clients", "Memory", "Persistence", "Stats", "Replication", "CPU", "Modules", "Commandstats", "Errorstats", "Latencystats", "Cluster", "Keyspace")
-        : List.of("Server", "Clients", "Memory", "Persistence", "Stats", "Replication", "CPU", "Modules", "Commandstats", "Errorstats", "Cluster", "Keyspace");
+    public static final List<String> DEFAULT_INFO_SECTIONS =
+            List.of(
+                    "Server",
+                    "Clients",
+                    "Memory",
+                    "Persistence",
+                    "Stats",
+                    "Replication",
+                    "CPU",
+                    "Modules",
+                    "Errorstats",
+                    "Cluster",
+                    "Keyspace");
+    public static final List<String> EVERYTHING_INFO_SECTIONS =
+            REDIS_VERSION.feature() >= 7
+                    // Latencystats was added in redis 7
+                    ? List.of(
+                            "Server",
+                            "Clients",
+                            "Memory",
+                            "Persistence",
+                            "Stats",
+                            "Replication",
+                            "CPU",
+                            "Modules",
+                            "Commandstats",
+                            "Errorstats",
+                            "Latencystats",
+                            "Cluster",
+                            "Keyspace")
+                    : List.of(
+                            "Server",
+                            "Clients",
+                            "Memory",
+                            "Persistence",
+                            "Stats",
+                            "Replication",
+                            "CPU",
+                            "Modules",
+                            "Commandstats",
+                            "Errorstats",
+                            "Cluster",
+                            "Keyspace");
 
     @BeforeAll
     @SneakyThrows
@@ -79,7 +114,8 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void custom_command_ping() {
-        ClusterValue<Object> data = clusterClient.customCommand(new String[] {"ping"}).get(10, TimeUnit.SECONDS);
+        ClusterValue<Object> data =
+                clusterClient.customCommand(new String[] {"ping"}).get(10, TimeUnit.SECONDS);
         assertEquals("PONG", data.getSingleValue());
     }
 
@@ -141,8 +177,10 @@ public class CommandTests {
         InfoOptions options = builder.build();
         ClusterValue<String> data = clusterClient.info(options).get();
         for (String info : data.getMultiValue().values()) {
-            for (String section :  options.toArgs()) {
-                assertTrue(info.toLowerCase().contains("# " + section.toLowerCase()), "Section " + section + " is missing");
+            for (String section : options.toArgs()) {
+                assertTrue(
+                        info.toLowerCase().contains("# " + section.toLowerCase()),
+                        "Section " + section + " is missing");
             }
         }
     }
@@ -163,18 +201,19 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void info_with_routing_and_options() {
-        ClusterValue<Object> slotData = clusterClient.customCommand(new String[] {"cluster", "slots"}).get();
-        /*
-        Nested Object arrays like
-        1) 1) (integer) 0
-           2) (integer) 5460
-           3) 1) "127.0.0.1"
-              2) (integer) 7000
-              3) "92d73b6eb847604b63c7f7cbbf39b148acdd1318"
-              4) (empty array)
-        */
+        ClusterValue<Object> slotData =
+                clusterClient.customCommand(new String[] {"cluster", "slots"}).get();
+
+        // Nested Object arrays like
+        // 1) 1) (integer) 0
+        //    2) (integer) 5460
+        //    3) 1) "127.0.0.1"
+        //       2) (integer) 7000
+        //       3) "92d73b6eb847604b63c7f7cbbf39b148acdd1318"
+        //       4) (empty array)
         // Extracting first slot key
-        var slotKey = (String)((Object[])((Object[])((Object[])slotData.getSingleValue())[0])[2])[2];
+        var slotKey =
+                (String) ((Object[]) ((Object[]) ((Object[]) slotData.getSingleValue())[0])[2])[2];
 
         InfoOptions.InfoOptionsBuilder builder = InfoOptions.builder().section(CLIENTS);
         if (REDIS_VERSION.feature() >= 7) {
@@ -185,7 +224,9 @@ public class CommandTests {
         ClusterValue<String> data = clusterClient.info(options, routing).get();
 
         for (String section : options.toArgs()) {
-            assertTrue(data.getSingleValue().toLowerCase().contains("# " + section.toLowerCase()), "Section " + section + " is missing");
+            assertTrue(
+                    data.getSingleValue().toLowerCase().contains("# " + section.toLowerCase()),
+                    "Section " + section + " is missing");
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
A comment in `info_with_routing_and_options` was confusing spotless and it was ignoring this file entirely.

Some technical details:
```
Skipping '/mnt/c/GitHub/babushka/java/integTest/src/test/java/glide/cluster/CommandTests.java' because it does not converge.  Run {@code spotlessDiagnose} to understand why
```
```
> Task :spotlessJavaDiagnose
    integTest/src/test/java/glide/cluster/CommandTests.java diverges after 10 steps
```
https://github.com/diffplug/spotless/blob/main/PADDEDCELL.md

There is a spotless rule conflict, it goes to patch the file infinitely, but luckily it has a protection and breaks on 10th iteration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
