### PR TITLE
Java: Add `UNLINK()` command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -28,6 +28,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SCard;
 import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericBaseCommands;
@@ -364,5 +365,10 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Long> exists(@NonNull String[] keys) {
         return commandManager.submitNewCommand(Exists, keys, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> unlink(@NonNull String[] keys) {
+        return commandManager.submitNewCommand(Unlink, keys, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -37,13 +37,19 @@ public interface GenericBaseCommands {
     CompletableFuture<Long> exists(String[] keys);
 
     /**
-     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
-     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
-     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     * Unlink (delete) multiple <code>keys</code> from the database. A key is ignored if it does not
+     * exist. This command, similar to <a href="https://redis.io/commands/del/">DEL</a>, removes
+     * specified keys and ignores non-existent ones. However, this command does not block the server,
+     * while <a href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys The <code>keys</code> we wanted to unlink.
+     * @param keys The list of keys to unlink.
      * @return The number of <code>keys</code> that were unlinked.
+     * @example
+     *     <p><code>
+     * long result = client.unlink("my_key").get();
+     * assert result == 1L;
+     * </code>
      */
     CompletableFuture<Long> unlink(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -43,7 +43,7 @@ public interface GenericBaseCommands {
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
      * @param keys The <code>keys</code> we wanted to unlink.
-     * @return the number of <code>keys</code> that were unlinked.
+     * @return The number of <code>keys</code> that were unlinked.
      */
     CompletableFuture<Long> unlink(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -46,10 +46,11 @@ public interface GenericBaseCommands {
      * @param keys The list of keys to unlink.
      * @return The number of <code>keys</code> that were unlinked.
      * @example
-     *     <p><code>
+     *     <p>
+     *     <pre>
      * long result = client.unlink("my_key").get();
      * assert result == 1L;
-     * </code>
+     * </pre>
      */
     CompletableFuture<Long> unlink(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -35,4 +35,15 @@ public interface GenericBaseCommands {
      * </code>
      */
     CompletableFuture<Long> exists(String[] keys);
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
+     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
+     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     *
+     * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
+     * @param keys The <code>keys</code> we wanted to unlink.
+     * @return the number of <code>keys</code> that were unlinked.
+     */
+    CompletableFuture<Long> unlink(String[] keys);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -28,6 +28,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SCard;
 import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.InfoOptions.Section;
@@ -544,6 +545,22 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(keys);
 
         protobufTransaction.addCommands(buildCommand(Exists, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
+     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
+     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     *
+     * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
+     * @param keys The <code>keys</code> we wanted to unlink.
+     * @return the number of <code>keys</code> that were unlinked.
+     */
+    public T unlink(String[] keys) {
+        ArgsArray commandArgs = buildArgs(keys);
+
+        protobufTransaction.addCommands(buildCommand(Unlink, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -549,13 +549,14 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Removes the specified <code>keys</code>. A key is ignored if it does not exist. This command,
-     * similar to DEL, removes specified keys and ignores non-existent ones. However, this command
-     * does not block the server, while <a href="https://redis.io/commands/del/">DEL</a> does.
+     * Unlink (delete) multiple <code>keys</code> from the database. A key is ignored if it does not
+     * exist. This command, similar to DEL, removes specified keys and ignores non-existent ones.
+     * However, this command does not block the server, while <a
+     * href="https://redis.io/commands/del/">DEL</a> does.
      *
      * @see <a href="https://redis.io/commands/unlink/">redis.io</a> for details.
-     * @param keys The <code>keys</code> we wanted to unlink.
-     * @return the number of <code>keys</code> that were unlinked.
+     * @param keys The list of keys to unlink.
+     * @return Command Response - The number of <code>keys</code> that were unlinked.
      */
     public T unlink(String[] keys) {
         ArgsArray commandArgs = buildArgs(keys);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -38,6 +38,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SCard;
 import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SetOptions;
@@ -151,6 +152,26 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(numberDeleted, result);
+    }
+
+    @SneakyThrows
+    @Test
+    public void unlink_returns_long_success() {
+        // setup
+        String[] keys = new String[] {"testKey1", "testKey2"};
+        Long numberUnlinked = 1L;
+        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(numberUnlinked);
+        when(commandManager.<Long>submitNewCommand(eq(Unlink), eq(keys), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.unlink(keys);
+        Long result = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(numberUnlinked, result);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -162,6 +162,8 @@ public class RedisClientTest {
         Long numberUnlinked = 1L;
         CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn(numberUnlinked);
+
+        // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Unlink), eq(keys), any()))
                 .thenReturn(testResponse);
 

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -28,6 +28,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SCard;
 import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
 import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
+import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SetOptions;
@@ -74,6 +75,9 @@ public class TransactionTests {
 
         transaction.del(new String[] {"key1", "key2"});
         results.add(Pair.of(Del, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
+
+        transaction.unlink(new String[] {"key1", "key2"});
+        results.add(Pair.of(Unlink, ArgsArray.newBuilder().addArgs("key1").addArgs("key2").build()));
 
         transaction.ping();
         results.add(Pair.of(Ping, ArgsArray.newBuilder().build()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -96,6 +96,34 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
+    public void unlink_multiple_keys(BaseClient client) {
+        String key1 = "{key}" + UUID.randomUUID();
+        String key2 = "{key}" + UUID.randomUUID();
+        String key3 = "{key}" + UUID.randomUUID();
+        String value = UUID.randomUUID().toString();
+
+        String setResult = client.set(key1, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key2, value).get();
+        assertEquals(OK, setResult);
+        setResult = client.set(key3, value).get();
+        assertEquals(OK, setResult);
+
+        Long unlinkedKeysNum = client.unlink(new String[] {key1, key2, key3}).get();
+        assertEquals(3L, unlinkedKeysNum);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
+    public void unlink_non_existent_key(BaseClient client) {
+        Long unlinkedKeysNum = client.unlink(new String[] {UUID.randomUUID().toString()}).get();
+        assertEquals(0L, unlinkedKeysNum);
+    }
+
+    @SneakyThrows
+    @ParameterizedTest
+    @MethodSource("getClients")
     public void set_and_get_without_options(BaseClient client) {
         String ok = client.set(KEY_NAME, INITIAL_VALUE).get();
         assertEquals(OK, ok);

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -46,6 +46,8 @@ public class TransactionTestUtilities {
 
         baseTransaction.incrByFloat(key3, 0.5);
 
+        baseTransaction.unlink(new String[] {key3});
+
         baseTransaction.hset(key4, Map.of(field1, value1, field2, value2));
         baseTransaction.hget(key4, field1);
         baseTransaction.hexists(key4, field2);
@@ -82,6 +84,7 @@ public class TransactionTestUtilities {
             2L,
             0L,
             0.5,
+            1L,
             2L,
             value1,
             true,

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -32,6 +32,9 @@ public class TransactionTestUtilities {
         baseTransaction.del(new String[] {key1});
         baseTransaction.get(key1);
 
+        baseTransaction.unlink(new String[] {key2});
+        baseTransaction.get(key2);
+
         baseTransaction.mset(Map.of(key1, value2, key2, value1));
         baseTransaction.mget(new String[] {key1, key2});
 
@@ -68,6 +71,8 @@ public class TransactionTestUtilities {
             null,
             new String[] {value1, value2},
             1L,
+            1L,
+            null,
             1L,
             null,
             "OK",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding the UNLINK() command (Generic command).  Note, unlink() and del() are very similar commands. 

Example: 
```
// assuming key1 and key2 exist, while key "invalid" does not. 
Integer result = client.unlink(new String[] {"key1", "key2", "invalid"}).get();
assert result == 2;
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
