### PR TITLE
Update jedis sync client with thread pooling

### DIFF
--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
@@ -13,7 +13,7 @@ import redis.clients.jedis.JedisPool;
 /** A Jedis client with sync capabilities. See: https://github.com/redis/jedis */
 public class JedisClient implements SyncClient {
     boolean isClusterMode;
-    private JedisPool jedisPool;
+    private JedisPool jedisStandalonePool;
     private JedisCluster jedisCluster;
 
     @Override
@@ -21,8 +21,8 @@ public class JedisClient implements SyncClient {
         if (jedisCluster != null) {
             jedisCluster.close();
         }
-        if (jedisPool != null) {
-            jedisPool.close();
+        if (jedisStandalonePool != null) {
+            jedisStandalonePool.close();
         }
     }
 
@@ -40,7 +40,7 @@ public class JedisClient implements SyncClient {
                             Set.of(new HostAndPort(connectionSettings.host, connectionSettings.port)),
                             DefaultJedisClientConfig.builder().ssl(connectionSettings.useSsl).build());
         } else {
-            jedisPool =
+            jedisStandalonePool =
                     new JedisPool(
                             connectionSettings.host, connectionSettings.port, connectionSettings.useSsl);
         }
@@ -51,7 +51,7 @@ public class JedisClient implements SyncClient {
         if (isClusterMode) {
             jedisCluster.set(key, value);
         } else {
-            try (Jedis jedis = jedisPool.getResource()) {
+            try (Jedis jedis = jedisStandalonePool.getResource()) {
                 jedis.set(key, value);
             }
         }
@@ -62,7 +62,7 @@ public class JedisClient implements SyncClient {
         if (isClusterMode) {
             return jedisCluster.get(key);
         } else {
-            try (Jedis jedis = jedisPool.getResource()) {
+            try (Jedis jedis = jedisStandalonePool.getResource()) {
                 return jedis.get(key);
             }
         }

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
@@ -41,7 +41,8 @@ public class JedisClient implements SyncClient {
                             DefaultJedisClientConfig.builder().ssl(connectionSettings.useSsl).build());
         } else {
             jedisPool =
-                new JedisPool(connectionSettings.host, connectionSettings.port, connectionSettings.useSsl);
+                    new JedisPool(
+                            connectionSettings.host, connectionSettings.port, connectionSettings.useSsl);
         }
     }
 

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
@@ -39,9 +39,10 @@ public class JedisClient implements SyncClient {
                     new JedisCluster(
                             Set.of(new HostAndPort(connectionSettings.host, connectionSettings.port)),
                             DefaultJedisClientConfig.builder().ssl(connectionSettings.useSsl).build());
-        }
-        jedisPool =
+        } else {
+            jedisPool =
                 new JedisPool(connectionSettings.host, connectionSettings.port, connectionSettings.useSsl);
+        }
     }
 
     @Override

--- a/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/clients/jedis/JedisClient.java
@@ -6,18 +6,24 @@ import glide.benchmarks.utils.ConnectionSettings;
 import java.util.Set;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.commands.JedisCommands;
 
 /** A Jedis client with sync capabilities. See: https://github.com/redis/jedis */
 public class JedisClient implements SyncClient {
-
-    private JedisCommands jedis;
+    boolean isClusterMode;
+    private JedisPool jedisPool;
+    private JedisCluster jedisCluster;
 
     @Override
     public void closeConnection() {
-        // nothing to do
+        if (jedisCluster != null) {
+            jedisCluster.close();
+        }
+        if (jedisPool != null) {
+            jedisPool.close();
+        }
     }
 
     @Override
@@ -27,27 +33,36 @@ public class JedisClient implements SyncClient {
 
     @Override
     public void connectToRedis(ConnectionSettings connectionSettings) {
-        if (connectionSettings.clusterMode) {
-            jedis =
+        isClusterMode = connectionSettings.clusterMode;
+        if (isClusterMode) {
+            jedisCluster =
                     new JedisCluster(
                             Set.of(new HostAndPort(connectionSettings.host, connectionSettings.port)),
                             DefaultJedisClientConfig.builder().ssl(connectionSettings.useSsl).build());
+        }
+        jedisPool =
+                new JedisPool(connectionSettings.host, connectionSettings.port, connectionSettings.useSsl);
+    }
+
+    @Override
+    public void set(String key, String value) {
+        if (isClusterMode) {
+            jedisCluster.set(key, value);
         } else {
-            try (JedisPool pool =
-                    new JedisPool(
-                            connectionSettings.host, connectionSettings.port, connectionSettings.useSsl)) {
-                jedis = pool.getResource();
+            try (Jedis jedis = jedisPool.getResource()) {
+                jedis.set(key, value);
             }
         }
     }
 
     @Override
-    public void set(String key, String value) {
-        jedis.set(key, value);
-    }
-
-    @Override
     public String get(String key) {
-        return jedis.get(key);
+        if (isClusterMode) {
+            return jedisCluster.get(key);
+        } else {
+            try (Jedis jedis = jedisPool.getResource()) {
+                return jedis.get(key);
+            }
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Before: 
```
Exception in thread "main" java.lang.RuntimeException: java.util.concurrent.ExecutionException: redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Broken pipe
        at glide.benchmarks.utils.Benchmarking.testClientSetGet(Benchmarking.java:163)
        at glide.benchmarks.BenchmarkingApp.main(BenchmarkingApp.java:51)
Caused by: java.util.concurrent.ExecutionException: redis.clients.jedis.exceptions.JedisConnectionException: java.net.SocketException: Broken pipe
```

Fixed: 
```
> ./install_and_test.sh -$CLIENT -tasks 1 10 100 1000 -data $DATASIZE -clients 1 -host $HOST -tls -is-cluster;

...

 =====> Jedis <===== 1 clients 1000 concurrent 100 data size 

Runtime s: 273.788191
Iterations: 10000000
TPS: 36524.584858
===> GET_EXISTING <===
avg. time ms: 0.000405
std dev ms: 0.001159
p50 latency ms: 0.000173
p90 latency ms: 0.000322
p99 latency ms: 0.005903
Total hits: 6398289
===> GET_NON_EXISTING <===
avg. time ms: 0.000412
std dev ms: 0.001178
p50 latency ms: 0.000172
p90 latency ms: 0.000331
p99 latency ms: 0.005983
Total hits: 1598783
===> SET <===
avg. time ms: 0.000425
std dev ms: 0.001189
p50 latency ms: 0.000181
p90 latency ms: 0.000375
p99 latency ms: 0.006031
Total hits: 2002928
Total hits: 10000000
```

Also tested using standalone cluster. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
