### PR TITLE
Java: Add SADD, SREM, SMEMBERS, and SCARD commands (Set Commands)

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -4,9 +4,14 @@ package glide.api;
 import static glide.ffi.resolvers.SocketListenerResolver.getSocket;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.commands.ConnectionManagementCommands;
+import glide.api.commands.SetCommands;
 import glide.api.commands.StringCommands;
 import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.BaseClientConfiguration;
@@ -20,6 +25,7 @@ import glide.ffi.resolvers.RedisValueResolver;
 import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
@@ -32,7 +38,7 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient
-        implements AutoCloseable, ConnectionManagementCommands, StringCommands {
+        implements AutoCloseable, ConnectionManagementCommands, StringCommands, SetCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
@@ -149,8 +155,16 @@ public abstract class BaseClient
         return handleRedisResponse(String.class, true, response);
     }
 
+    protected Long handleLongResponse(Response response) throws RedisException {
+        return handleRedisResponse(Long.class, false, response);
+    }
+
     protected Object[] handleArrayResponse(Response response) {
         return handleRedisResponse(Object[].class, true, response);
+    }
+
+    protected Set<String> handleSetResponse(Response response) {
+        return handleRedisResponse(Set.class, false, response);
     }
 
     @Override
@@ -180,5 +194,27 @@ public abstract class BaseClient
             @NonNull String key, @NonNull String value, @NonNull SetOptions options) {
         String[] arguments = ArrayUtils.addAll(new String[] {key, value}, options.toArgs());
         return commandManager.submitNewCommand(SetString, arguments, this::handleStringOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> sadd(String key, String[] members) {
+        String[] arguments = ArrayUtils.addFirst(members, key);
+        return commandManager.submitNewCommand(SAdd, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> srem(String key, String[] members) {
+        String[] arguments = ArrayUtils.addFirst(members, key);
+        return commandManager.submitNewCommand(SRem, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> smembers(String key) {
+        return commandManager.submitNewCommand(SMembers, new String[] {key}, this::handleSetResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> scard(String key) {
+        return commandManager.submitNewCommand(SCard, new String[] {key}, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -18,8 +18,8 @@ public interface SetCommands {
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
      * @return The number of members that were added to the set, excluding members already present.
-     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
-     *
+     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members
+     *     </code>.
      * @example
      *     <p><code>
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
@@ -36,8 +36,8 @@ public interface SetCommands {
      * @param key The <code>key</code> from which members will be removed.
      * @param members A list of members to remove from the set stored at <code>key</code>.
      * @return The number of members that were removed from the set, excluding non-existing members.
-     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
-     *
+     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command
+     *     returns 0.
      * @example
      *     <p><code>
      *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
@@ -53,7 +53,6 @@ public interface SetCommands {
      * @param key The key from which to retrieve the set members.
      * @return A <code>Set</code> of all members of the set.
      * @remarks If <code>key</code> does not exist an empty set will be returned.
-     *
      * @example
      *     <p><code>
      *  {@literal Set<String>} result = client.smembers("my_set").get();
@@ -68,7 +67,6 @@ public interface SetCommands {
      * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
      * @param key The key from which to retrieve the number of set members.
      * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
-     *
      * @example
      *     <p><code>
      *  int result = client.scard("my_set").get();

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -18,16 +18,12 @@ public interface SetCommands {
      * @param key The <code>key</code> where members will be added to its set.
      * @param members A list of members to add to the set stored at <code>key</code>.
      * @return The number of members that were added to the set, excluding members already present.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
-     *           </code>.
-     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
      *
      * @example
      *     <p><code>
      *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
+     *  // result: 2
      *  </code>
      */
     CompletableFuture<Long> sadd(String key, String[] members);
@@ -40,16 +36,12 @@ public interface SetCommands {
      * @param key The <code>key</code> from which members will be removed.
      * @param members A list of members to remove from the set stored at <code>key</code>.
      * @return The number of members that were removed from the set, excluding non-existing members.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
-     *           returns 0.
-     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
      *
      * @example
      *     <p><code>
      *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
+     *  // result: 2
      *  </code>
      */
     CompletableFuture<Long> srem(String key, String[] members);
@@ -60,15 +52,12 @@ public interface SetCommands {
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
      * @return A <code>Set</code> of all members of the set.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist an empty set will be returned.
-     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist an empty set will be returned.
      *
      * @example
      *     <p><code>
      *  {@literal Set<String>} result = client.smembers("my_set").get();
+     *  // result: {"member1", "member2", "member3"}
      *  </code>
      */
     CompletableFuture<Set<String>> smembers(String key);
@@ -79,10 +68,11 @@ public interface SetCommands {
      * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
      * @param key The key from which to retrieve the number of set members.
      * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
-     * @remarks If <code>key</code> holds a value that is not a set, an error is returned.
+     *
      * @example
      *     <p><code>
      *  int result = client.scard("my_set").get();
+     *  // result: 3
      *  </code>
      */
     CompletableFuture<Long> scard(String key);

--- a/java/client/src/main/java/glide/api/commands/SetCommands.java
+++ b/java/client/src/main/java/glide/api/commands/SetCommands.java
@@ -1,0 +1,89 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.commands;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Set Commands interface.
+ *
+ * @see <a href="https://redis.io/commands/?group=set">Set Commands</a>
+ */
+public interface SetCommands {
+    /**
+     * Add specified members to the set stored at <code>key</code>. Specified members that are already
+     * a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
+     * @param key The <code>key</code> where members will be added to its set.
+     * @param members A list of members to add to the set stored at <code>key</code>.
+     * @return The number of members that were added to the set, excluding members already present.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
+     *           </code>.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     * @example
+     *     <p><code>
+     *  int result = client.sadd("my_set", new String[]{"member1", "member2"}).get();
+     *  </code>
+     */
+    CompletableFuture<Long> sadd(String key, String[] members);
+
+    /**
+     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * not a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
+     * @param key The <code>key</code> from which members will be removed.
+     * @param members A list of members to remove from the set stored at <code>key</code>.
+     * @return The number of members that were removed from the set, excluding non-existing members.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
+     *           returns 0.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     * @example
+     *     <p><code>
+     *  int result = client.srem("my_set", new String[]{"member1", "member2"}).get();
+     *  </code>
+     */
+    CompletableFuture<Long> srem(String key, String[] members);
+
+    /**
+     * Retrieve all the members of the set value stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
+     * @param key The key from which to retrieve the set members.
+     * @return A <code>Set</code> of all members of the set.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist an empty set will be returned.
+     *       <li>If <code>key</code> holds a value that is not a set, an error is returned.
+     *     </ul>
+     *
+     * @example
+     *     <p><code>
+     *  {@literal Set<String>} result = client.smembers("my_set").get();
+     *  </code>
+     */
+    CompletableFuture<Set<String>> smembers(String key);
+
+    /**
+     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
+     * @param key The key from which to retrieve the number of set members.
+     * @return The cardinality (number of elements) of the set, or 0 if the key does not exist.
+     * @remarks If <code>key</code> holds a value that is not a set, an error is returned.
+     * @example
+     *     <p><code>
+     *  int result = client.scard("my_set").get();
+     *  </code>
+     */
+    CompletableFuture<Long> scard(String key);
+}

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -178,7 +178,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param members A list of members to add to the set stored at <code>key</code>.
      * @return Command Response - The number of members that were added to the set, excluding members
      *     already present.
-     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
+     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members
+     *     </code>.
      */
     public T sadd(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
@@ -196,7 +197,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param members A list of members to remove from the set stored at <code>key</code>.
      * @return Command Response - The number of members that were removed from the set, excluding
      *     non-existing members.
-     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
+     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command
+     *     returns 0.
      */
     public T srem(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -5,6 +5,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -162,6 +166,87 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
                 buildArgs(ArrayUtils.addAll(new String[] {key, value}, options.toArgs()));
 
         protobufTransaction.addCommands(buildCommand(SetString, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Add specified members to the set stored at <code>key</code>. Specified members that are already
+     * a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/sadd/">redis.io</a> for details.
+     * @param key The <code>key</code> where members will be added to its set.
+     * @param members A list of members to add to the set stored at <code>key</code>.
+     * @return Command Response - The number of members that were added to the set, excluding members
+     *     already present.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
+     *           </code>.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
+     *     </ul>
+     */
+    public T sadd(String key, String[] members) {
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
+
+        protobufTransaction.addCommands(buildCommand(SAdd, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Remove specified members from the set stored at <code>key</code>. Specified members that are
+     * not a member of this set are ignored.
+     *
+     * @see <a href="https://redis.io/commands/srem/">redis.io</a> for details.
+     * @param key The <code>key</code> from which members will be removed.
+     * @param members A list of members to remove from the set stored at <code>key</code>.
+     * @return Command Response - The number of members that were removed from the set, excluding
+     *     non-existing members.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
+     *           returns 0.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
+     *     </ul>
+     */
+    public T srem(String key, String[] members) {
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
+
+        protobufTransaction.addCommands(buildCommand(SRem, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Retrieve all the members of the set value stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
+     * @param key The key from which to retrieve the set members.
+     * @return Command Response - A <code>Set</code> of all members of the set.
+     * @remarks
+     *     <ul>
+     *       <li>If <code>key</code> does not exist an empty set will be returned.
+     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
+     *     </ul>
+     */
+    public T smembers(String key) {
+        ArgsArray commandArgs = buildArgs(key);
+
+        protobufTransaction.addCommands(buildCommand(SMembers, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Retrieve the set cardinality (number of elements) of the set stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/scard/">redis.io</a> for details.
+     * @param key The key from which to retrieve the number of set members.
+     * @return Command Response - The cardinality (number of elements) of the set, or 0 if the key
+     *     does not exist.
+     * @remarks If <code>key</code> holds a value that is not a set, the transaction fails.
+     */
+    public T scard(String key) {
+        ArgsArray commandArgs = buildArgs(key);
+
+        protobufTransaction.addCommands(buildCommand(SCard, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -178,12 +178,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param members A list of members to add to the set stored at <code>key</code>.
      * @return Command Response - The number of members that were added to the set, excluding members
      *     already present.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist, a new set is created before adding <code>members
-     *           </code>.
-     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist, a new set is created before adding <code>members</code>.
      */
     public T sadd(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
@@ -201,12 +196,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param members A list of members to remove from the set stored at <code>key</code>.
      * @return Command Response - The number of members that were removed from the set, excluding
      *     non-existing members.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist, it is treated as an empty set and this command
-     *           returns 0.
-     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist, it is treated as an empty set and this command returns 0.
      */
     public T srem(String key, String[] members) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(members, key));
@@ -221,11 +211,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/smembers/">redis.io</a> for details.
      * @param key The key from which to retrieve the set members.
      * @return Command Response - A <code>Set</code> of all members of the set.
-     * @remarks
-     *     <ul>
-     *       <li>If <code>key</code> does not exist an empty set will be returned.
-     *       <li>If <code>key</code> holds a value that is not a set, the transaction fails.
-     *     </ul>
+     * @remarks If <code>key</code> does not exist an empty set will be returned.
      */
     public T smembers(String key) {
         ArgsArray commandArgs = buildArgs(key);
@@ -241,7 +227,6 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param key The key from which to retrieve the number of set members.
      * @return Command Response - The cardinality (number of elements) of the set, or 0 if the key
      *     does not exist.
-     * @remarks If <code>key</code> holds a value that is not a set, the transaction fails.
      */
     public T scard(String key) {
         ArgsArray commandArgs = buildArgs(key);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -15,6 +15,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -22,8 +26,10 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.SetOptions.Expiry;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -266,5 +272,101 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(testPayload, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void sadd_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] members = new String[] {"testMember1", "testMember2"};
+        String[] arguments = ArrayUtils.addFirst(members, key);
+        Long value = 2L;
+
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(SAdd), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.sadd(key, members);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void srem_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] members = new String[] {"testMember1", "testMember2"};
+        String[] arguments = ArrayUtils.addFirst(members, key);
+        Long value = 2L;
+
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(SRem), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.srem(key, members);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void smembers_returns_success() {
+        // setup
+        String key = "testKey";
+        Set<String> value = Set.of("testMember");
+
+        CompletableFuture<Set<String>> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<Set<String>>submitNewCommand(eq(SMembers), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Set<String>> response = service.smembers(key);
+        Set<String> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void scard_returns_success() {
+        // setup
+        String key = "testKey";
+        Long value = 2L;
+
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(SCard), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.scard(key);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -56,6 +60,18 @@ public class ClusterTransactionTests {
                 Pair.of(
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
+
+        transaction.sadd("key", new String[] {"value"});
+        results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.srem("key", new String[] {"value"});
+        results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.smembers("key");
+        results.add(Pair.of(SMembers, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.scard("key");
+        results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.SCard;
+import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
+import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 
 import glide.api.models.commands.InfoOptions;
@@ -55,6 +59,18 @@ public class TransactionTests {
                 Pair.of(
                         Info,
                         ArgsArray.newBuilder().addArgs(InfoOptions.Section.EVERYTHING.toString()).build()));
+
+        transaction.sadd("key", new String[] {"value"});
+        results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.srem("key", new String[] {"value"});
+        results.add(Pair.of(SRem, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));
+
+        transaction.smembers("key");
+        results.add(Pair.of(SMembers, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.scard("key");
+        results.add(Pair.of(SCard, ArgsArray.newBuilder().addArgs("key").build()));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -10,6 +10,7 @@ import static glide.api.models.commands.SetOptions.Expiry.Milliseconds;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.BaseClient;
 import glide.api.RedisClient;
@@ -18,7 +19,11 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
+import glide.api.models.exceptions.RequestException;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -246,5 +251,66 @@ public class SharedCommandTests {
         SetOptions options = SetOptions.builder().returnOldValue(true).build();
         String data = client.set("another", ANOTHER_VALUE, options).get();
         assertNull(data);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void sadd_srem_scard_smembers_existing_set(BaseClient client) {
+        String key = UUID.randomUUID().toString();
+        assertEquals(
+                4, client.sadd(key, new String[] {"member1", "member2", "member3", "member4"}).get());
+        assertEquals(1, client.srem(key, new String[] {"member3", "nonExistingMember"}).get());
+
+        Set<String> expectedMembers = Set.of("member1", "member2", "member4");
+        assertEquals(expectedMembers, client.smembers(key).get());
+        assertEquals(1, client.srem(key, new String[] {"member1"}).get());
+        assertEquals(2, client.scard(key).get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void srem_scard_smembers_non_existing_key(BaseClient client) {
+        assertEquals(0, client.srem("nonExistingKey", new String[] {"member"}).get());
+        assertEquals(0, client.scard("nonExistingKey").get());
+        assertEquals(Set.of(), client.smembers("nonExistingKey").get());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void sadd_srem_scard_smembers_key_with_non_set_value(BaseClient client) {
+        String key = UUID.randomUUID().toString();
+        assertEquals(OK, client.set(key, "foo").get());
+
+        Exception e =
+                assertThrows(ExecutionException.class, () -> client.sadd(key, new String[] {"baz"}).get());
+        assertTrue(e.getCause() instanceof RequestException);
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
+
+        e = assertThrows(ExecutionException.class, () -> client.srem(key, new String[] {"baz"}).get());
+        assertTrue(e.getCause() instanceof RequestException);
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
+
+        e = assertThrows(ExecutionException.class, () -> client.scard(key).get());
+        assertTrue(e.getCause() instanceof RequestException);
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
+
+        e = assertThrows(ExecutionException.class, () -> client.smembers(key).get());
+        assertTrue(e.getCause() instanceof RequestException);
+        assertTrue(
+                e.getCause()
+                        .getMessage()
+                        .contains("Operation against a key holding the wrong kind of value"));
     }
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -287,30 +287,14 @@ public class SharedCommandTests {
         Exception e =
                 assertThrows(ExecutionException.class, () -> client.sadd(key, new String[] {"baz"}).get());
         assertTrue(e.getCause() instanceof RequestException);
-        assertTrue(
-                e.getCause()
-                        .getMessage()
-                        .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.srem(key, new String[] {"baz"}).get());
         assertTrue(e.getCause() instanceof RequestException);
-        assertTrue(
-                e.getCause()
-                        .getMessage()
-                        .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.scard(key).get());
         assertTrue(e.getCause() instanceof RequestException);
-        assertTrue(
-                e.getCause()
-                        .getMessage()
-                        .contains("Operation against a key holding the wrong kind of value"));
 
         e = assertThrows(ExecutionException.class, () -> client.smembers(key).get());
         assertTrue(e.getCause() instanceof RequestException);
-        assertTrue(
-                e.getCause()
-                        .getMessage()
-                        .contains("Operation against a key holding the wrong kind of value"));
     }
 }

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -3,6 +3,7 @@ package glide;
 
 import glide.api.models.BaseTransaction;
 import glide.api.models.commands.SetOptions;
+import java.util.Set;
 import java.util.UUID;
 
 public class TestUtilities {
@@ -10,15 +11,21 @@ public class TestUtilities {
     public static BaseTransaction transactionTest(BaseTransaction baseTransaction) {
         String key1 = "{key}" + UUID.randomUUID();
         String key2 = "{key}" + UUID.randomUUID();
+        String key3 = "{key}" + UUID.randomUUID();
 
         baseTransaction.set(key1, "bar");
         baseTransaction.set(key2, "baz", SetOptions.builder().returnOldValue(true).build());
         baseTransaction.customCommand("MGET", key1, key2);
 
+        baseTransaction.sadd(key3, new String[] {"baz", "foo"});
+        baseTransaction.srem(key3, new String[] {"foo"});
+        baseTransaction.scard(key3);
+        baseTransaction.smembers(key3);
+
         return baseTransaction;
     }
 
     public static Object[] transactionTestResult() {
-        return new Object[] {"OK", null, new String[] {"bar", "baz"}};
+        return new Object[] {"OK", null, new String[] {"bar", "baz"}, 2L, 1L, 1L, Set.of("baz")};
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds set commands: `sadd`, `srem`, `smembers`, and `scard`.

Examples:
```java
Long saddResult = client.sadd("key", "member1", "member2", "member3", "member4").get();
assert saddResult == 4;
Long sremResult = client.srem("key", "member3").get();
assert sremResult == 1;
Set<String> smembersResult = client.smembers("key").get();
assert smembersResult.equals(Set.of("member1", "member2", "member4"));
Long scardResult = client.scard("key").get();
assert scardResult == 3;
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
