### PR TITLE
Fix test warning.

### DIFF
--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -981,7 +981,7 @@ class TestCommands:
         # set command clears the timeout.
         assert await redis_client.set(key, "bar") == OK
         current_time_ms = int(time.time() * 1000)
-        if not check_if_server_version_lt(redis_client, "7.0.0"):
+        if not await check_if_server_version_lt(redis_client, "7.0.0"):
             assert (
                 await redis_client.pexpireat(
                     key, current_time_ms + 50000, ExpireOptions.HasExistingExpiry


### PR DESCRIPTION
```bash
python/tests/test_async_client.py::TestCommands::test_expireat_pexpireat_ttl_with_positive_timeout[ProtocolVersion.RESP2-True]
python/tests/test_async_client.py::TestCommands::test_expireat_pexpireat_ttl_with_positive_timeout[ProtocolVersion.RESP2-False]
python/tests/test_async_client.py::TestCommands::test_expireat_pexpireat_ttl_with_positive_timeout[ProtocolVersion.RESP3-True]
python/tests/test_async_client.py::TestCommands::test_expireat_pexpireat_ttl_with_positive_timeout[ProtocolVersion.RESP3-False]
  /home/ubuntu/repositories/glide/python/python/tests/test_async_client.py:984: RuntimeWarning: coroutine 'check_if_server_version_lt' was never awaited
    if not check_if_server_version_lt(redis_client, "7.0.0"):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
