### PR TITLE
Lint all TS files base on our prettier for easier developer life, and added CI prettier step

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -1,4 +1,5 @@
 name: lint-ts
+
 on:
     push:
         branches: ["main"]
@@ -16,30 +17,23 @@ on:
 
 env:
     CARGO_TERM_COLOR: always
+
 jobs:
-    job:
+    lint:
         runs-on: ubuntu-latest
         timeout-minutes: 10
+
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-            - uses: ./.github/workflows/lint-ts
-              with:
-                  package-folder: ./node
-              name: lint node
-
-            - uses: ./.github/workflows/lint-ts
-              with:
-                  package-folder: ./benchmarks/node
-              name: lint benchmark
-
-            - uses: ./.github/workflows/lint-ts
-              with:
-                  package-folder: ./benchmarks/utilities
-              name: lint benchmark utilities
-
-            - name: lint ts
+            - name: Install dependencies
               run: |
-                  npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier
-                  npm i
-                  npx eslint .
+                  npm install @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier prettier
+
+            - name: Run linting and prettier
+              run: |
+                  for folder in node benchmarks/node benchmarks/utilities; do
+                    npx eslint ${{ github.workspace }}/$folder
+                    npx prettier --check ${{ github.workspace }}/$folder
+                  done

--- a/benchmarks/node/node_benchmark.ts
+++ b/benchmarks/node/node_benchmark.ts
@@ -66,7 +66,7 @@ async function redisBenchmark(
     clients: IAsyncClient[],
     totalCommands: number,
     data: string,
-    actionLatencies: Record<ChosenAction, number[]>
+    actionLatencies: Record<ChosenAction, number[]>,
 ) {
     while (startedTasksCounter < totalCommands) {
         startedTasksCounter += 1;
@@ -97,14 +97,14 @@ async function createBenchTasks(
     totalCommands: number,
     numOfConcurrentTasks: number,
     data: string,
-    actionLatencies: Record<ChosenAction, number[]>
+    actionLatencies: Record<ChosenAction, number[]>,
 ) {
     startedTasksCounter = 0;
     const tic = process.hrtime();
 
     for (let i = 0; i < numOfConcurrentTasks; i++) {
         runningTasks.push(
-            redisBenchmark(clients, totalCommands, data, actionLatencies)
+            redisBenchmark(clients, totalCommands, data, actionLatencies),
         );
     }
 
@@ -115,7 +115,7 @@ async function createBenchTasks(
 
 function latencyResults(
     prefix: string,
-    latencies: number[]
+    latencies: number[],
 ): Record<string, number> {
     const result: Record<string, number> = {};
     result[prefix + "_p50_latency"] = calculateLatency(latencies, 50);
@@ -136,13 +136,13 @@ async function runClients(
     dataSize: number,
     data: string,
     clientDisposal: (client: IAsyncClient) => void,
-    isCluster: boolean
+    isCluster: boolean,
 ) {
     const now = new Date();
     console.log(
         `Starting ${clientName} data size: ${dataSize} concurrency: ${numOfConcurrentTasks} client count: ${
             clients.length
-        } isCluster: ${isCluster} ${now.toLocaleTimeString()}`
+        } isCluster: ${isCluster} ${now.toLocaleTimeString()}`,
     );
     const actionLatencies = {
         [ChosenAction.SET]: [],
@@ -155,7 +155,7 @@ async function runClients(
         totalCommands,
         numOfConcurrentTasks,
         data,
-        actionLatencies
+        actionLatencies,
     );
     const tps = Math.round(startedTasksCounter / time);
 
@@ -163,13 +163,13 @@ async function runClients(
         actionLatencies[ChosenAction.GET_NON_EXISTING];
     const getNonExistingLatencyResults = latencyResults(
         "get_non_existing",
-        getNonExistingLatencies
+        getNonExistingLatencies,
     );
 
     const getExistingLatencies = actionLatencies[ChosenAction.GET_EXISTING];
     const getExistingLatencyResults = latencyResults(
         "get_existing",
-        getExistingLatencies
+        getExistingLatencies,
     );
 
     const setLatencies = actionLatencies[ChosenAction.SET];
@@ -193,10 +193,10 @@ async function runClients(
 
 function createClients(
     clientCount: number,
-    createAction: () => Promise<IAsyncClient>
+    createAction: () => Promise<IAsyncClient>,
 ): Promise<IAsyncClient[]> {
     const creationActions = Array.from({ length: clientCount }, () =>
-        createAction()
+        createAction(),
     );
     return Promise.all(creationActions);
 }
@@ -210,7 +210,7 @@ async function main(
     clientCount: number,
     useTLS: boolean,
     clusterModeEnabled: boolean,
-    port: number
+    port: number,
 ) {
     const data = generateValue(dataSize);
 
@@ -222,7 +222,7 @@ async function main(
             clientClass.createClient({
                 addresses: [{ host, port }],
                 useTLS,
-            })
+            }),
         );
         await runClients(
             clients,
@@ -234,7 +234,7 @@ async function main(
             (client) => {
                 (client as RedisClient).close();
             },
-            clusterModeEnabled
+            clusterModeEnabled,
         );
         await new Promise((resolve) => setTimeout(resolve, 100));
     }
@@ -268,7 +268,7 @@ async function main(
             (client) => {
                 (client as RedisClientType).disconnect();
             },
-            clusterModeEnabled
+            clusterModeEnabled,
         );
         await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -297,7 +297,7 @@ async function main(
             (client) => {
                 (client as RedisClientType).disconnect();
             },
-            clusterModeEnabled
+            clusterModeEnabled,
         );
     }
 }
@@ -313,20 +313,20 @@ Promise.resolve() // just added to clean the indentation of the rest of the call
         const clientCount: string[] = receivedOptions.clientCount;
         const lambda: (
             numOfClients: string,
-            concurrentTasks: string
+            concurrentTasks: string,
         ) => [number, number, number] = (
             numOfClients: string,
-            concurrentTasks: string
+            concurrentTasks: string,
         ) => [parseInt(concurrentTasks), dataSize, parseInt(numOfClients)];
         const product: [number, number, number][] = concurrentTasks
             .flatMap((concurrentTasks: string) =>
                 clientCount.map((clientCount) =>
-                    lambda(clientCount, concurrentTasks)
-                )
+                    lambda(clientCount, concurrentTasks),
+                ),
             )
             .filter(
                 ([concurrentTasks, , clientCount]) =>
-                    clientCount <= concurrentTasks
+                    clientCount <= concurrentTasks,
             );
 
         for (const [concurrentTasks, dataSize, clientCount] of product) {
@@ -342,7 +342,7 @@ Promise.resolve() // just added to clean the indentation of the rest of the call
                 clientCount,
                 receivedOptions.tls,
                 receivedOptions.clusterModeEnabled,
-                receivedOptions.port
+                receivedOptions.port,
             );
         }
 

--- a/benchmarks/node/package.json
+++ b/benchmarks/node/package.json
@@ -4,7 +4,9 @@
     "description": "",
     "main": "node_benchmark.ts",
     "scripts": {
-        "bench": "node node_benchmark.js"
+        "bench": "node node_benchmark.js",
+        "prettier:check:ci": "./node_modules/.bin/prettier --check .",
+        "prettier:format": "./node_modules/.bin/prettier --write . "
     },
     "author": "",
     "license": "ISC",
@@ -20,7 +22,7 @@
     },
     "devDependencies": {
         "@types/node": "^18.7.9",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.8",
         "typescript": "^4.8.4"
     }
 }

--- a/benchmarks/node/tsconfig.json
+++ b/benchmarks/node/tsconfig.json
@@ -1,103 +1,103 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig to read more about this file */
 
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+        /* Projects */
+        // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+        // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+        // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+        // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+        // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+        // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
-    /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+        /* Language and Environment */
+        "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+        // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+        // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+        // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+        // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+        // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+        // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+        // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+        // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+        // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+        /* Modules */
+        "module": "commonjs" /* Specify what module code is generated. */,
+        // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+        // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+        // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+        // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+        // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+        // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+        // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+        // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+        // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+        // "resolveJsonModule": true,                        /* Enable importing .json files. */
+        // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+        /* JavaScript Support */
+        // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+        // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+        // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+        /* Emit */
+        // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+        // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+        // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+        // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+        // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+        // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+        // "removeComments": true,                           /* Disable emitting comments. */
+        // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+        // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+        // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+        // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+        // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+        // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+        // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+        // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+        // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+        // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+        // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+        // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+        // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+        // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+        // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+        /* Interop Constraints */
+        // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+        // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+        "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+        // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+        "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+        /* Type Checking */
+        "strict": true /* Enable all strict type-checking options. */,
+        // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+        // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+        // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+        // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+        // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+        // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+        // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+        // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+        // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+        // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+        // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+        // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+        // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+        // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+        // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+        // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+        // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+        /* Completeness */
+        // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    }
 }

--- a/benchmarks/utilities/fill_db.ts
+++ b/benchmarks/utilities/fill_db.ts
@@ -14,7 +14,7 @@ async function fill_database(
     host: string,
     isCluster: boolean,
     tls: boolean,
-    port: number
+    port: number,
 ) {
     const client = await createRedisClient(host, isCluster, tls, port);
     const data = generateValue(data_size);
@@ -27,7 +27,7 @@ async function fill_database(
                 const key = (i * CONCURRENT_SETS + index).toString();
                 await client.set(key, data);
             }
-        }
+        },
     );
 
     await Promise.all(sets);
@@ -37,14 +37,14 @@ async function fill_database(
 Promise.resolve()
     .then(async () => {
         console.log(
-            `Filling ${receivedOptions.host} with data size ${receivedOptions.dataSize}`
+            `Filling ${receivedOptions.host} with data size ${receivedOptions.dataSize}`,
         );
         await fill_database(
             receivedOptions.dataSize,
             receivedOptions.host,
             receivedOptions.clusterModeEnabled,
             receivedOptions.tls,
-            receivedOptions.port
+            receivedOptions.port,
         );
     })
     .then(() => {

--- a/benchmarks/utilities/flush_db.ts
+++ b/benchmarks/utilities/flush_db.ts
@@ -9,19 +9,19 @@ async function flush_database(
     host: string,
     isCluster: boolean,
     tls: boolean,
-    port: number
+    port: number,
 ) {
     if (isCluster) {
         const client = (await createRedisClient(
             host,
             isCluster,
             tls,
-            port
+            port,
         )) as RedisClusterType;
         await Promise.all(
             client.masters.map((master) => {
                 return flush_database(master.host, false, tls, master.port);
-            })
+            }),
         );
         await client.quit();
     } else {
@@ -29,7 +29,7 @@ async function flush_database(
             host,
             isCluster,
             tls,
-            port
+            port,
         )) as RedisClientType;
         await client.connect();
         await client.flushAll();
@@ -44,7 +44,7 @@ Promise.resolve()
             receivedOptions.host,
             receivedOptions.clusterModeEnabled,
             receivedOptions.tls,
-            receivedOptions.port
+            receivedOptions.port,
         );
     })
     .then(() => {

--- a/benchmarks/utilities/package.json
+++ b/benchmarks/utilities/package.json
@@ -6,17 +6,20 @@
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "fill": "node fill_db.js",
-        "flush": "node flush_db.js"
+        "flush": "node flush_db.js",
+        "prettier:check:ci": "./node_modules/.bin/prettier --check .",
+        "prettier:format": "./node_modules/.bin/prettier --write . "
     },
     "author": "",
     "license": "ISC",
     "dependencies": {
         "command-line-args": "^5.2.1",
+        "prettier": "^3.2.5",
         "redis": "^4.6.8"
     },
     "devDependencies": {
         "@types/command-line-args": "^5.2.1",
-        "typescript": "^4.8.4",
-        "@types/node": "^20.6.3"
+        "@types/node": "^20.6.3",
+        "typescript": "^4.8.4"
     }
 }

--- a/benchmarks/utilities/tsconfig.json
+++ b/benchmarks/utilities/tsconfig.json
@@ -1,103 +1,103 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig to read more about this file */
 
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+        /* Projects */
+        // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+        // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+        // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+        // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+        // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+        // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
-    /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+        /* Language and Environment */
+        "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+        // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+        // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+        // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+        // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+        // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+        // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+        // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+        // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+        // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+        /* Modules */
+        "module": "commonjs" /* Specify what module code is generated. */,
+        // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+        // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+        // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+        // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+        // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+        // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+        // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+        // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+        // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+        // "resolveJsonModule": true,                        /* Enable importing .json files. */
+        // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
-    /* JavaScript Support */
-    /*"allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+        /* JavaScript Support */
+        /*"allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+        // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+        // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+        /* Emit */
+        // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+        // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+        // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+        // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+        // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+        // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+        // "removeComments": true,                           /* Disable emitting comments. */
+        // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+        // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+        // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+        // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+        // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+        // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+        // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+        // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+        // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+        // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+        // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+        // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+        // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+        // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+        // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+        /* Interop Constraints */
+        // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+        // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+        "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+        // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+        "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+        /* Type Checking */
+        "strict": true /* Enable all strict type-checking options. */,
+        // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+        // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+        // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+        // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+        // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+        // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+        // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+        // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+        // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+        // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+        // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+        // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+        // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+        // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+        // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+        // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+        // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+        /* Completeness */
+        // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    }
 }

--- a/benchmarks/utilities/utils.ts
+++ b/benchmarks/utilities/utils.ts
@@ -24,7 +24,7 @@ export function createRedisClient(
     host: string,
     isCluster: boolean,
     tls: boolean,
-    port: number
+    port: number,
 ): RedisClusterType | RedisClientType {
     return isCluster
         ? createCluster({

--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -150,9 +150,10 @@ Development on the Node wrapper may involve changes in either the TypeScript or 
 1. TypeScript
     ```bash
     # Run from the `node` folder
-    npm install eslint-plugin-import@latest  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier
+    npm install eslint-plugin-import@latest  @typescript-eslint/parser @typescript-eslint/eslint-plugin eslint-plugin-tsdoc eslint typescript eslint-plugin-import@latest eslint-config-prettier prettier
     npm i
     npx eslint . --max-warnings=0
+    npx prettier --check .
     ```
 2. Rust
     ```bash

--- a/node/babel.config.js
+++ b/node/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = { presets: ['@babel/preset-env'] }
+module.exports = { presets: ["@babel/preset-env"] };

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -7,28 +7,40 @@
 const { platform, arch } = process;
 let nativeBinding = null;
 switch (platform) {
-    case 'linux':
+    case "linux":
         switch (arch) {
-            case 'x64':
-                nativeBinding = await import("@scope/glide-for-redis-linux-x64");
+            case "x64":
+                nativeBinding = await import(
+                    "@scope/glide-for-redis-linux-x64"
+                );
                 break;
-            case 'arm64':
-                nativeBinding = await import("@scope/glide-for-redis-linux-arm64");
+            case "arm64":
+                nativeBinding = await import(
+                    "@scope/glide-for-redis-linux-arm64"
+                );
                 break;
             default:
-                throw new Error(`Unsupported OS: ${platform}, architecture: ${arch}`);
+                throw new Error(
+                    `Unsupported OS: ${platform}, architecture: ${arch}`,
+                );
         }
         break;
-    case 'darwin':
+    case "darwin":
         switch (arch) {
-            case 'x64':
-                nativeBinding = await import("@scope/glide-for-redis-darwin-x64");
+            case "x64":
+                nativeBinding = await import(
+                    "@scope/glide-for-redis-darwin-x64"
+                );
                 break;
-            case 'arm64':
-                nativeBinding = await import("@scope/glide-for-redis-darwin-arm64");
+            case "arm64":
+                nativeBinding = await import(
+                    "@scope/glide-for-redis-darwin-arm64"
+                );
                 break;
             default:
-                throw new Error(`Unsupported OS: ${platform}, architecture: ${arch}`);
+                throw new Error(
+                    `Unsupported OS: ${platform}, architecture: ${arch}`,
+                );
         }
         break;
     default:
@@ -37,5 +49,18 @@ switch (platform) {
 if (!nativeBinding) {
     throw new Error(`Failed to load native binding`);
 }
-export const { RedisClient, RedisClusterClient, Logger, ExpireOptions, InfoOptions, ClosingError, ExecAbortError, RedisError, RequestError, TimeoutError, ClusterTransaction, Transaction } = nativeBinding;
+export const {
+    RedisClient,
+    RedisClusterClient,
+    Logger,
+    ExpireOptions,
+    InfoOptions,
+    ClosingError,
+    ExecAbortError,
+    RedisError,
+    RequestError,
+    TimeoutError,
+    ClusterTransaction,
+    Transaction,
+} = nativeBinding;
 export default Object.assign(global, nativeBinding);

--- a/node/rust-client/.ort.yml
+++ b/node/rust-client/.ort.yml
@@ -1,11 +1,11 @@
 excludes:
     scopes:
-        - pattern: "devDependencies"
-          reason: "DEV_DEPENDENCY_OF"
-          comment: "Packages for development only."
-        - pattern: "build-dependencies"
-          reason: "BUILD_DEPENDENCY_OF"
-          comment: "Packages for building the code only."
-        - pattern: "dev-dependencies"
-          reason: "DEV_DEPENDENCY_OF"
-          comment: "Packages for development only."
+        - pattern: 'devDependencies'
+          reason: 'DEV_DEPENDENCY_OF'
+          comment: 'Packages for development only.'
+        - pattern: 'build-dependencies'
+          reason: 'BUILD_DEPENDENCY_OF'
+          comment: 'Packages for building the code only.'
+        - pattern: 'dev-dependencies'
+          reason: 'DEV_DEPENDENCY_OF'
+          comment: 'Packages for development only.'

--- a/node/rust-client/package.json
+++ b/node/rust-client/package.json
@@ -1,74 +1,74 @@
 {
-  "name": "glide-rs",
-  "version": "0.1.0",
-  "description": "Redis client",
-  "main": "index.js",
-  "license": "Apache-2.0",
-  "files": [
-    "index.d.ts",
-    "index.js",
-    "glide*.*.node"
-  ],
-  "napi": {
     "name": "glide-rs",
-    "triples": {
-      "defaults": true,
-      "additional": [
-        "x86_64-unknown-linux-musl",
-        "aarch64-unknown-linux-gnu",
-        "armv7-unknown-linux-gnueabihf",
-        "aarch64-apple-darwin",
-        "aarch64-linux-android",
-        "x86_64-unknown-freebsd",
-        "aarch64-unknown-linux-musl",
-        "armv7-linux-androideabi"
-      ]
-    }
-  },
-  "engines": {
-    "node": ">= 10"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/",
-    "access": "public"
-  },
-  "scripts": {
-    "artifacts": "napi artifacts",
-    "build": "npm install && napi build --features testing_utilities --platform --pipe \"prettier -w\" $npm_config_build_flags",
-    "build:release": "npm install && napi build --platform --release --strip --pipe \"prettier -w\" $npm_config_build_flags",
-    "build:benchmark": "npm install && napi build --features testing_utilities --platform --release --pipe \"prettier -w\" $npm_config_build_flags",
-    "format": "run-p format:prettier format:rs",
-    "format:prettier": "prettier . -w",
-    "format:rs": "cargo fmt",
-    "lint": "eslint . -c ./.eslintrc.yml",
-    "prepublishOnly": "napi prepublish -t npm",
-    "version": "napi version"
-  },
-  "devDependencies": {
-    "@napi-rs/cli": "^2.7.0",
-    "@typescript-eslint/eslint-plugin": "^5.22.0",
-    "@typescript-eslint/parser": "^5.22.0",
-    "eslint": "^8.14.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-prettier": "^4.0.0",
-    "lint-staged": "^12.4.1",
-    "npm-run-all": "^4.1.5",
-    "prettier": "^2.7.1"
-  },
-  "lint-staged": {
-    "*.@(js|ts|tsx)": [
-      "eslint -c .eslintrc.yml --fix"
+    "version": "0.1.0",
+    "description": "Redis client",
+    "main": "index.js",
+    "license": "Apache-2.0",
+    "files": [
+        "index.d.ts",
+        "index.js",
+        "glide*.*.node"
     ],
-    "*.@(js|ts|tsx|yml|yaml|md|json)": [
-      "prettier --write"
-    ]
-  },
-  "prettier": {
-    "printWidth": 120,
-    "semi": false,
-    "trailingComma": "all",
-    "singleQuote": true,
-    "arrowParens": "always"
-  }
+    "napi": {
+        "name": "glide-rs",
+        "triples": {
+            "defaults": true,
+            "additional": [
+                "x86_64-unknown-linux-musl",
+                "aarch64-unknown-linux-gnu",
+                "armv7-unknown-linux-gnueabihf",
+                "aarch64-apple-darwin",
+                "aarch64-linux-android",
+                "x86_64-unknown-freebsd",
+                "aarch64-unknown-linux-musl",
+                "armv7-linux-androideabi"
+            ]
+        }
+    },
+    "engines": {
+        "node": ">= 10"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
+    },
+    "scripts": {
+        "artifacts": "napi artifacts",
+        "build": "npm install && napi build --features testing_utilities --platform --pipe \"prettier -w\" $npm_config_build_flags",
+        "build:release": "npm install && napi build --platform --release --strip --pipe \"prettier -w\" $npm_config_build_flags",
+        "build:benchmark": "npm install && napi build --features testing_utilities --platform --release --pipe \"prettier -w\" $npm_config_build_flags",
+        "format": "run-p format:prettier format:rs",
+        "format:prettier": "prettier . -w",
+        "format:rs": "cargo fmt",
+        "lint": "eslint . -c ./.eslintrc.yml",
+        "prepublishOnly": "napi prepublish -t npm",
+        "version": "napi version"
+    },
+    "devDependencies": {
+        "@napi-rs/cli": "^2.7.0",
+        "@typescript-eslint/eslint-plugin": "^5.22.0",
+        "@typescript-eslint/parser": "^5.22.0",
+        "eslint": "^8.14.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-prettier": "^4.0.0",
+        "lint-staged": "^12.4.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.7.1"
+    },
+    "lint-staged": {
+        "*.@(js|ts|tsx)": [
+            "eslint -c .eslintrc.yml --fix"
+        ],
+        "*.@(js|ts|tsx|yml|yaml|md|json)": [
+            "prettier --write"
+        ]
+    },
+    "prettier": {
+        "printWidth": 120,
+        "semi": false,
+        "trailingComma": "all",
+        "singleQuote": true,
+        "arrowParens": "always"
+    }
 }

--- a/node/rust-client/tsconfig.json
+++ b/node/rust-client/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "compilerOptions": {
-    "target": "ES2018",
-    "strict": true,
-    "moduleResolution": "node",
-    "module": "CommonJS",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "outDir": "./build-ts"
-  },
-  "include": ["."],
-  "exclude": ["node_modules"]
+    "compilerOptions": {
+        "target": "ES2018",
+        "strict": true,
+        "moduleResolution": "node",
+        "module": "CommonJS",
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "outDir": "./build-ts"
+    },
+    "include": ["."],
+    "exclude": ["node_modules"]
 }

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -191,7 +191,7 @@ export type ScriptOptions = {
 };
 
 function getRequestErrorClass(
-    type: response.RequestErrorType | null | undefined
+    type: response.RequestErrorType | null | undefined,
 ): typeof RequestError {
     if (type === response.RequestErrorType.Disconnect) {
         return ConnectionError;
@@ -216,7 +216,7 @@ export class BaseClient {
     private socket: net.Socket;
     private readonly promiseCallbackFunctions: [
         PromiseFunction,
-        ErrorFunction
+        ErrorFunction,
     ][] = [];
     private readonly availableCallbackSlots: number[] = [];
     private requestWriter = new BufferWriter();
@@ -263,10 +263,10 @@ export class BaseClient {
 
             if (message.requestError != null) {
                 const errorType = getRequestErrorClass(
-                    message.requestError.type
+                    message.requestError.type,
                 );
                 reject(
-                    new errorType(message.requestError.message ?? undefined)
+                    new errorType(message.requestError.message ?? undefined),
                 );
             } else if (message.respPointer != null) {
                 const pointer = message.respPointer;
@@ -293,7 +293,7 @@ export class BaseClient {
      */
     protected constructor(
         socket: net.Socket,
-        options?: BaseClientConfiguration
+        options?: BaseClientConfiguration,
     ) {
         // if logger has been initialized by the external-user on info level this log will be shown
         Logger.log("info", "Client lifetime", `construct client`);
@@ -337,11 +337,11 @@ export class BaseClient {
             | redis_request.Command
             | redis_request.Command[]
             | redis_request.ScriptInvocation,
-        route?: redis_request.Routes
+        route?: redis_request.Routes,
     ): Promise<T> {
         if (this.isClosed) {
             throw new ClosingError(
-                "Unable to execute requests; the client is closed. Please create a new client."
+                "Unable to execute requests; the client is closed. Please create a new client.",
             );
         }
 
@@ -358,7 +358,7 @@ export class BaseClient {
             | redis_request.Command
             | redis_request.Command[]
             | redis_request.ScriptInvocation,
-        route?: redis_request.Routes
+        route?: redis_request.Routes,
     ) {
         const message = Array.isArray(command)
             ? redis_request.RedisRequest.create({
@@ -368,27 +368,27 @@ export class BaseClient {
                   }),
               })
             : command instanceof redis_request.Command
-            ? redis_request.RedisRequest.create({
-                  callbackIdx,
-                  singleCommand: command,
-              })
-            : redis_request.RedisRequest.create({
-                  callbackIdx,
-                  scriptInvocation: command,
-              });
+              ? redis_request.RedisRequest.create({
+                    callbackIdx,
+                    singleCommand: command,
+                })
+              : redis_request.RedisRequest.create({
+                    callbackIdx,
+                    scriptInvocation: command,
+                });
         message.route = route;
 
         this.writeOrBufferRequest(
             message,
             (message: redis_request.RedisRequest, writer: Writer) => {
                 redis_request.RedisRequest.encodeDelimited(message, writer);
-            }
+            },
         );
     }
 
     private writeOrBufferRequest<TRequest>(
         message: TRequest,
-        encodeDelimited: (message: TRequest, writer: Writer) => void
+        encodeDelimited: (message: TRequest, writer: Writer) => void,
     ) {
         encodeDelimited(message, this.requestWriter);
 
@@ -422,7 +422,7 @@ export class BaseClient {
     public set(
         key: string,
         value: string,
-        options?: SetOptions
+        options?: SetOptions,
     ): Promise<"OK" | string | null> {
         return this.createWritePromise(createSet(key, value, options));
     }
@@ -535,7 +535,7 @@ export class BaseClient {
      */
     public hset(
         key: string,
-        fieldValueMap: Record<string, string>
+        fieldValueMap: Record<string, string>,
     ): Promise<number> {
         return this.createWritePromise(createHSet(key, fieldValueMap));
     }
@@ -601,7 +601,7 @@ export class BaseClient {
     public hincrBy(
         key: string,
         field: string,
-        amount: number
+        amount: number,
     ): Promise<number> {
         return this.createWritePromise(createHIncrBy(key, field, amount));
     }
@@ -619,14 +619,14 @@ export class BaseClient {
     public hincrByFloat(
         key: string,
         field: string,
-        amount: number
+        amount: number,
     ): Promise<number> {
         return this.createWritePromise(createHIncrByFloat(key, field, amount));
     }
 
     /** Returns the number of fields contained in the hash stored at `key`.
      * See https://redis.io/commands/hlen/ for more details.
-     * 
+     *
      * @param key - The key of the hash.
      * @returns The number of fields in the hash, or 0 when the key does not exist.
      */
@@ -636,8 +636,8 @@ export class BaseClient {
 
     /** Returns all values in the hash stored at key.
      * See https://redis.io/commands/hvals/ for more details.
-     * 
-     * @param key - The key of the hash. 
+     *
+     * @param key - The key of the hash.
      * @returns a list of values in the hash, or an empty list when the key does not exist.
      */
     public hvals(key: string): Promise<string[]> {
@@ -863,7 +863,7 @@ export class BaseClient {
     public expire(
         key: string,
         seconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): Promise<boolean> {
         return this.createWritePromise(createExpire(key, seconds, option));
     }
@@ -883,10 +883,10 @@ export class BaseClient {
     public expireAt(
         key: string,
         unixSeconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): Promise<boolean> {
         return this.createWritePromise(
-            createExpireAt(key, unixSeconds, option)
+            createExpireAt(key, unixSeconds, option),
         );
     }
 
@@ -905,10 +905,10 @@ export class BaseClient {
     public pexpire(
         key: string,
         milliseconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): Promise<boolean> {
         return this.createWritePromise(
-            createPExpire(key, milliseconds, option)
+            createPExpire(key, milliseconds, option),
         );
     }
 
@@ -927,10 +927,10 @@ export class BaseClient {
     public pexpireAt(
         key: string,
         unixMilliseconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): Promise<number> {
         return this.createWritePromise(
-            createPExpireAt(key, unixMilliseconds, option)
+            createPExpireAt(key, unixMilliseconds, option),
         );
     }
 
@@ -964,7 +964,7 @@ export class BaseClient {
      */
     public invokeScript(
         script: Script,
-        option?: ScriptOptions
+        option?: ScriptOptions,
     ): Promise<ReturnType> {
         const scriptInvocation = redis_request.ScriptInvocation.create({
             hash: script.getHash(),
@@ -997,15 +997,15 @@ export class BaseClient {
         key: string,
         membersScoresMap: Record<string, number>,
         options?: ZaddOptions,
-        changed?: boolean
+        changed?: boolean,
     ): Promise<number> {
         return this.createWritePromise(
             createZadd(
                 key,
                 membersScoresMap,
                 options,
-                changed ? "CH" : undefined
-            )
+                changed ? "CH" : undefined,
+            ),
         );
     }
 
@@ -1032,10 +1032,10 @@ export class BaseClient {
         key: string,
         member: string,
         increment: number,
-        options?: ZaddOptions
+        options?: ZaddOptions,
     ): Promise<number | null> {
         return this.createWritePromise(
-            createZadd(key, { [member]: increment }, options, "INCR")
+            createZadd(key, { [member]: increment }, options, "INCR"),
         );
     }
 
@@ -1089,7 +1089,7 @@ export class BaseClient {
     public zcount(
         key: string,
         minScore: ScoreLimit,
-        maxScore: ScoreLimit
+        maxScore: ScoreLimit,
     ): Promise<number> {
         return this.createWritePromise(createZcount(key, minScore, maxScore));
     }
@@ -1128,7 +1128,7 @@ export class BaseClient {
      */
     public zpopmin(
         key: string,
-        count?: number
+        count?: number,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(createZpopmin(key, count));
     }
@@ -1137,7 +1137,7 @@ export class BaseClient {
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
      * See https://redis.io/commands/zpopmax for more details.
-     * 
+     *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
      * @returns A map of the removed members and their scores, ordered from the one with the highest score to the one with the lowest.
@@ -1146,14 +1146,14 @@ export class BaseClient {
      */
     public zpopmax(
         key: string,
-        count?: number
+        count?: number,
     ): Promise<Record<string, number>> {
         return this.createWritePromise(createZpopmax(key, count));
     }
 
     /** Echoes the provided `message` back.
      * See https://redis.io/commands/echo for more details.
-     * 
+     *
      * @param message - The message to be echoed back.
      * @returns The provided `message`.
      */
@@ -1163,7 +1163,7 @@ export class BaseClient {
 
     /** Returns the remaining time to live of `key` that has a timeout, in milliseconds.
      * See https://redis.io/commands/pttl for more details.
-     * 
+     *
      * @param key - The key to return its timeout.
      * @returns TTL in milliseconds. -2 if `key` does not exist, -1 if `key` exists but has no associated expire.
      */
@@ -1198,7 +1198,7 @@ export class BaseClient {
      * @internal
      */
     protected createClientRequest(
-        options: BaseClientConfiguration
+        options: BaseClientConfiguration,
     ): connection_request.IConnectionRequest {
         const readFrom = options.readFrom
             ? this.MAP_READ_FROM_STRATEGY[options.readFrom]
@@ -1236,20 +1236,20 @@ export class BaseClient {
             this.promiseCallbackFunctions[0] = [resolve, reject];
 
             const message = connection_request.ConnectionRequest.create(
-                this.createClientRequest(options)
+                this.createClientRequest(options),
             );
 
             this.writeOrBufferRequest(
                 message,
                 (
                     message: connection_request.ConnectionRequest,
-                    writer: Writer
+                    writer: Writer,
                 ) => {
                     connection_request.ConnectionRequest.encodeDelimited(
                         message,
-                        writer
+                        writer,
                     );
-                }
+                },
             );
         });
     }
@@ -1272,14 +1272,14 @@ export class BaseClient {
      * @internal
      */
     protected static async __createClientInternal<
-        TConnection extends BaseClient
+        TConnection extends BaseClient,
     >(
         options: BaseClientConfiguration,
         connectedSocket: net.Socket,
         constructor: (
             socket: net.Socket,
-            options?: BaseClientConfiguration
-        ) => TConnection
+            options?: BaseClientConfiguration,
+        ) => TConnection,
     ): Promise<TConnection> {
         const connection = constructor(connectedSocket, options);
         await connection.connectToServer(options);
@@ -1307,15 +1307,15 @@ export class BaseClient {
         options: BaseClientConfiguration,
         constructor: (
             socket: net.Socket,
-            options?: BaseClientConfiguration
-        ) => TConnection
+            options?: BaseClientConfiguration,
+        ) => TConnection,
     ): Promise<TConnection> {
         const path = await StartSocketConnection();
         const socket = await this.GetSocket(path);
         return await this.__createClientInternal<TConnection>(
             options,
             socket,
-            constructor
+            constructor,
         );
     }
 }

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -2,10 +2,7 @@
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-import {
-    MAX_REQUEST_ARGS_LEN,
-    createLeakedStringVec,
-} from "glide-rs";
+import { MAX_REQUEST_ARGS_LEN, createLeakedStringVec } from "glide-rs";
 import Long from "long";
 import { redis_request } from "./ProtobufMessage";
 import RequestType = redis_request.RequestType;
@@ -44,7 +41,7 @@ export function parseInfoResponse(response: string): Record<string, string> {
 
 function createCommand(
     requestType: redis_request.RequestType,
-    args: string[]
+    args: string[],
 ): redis_request.Command {
     const singleCommand = redis_request.Command.create({
         requestType,
@@ -118,7 +115,7 @@ export type SetOptions = {
 export function createSet(
     key: string,
     value: string,
-    options?: SetOptions
+    options?: SetOptions,
 ): redis_request.Command {
     const args = [key, value];
 
@@ -140,8 +137,8 @@ export function createSet(
         ) {
             throw new Error(
                 `Received expiry '${JSON.stringify(
-                    options.expiry
-                )}'. Count must be an integer`
+                    options.expiry,
+                )}'. Count must be an integer`,
             );
         }
 
@@ -298,7 +295,7 @@ export function createMGet(keys: string[]): redis_request.Command {
  * @internal
  */
 export function createMSet(
-    keyValueMap: Record<string, string>
+    keyValueMap: Record<string, string>,
 ): redis_request.Command {
     return createCommand(RequestType.MSet, Object.entries(keyValueMap).flat());
 }
@@ -315,7 +312,7 @@ export function createIncr(key: string): redis_request.Command {
  */
 export function createIncrBy(
     key: string,
-    amount: number
+    amount: number,
 ): redis_request.Command {
     return createCommand(RequestType.IncrBy, [key, amount.toString()]);
 }
@@ -325,7 +322,7 @@ export function createIncrBy(
  */
 export function createIncrByFloat(
     key: string,
-    amount: number
+    amount: number,
 ): redis_request.Command {
     return createCommand(RequestType.IncrByFloat, [key, amount.toString()]);
 }
@@ -348,11 +345,11 @@ export function createConfigGet(parameters: string[]): redis_request.Command {
  * @internal
  */
 export function createConfigSet(
-    parameters: Record<string, string>
+    parameters: Record<string, string>,
 ): redis_request.Command {
     return createCommand(
         RequestType.ConfigSet,
-        Object.entries(parameters).flat()
+        Object.entries(parameters).flat(),
     );
 }
 
@@ -368,11 +365,11 @@ export function createHGet(key: string, field: string): redis_request.Command {
  */
 export function createHSet(
     key: string,
-    fieldValueMap: Record<string, string>
+    fieldValueMap: Record<string, string>,
 ): redis_request.Command {
     return createCommand(
         RequestType.HashSet,
-        [key].concat(Object.entries(fieldValueMap).flat())
+        [key].concat(Object.entries(fieldValueMap).flat()),
     );
 }
 
@@ -388,7 +385,7 @@ export function createDecr(key: string): redis_request.Command {
  */
 export function createDecrBy(
     key: string,
-    amount: number
+    amount: number,
 ): redis_request.Command {
     return createCommand(RequestType.DecrBy, [key, amount.toString()]);
 }
@@ -398,7 +395,7 @@ export function createDecrBy(
  */
 export function createHDel(
     key: string,
-    fields: string[]
+    fields: string[],
 ): redis_request.Command {
     return createCommand(RequestType.HashDel, [key].concat(fields));
 }
@@ -408,7 +405,7 @@ export function createHDel(
  */
 export function createHMGet(
     key: string,
-    fields: string[]
+    fields: string[],
 ): redis_request.Command {
     return createCommand(RequestType.HashMGet, [key].concat(fields));
 }
@@ -418,7 +415,7 @@ export function createHMGet(
  */
 export function createHExists(
     key: string,
-    field: string
+    field: string,
 ): redis_request.Command {
     return createCommand(RequestType.HashExists, [key, field]);
 }
@@ -435,7 +432,7 @@ export function createHGetAll(key: string): redis_request.Command {
  */
 export function createLPush(
     key: string,
-    elements: string[]
+    elements: string[],
 ): redis_request.Command {
     return createCommand(RequestType.LPush, [key].concat(elements));
 }
@@ -454,7 +451,7 @@ export function createLPop(key: string, count?: number): redis_request.Command {
 export function createLRange(
     key: string,
     start: number,
-    end: number
+    end: number,
 ): redis_request.Command {
     return createCommand(RequestType.LRange, [
         key,
@@ -476,7 +473,7 @@ export function createLLen(key: string): redis_request.Command {
 export function createLTrim(
     key: string,
     start: number,
-    end: number
+    end: number,
 ): redis_request.Command {
     return createCommand(RequestType.LTrim, [
         key,
@@ -491,7 +488,7 @@ export function createLTrim(
 export function createLRem(
     key: string,
     count: number,
-    element: string
+    element: string,
 ): redis_request.Command {
     return createCommand(RequestType.LRem, [key, count.toString(), element]);
 }
@@ -501,7 +498,7 @@ export function createLRem(
  */
 export function createRPush(
     key: string,
-    elements: string[]
+    elements: string[],
 ): redis_request.Command {
     return createCommand(RequestType.RPush, [key].concat(elements));
 }
@@ -519,7 +516,7 @@ export function createRPop(key: string, count?: number): redis_request.Command {
  */
 export function createSAdd(
     key: string,
-    members: string[]
+    members: string[],
 ): redis_request.Command {
     return createCommand(RequestType.SAdd, [key].concat(members));
 }
@@ -529,7 +526,7 @@ export function createSAdd(
  */
 export function createSRem(
     key: string,
-    members: string[]
+    members: string[],
 ): redis_request.Command {
     return createCommand(RequestType.SRem, [key].concat(members));
 }
@@ -561,7 +558,7 @@ export function createCustomCommand(args: string[]) {
 export function createHIncrBy(
     key: string,
     field: string,
-    amount: number
+    amount: number,
 ): redis_request.Command {
     return createCommand(RequestType.HashIncrBy, [
         key,
@@ -576,7 +573,7 @@ export function createHIncrBy(
 export function createHIncrByFloat(
     key: string,
     field: string,
-    amount: number
+    amount: number,
 ): redis_request.Command {
     return createCommand(RequestType.HashIncrByFloat, [
         key,
@@ -638,7 +635,7 @@ export enum ExpireOptions {
 export function createExpire(
     key: string,
     seconds: number,
-    option?: ExpireOptions
+    option?: ExpireOptions,
 ): redis_request.Command {
     const args: string[] =
         option == undefined
@@ -653,7 +650,7 @@ export function createExpire(
 export function createExpireAt(
     key: string,
     unixSeconds: number,
-    option?: ExpireOptions
+    option?: ExpireOptions,
 ): redis_request.Command {
     const args: string[] =
         option == undefined
@@ -668,7 +665,7 @@ export function createExpireAt(
 export function createPExpire(
     key: string,
     milliseconds: number,
-    option?: ExpireOptions
+    option?: ExpireOptions,
 ): redis_request.Command {
     const args: string[] =
         option == undefined
@@ -683,7 +680,7 @@ export function createPExpire(
 export function createPExpireAt(
     key: string,
     unixMilliseconds: number,
-    option?: ExpireOptions
+    option?: ExpireOptions,
 ): redis_request.Command {
     const args: string[] =
         option == undefined
@@ -721,7 +718,7 @@ export function createZadd(
     key: string,
     membersScoresMap: Record<string, number>,
     options?: ZaddOptions,
-    changedOrIncr?: "CH" | "INCR"
+    changedOrIncr?: "CH" | "INCR",
 ): redis_request.Command {
     let args = [key];
 
@@ -731,7 +728,7 @@ export function createZadd(
         } else if (options.conditionalChange === "onlyIfDoesNotExist") {
             if (options.updateOptions) {
                 throw new Error(
-                    `The GT, LT, and NX options are mutually exclusive. Cannot choose both ${options.updateOptions} and NX.`
+                    `The GT, LT, and NX options are mutually exclusive. Cannot choose both ${options.updateOptions} and NX.`,
                 );
             }
 
@@ -753,7 +750,7 @@ export function createZadd(
         Object.entries(membersScoresMap).flatMap(([key, value]) => [
             value.toString(),
             key,
-        ])
+        ]),
     );
     return createCommand(RequestType.Zadd, args);
 }
@@ -763,7 +760,7 @@ export function createZadd(
  */
 export function createZrem(
     key: string,
-    members: string[]
+    members: string[],
 ): redis_request.Command {
     return createCommand(RequestType.Zrem, [key].concat(members));
 }
@@ -778,7 +775,10 @@ export function createZcard(key: string): redis_request.Command {
 /**
  * @internal
  */
-export function createZscore(key: string, member: string): redis_request.Command {
+export function createZscore(
+    key: string,
+    member: string,
+): redis_request.Command {
     return createCommand(RequestType.ZScore, [key, member]);
 }
 
@@ -800,7 +800,7 @@ const isInclusiveArg = "(";
 export function createZcount(
     key: string,
     minScore: ScoreLimit,
-    maxScore: ScoreLimit
+    maxScore: ScoreLimit,
 ): redis_request.Command {
     const args = [key];
 
@@ -827,9 +827,9 @@ export function createZcount(
                 : maxScore.bound.toString();
         args.push(value);
     }
-    
+
     return createCommand(RequestType.Zcount, args);
-}    
+}
 
 /**
  * @internal
@@ -850,7 +850,7 @@ export function createStrlen(key: string): redis_request.Command {
  */
 export function createLindex(
     key: string,
-    index: number
+    index: number,
 ): redis_request.Command {
     return createCommand(RequestType.Lindex, [key, index.toString()]);
 }
@@ -858,7 +858,10 @@ export function createLindex(
 /**
  * @internal
  */
-export function createZpopmin(key: string, count?: number): redis_request.Command {
+export function createZpopmin(
+    key: string,
+    count?: number,
+): redis_request.Command {
     const args: string[] = count == undefined ? [key] : [key, count.toString()];
     return createCommand(RequestType.ZPopMin, args);
 }
@@ -866,7 +869,10 @@ export function createZpopmin(key: string, count?: number): redis_request.Comman
 /**
  * @internal
  */
-export function createZpopmax(key: string, count?: number): redis_request.Command {
+export function createZpopmax(
+    key: string,
+    count?: number,
+): redis_request.Command {
     const args: string[] = count == undefined ? [key] : [key, count.toString()];
     return createCommand(RequestType.ZPopMax, args);
 }

--- a/node/src/Logger.ts
+++ b/node/src/Logger.ts
@@ -40,7 +40,7 @@ export class Logger {
     public static log(
         logLevel: LevelOptions,
         logIdentifier: string,
-        message: string
+        message: string,
     ) {
         if (!Logger._instance) {
             new Logger();

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -62,7 +62,7 @@ export class RedisClient extends BaseClient {
      * @internal
      */
     protected createClientRequest(
-        options: RedisClientConfiguration
+        options: RedisClientConfiguration,
     ): connection_request.IConnectionRequest {
         const configuration = super.createClientRequest(options);
         configuration.databaseId = options.databaseId;
@@ -71,22 +71,22 @@ export class RedisClient extends BaseClient {
     }
 
     public static createClient(
-        options: RedisClientConfiguration
+        options: RedisClientConfiguration,
     ): Promise<RedisClient> {
         return super.createClientInternal<RedisClient>(
             options,
-            (socket: net.Socket) => new RedisClient(socket)
+            (socket: net.Socket) => new RedisClient(socket),
         );
     }
 
     static async __createClient(
         options: BaseClientConfiguration,
-        connectedSocket: net.Socket
+        connectedSocket: net.Socket,
     ): Promise<RedisClient> {
         return this.__createClientInternal(
             options,
             connectedSocket,
-            (socket, options) => new RedisClient(socket, options)
+            (socket, options) => new RedisClient(socket, options),
         );
     }
 
@@ -121,7 +121,7 @@ export class RedisClient extends BaseClient {
     /** Ping the Redis server.
      * See https://redis.io/commands/ping/ for details.
      *
-     * @param message - An optional message to include in the PING command. 
+     * @param message - An optional message to include in the PING command.
      * If not provided, the server will respond with "PONG".
      * If provided, the server will respond with a copy of the message.
      * @returns - "PONG" if `message` is not provided, otherwise return a copy of `message`.

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -93,7 +93,7 @@ export type SingleNodeRoute =
     | RouteByAddress;
 
 function toProtobufRoute(
-    route: Routes | undefined
+    route: Routes | undefined,
 ): redis_request.Routes | undefined {
     if (route === undefined) {
         return undefined;
@@ -149,7 +149,7 @@ function toProtobufRoute(
             if (split.length !== 2) {
                 throw new RequestError(
                     "No port provided, expected host to be formatted as `{hostname}:{port}`. Received " +
-                        host
+                        host,
                 );
             }
 
@@ -173,7 +173,7 @@ export class RedisClusterClient extends BaseClient {
      * @internal
      */
     protected createClientRequest(
-        options: ClusterClientConfiguration
+        options: ClusterClientConfiguration,
     ): connection_request.IConnectionRequest {
         const configuration = super.createClientRequest(options);
         configuration.clusterModeEnabled = true;
@@ -181,23 +181,23 @@ export class RedisClusterClient extends BaseClient {
     }
 
     public static async createClient(
-        options: ClusterClientConfiguration
+        options: ClusterClientConfiguration,
     ): Promise<RedisClusterClient> {
         return await super.createClientInternal(
             options,
             (socket: net.Socket, options?: ClusterClientConfiguration) =>
-                new RedisClusterClient(socket, options)
+                new RedisClusterClient(socket, options),
         );
     }
 
     static async __createClient(
         options: BaseClientConfiguration,
-        connectedSocket: net.Socket
+        connectedSocket: net.Socket,
     ): Promise<RedisClusterClient> {
         return super.__createClientInternal(
             options,
             connectedSocket,
-            (socket, options) => new RedisClusterClient(socket, options)
+            (socket, options) => new RedisClusterClient(socket, options),
         );
     }
 
@@ -233,11 +233,11 @@ export class RedisClusterClient extends BaseClient {
      */
     public exec(
         transaction: ClusterTransaction,
-        route?: SingleNodeRoute
+        route?: SingleNodeRoute,
     ): Promise<ReturnType[] | null> {
         return this.createWritePromise(
             transaction.commands,
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -254,7 +254,7 @@ export class RedisClusterClient extends BaseClient {
     public ping(message?: string, route?: Routes): Promise<string> {
         return this.createWritePromise(
             createPing(message),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -270,11 +270,11 @@ export class RedisClusterClient extends BaseClient {
      */
     public info(
         options?: InfoOptions[],
-        route?: Routes
+        route?: Routes,
     ): Promise<ClusterResponse<string>> {
         return this.createWritePromise<ClusterResponse<string>>(
             createInfo(options),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -289,11 +289,11 @@ export class RedisClusterClient extends BaseClient {
      * its corresponding node response is the value.
      */
     public clientGetName(
-        route?: Routes
+        route?: Routes,
     ): Promise<ClusterResponse<string | null>> {
         return this.createWritePromise<ClusterResponse<string | null>>(
             createClientGetName(),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -308,7 +308,7 @@ export class RedisClusterClient extends BaseClient {
     public configRewrite(route?: Routes): Promise<"OK"> {
         return this.createWritePromise(
             createConfigRewrite(),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -323,7 +323,7 @@ export class RedisClusterClient extends BaseClient {
     public configResetStat(route?: Routes): Promise<"OK"> {
         return this.createWritePromise(
             createConfigResetStat(),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -338,7 +338,7 @@ export class RedisClusterClient extends BaseClient {
     public clientId(route?: Routes): Promise<ClusterResponse<number>> {
         return this.createWritePromise<ClusterResponse<number>>(
             createClientId(),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -355,11 +355,11 @@ export class RedisClusterClient extends BaseClient {
      */
     public configGet(
         parameters: string[],
-        route?: Routes
+        route?: Routes,
     ): Promise<ClusterResponse<Record<string, string>>> {
         return this.createWritePromise<ClusterResponse<Record<string, string>>>(
             createConfigGet(parameters),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 
@@ -379,11 +379,11 @@ export class RedisClusterClient extends BaseClient {
      */
     public configSet(
         parameters: Record<string, string>,
-        route?: Routes
+        route?: Routes,
     ): Promise<"OK"> {
         return this.createWritePromise(
             createConfigSet(parameters),
-            toProtobufRoute(route)
+            toProtobufRoute(route),
         );
     }
 }

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -129,7 +129,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     /** Ping the Redis server.
      * See https://redis.io/commands/ping/ for details.
      *
-     * @param message - An optional message to include in the PING command. 
+     * @param message - An optional message to include in the PING command.
      * If not provided, the server will respond with "PONG".
      * If provided, the server will respond with a copy of the message.
      *
@@ -419,9 +419,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the number of fields contained in the hash stored at `key`.
      * See https://redis.io/commands/hlen/ for more details.
-     * 
+     *
      * @param key - The key of the hash.
-     * 
+     *
      * Command Response - The number of fields in the hash, or 0 when the key does not exist.
      */
     public hlen(key: string): T {
@@ -430,9 +430,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns all values in the hash stored at key.
      * See https://redis.io/commands/hvals/ for more details.
-     * 
-     * @param key - The key of the hash. 
-     * 
+     *
+     * @param key - The key of the hash.
+     *
      * Command Response - a list of values in the hash, or an empty list when the key does not exist.
      */
     public hvals(key: string): T {
@@ -458,7 +458,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * See https://redis.io/commands/lpop/ for details.
      *
      * @param key - The key of the list.
-     * 
+     *
      * Command Response - The value of the first element.
      * If `key` does not exist null will be returned.
      */
@@ -471,7 +471,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
-     * 
+     *
      * Command Response - A list of the popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      */
@@ -564,7 +564,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * See https://redis.io/commands/rpop/ for details.
      *
      * @param key - The key of the list.
-     * 
+     *
      * Command Response - The value of the last element.
      * If `key` does not exist null will be returned.
      */
@@ -577,7 +577,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @param key - The key of the list.
      * @param count - The count of the elements to pop from the list.
-     * 
+     *
      * Command Response - A list of popped elements will be returned depending on the list's length.
      * If `key` does not exist null will be returned.
      */
@@ -692,7 +692,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public expireAt(
         key: string,
         unixSeconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): T {
         return this.addAndReturn(createExpireAt(key, unixSeconds, option));
     }
@@ -713,7 +713,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public pexpire(
         key: string,
         milliseconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): T {
         return this.addAndReturn(createPExpire(key, milliseconds, option));
     }
@@ -734,10 +734,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
     public pexpireAt(
         key: string,
         unixMilliseconds: number,
-        option?: ExpireOptions
+        option?: ExpireOptions,
     ): T {
         return this.addAndReturn(
-            createPExpireAt(key, unixMilliseconds, option)
+            createPExpireAt(key, unixMilliseconds, option),
         );
     }
 
@@ -768,15 +768,15 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         key: string,
         membersScoresMap: Record<string, number>,
         options?: ZaddOptions,
-        changed?: boolean
+        changed?: boolean,
     ): T {
         return this.addAndReturn(
             createZadd(
                 key,
                 membersScoresMap,
                 options,
-                changed ? "CH" : undefined
-            )
+                changed ? "CH" : undefined,
+            ),
         );
     }
 
@@ -797,10 +797,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
         key: string,
         member: string,
         increment: number,
-        options?: ZaddOptions
+        options?: ZaddOptions,
     ): T {
         return this.addAndReturn(
-            createZadd(key, { [member]: increment }, options, "INCR")
+            createZadd(key, { [member]: increment }, options, "INCR"),
         );
     }
 
@@ -861,9 +861,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the string representation of the type of the value stored at `key`.
      * See https://redis.io/commands/type/ for more details.
-     * 
+     *
      * @param key - The key to check its data type.
-     * 
+     *
      * Command Response - If the key exists, the type of the stored value is returned. Otherwise, a "none" string is returned.
      */
     public type(key: string): T {
@@ -874,7 +874,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * See https://redis.io/commands/strlen/ for more details.
      *
      * @param key - The `key` to check its length.
-     * 
+     *
      * Command Response - The length of the string value stored at `key`
      * If `key` does not exist, it is treated as an empty string, and the command returns 0.
      */
@@ -902,10 +902,10 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `count` is provided, up to `count` members with the highest scores are removed and returned.
      * Otherwise, only one member with the highest score is removed and returned.
      * See https://redis.io/commands/zpopmax for more details.
-     * 
+     *
      * @param key - The key of the sorted set.
      * @param count - Specifies the quantity of members to pop. If not specified, pops one member.
-     * 
+     *
      * Command Response - A map of the removed members and their scores, ordered from the one with the highest score to the one with the lowest.
      * If `key` doesn't exist, it will be treated as an empty sorted set and the command returns an empty map.
      * If `count` is higher than the sorted set's cardinality, returns all members and their scores, ordered from highest to lowest.
@@ -916,9 +916,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Echoes the provided `message` back.
      * See https://redis.io/commands/echo for more details.
-     * 
+     *
      * @param message - The message to be echoed back.
-     * 
+     *
      * Command Response - The provided `message`.
      */
     public echo(message: string): T {
@@ -927,9 +927,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
 
     /** Returns the remaining time to live of `key` that has a timeout, in milliseconds.
      * See https://redis.io/commands/pttl for more details.
-     * 
+     *
      * @param key - The key to return its timeout.
-     * 
+     *
      * Command Response - TTL in milliseconds. -2 if `key` does not exist, -1 if `key` exists but has no associated expire.
      */
     public pttl(key: string): T {

--- a/node/tests/AsyncClient.test.ts
+++ b/node/tests/AsyncClient.test.ts
@@ -19,7 +19,7 @@ describe("AsyncClient", () => {
     let port: number;
     beforeAll(async () => {
         port = await FreePort(PORT_NUMBER).then(
-            ([free_port]: number[]) => free_port
+            ([free_port]: number[]) => free_port,
         );
         server = await new Promise((resolve, reject) => {
             const server = new RedisServer(port);
@@ -44,7 +44,7 @@ describe("AsyncClient", () => {
     runCommonTests<EmptyObject>({
         init: async () => {
             const client = await AsyncClient.CreateConnection(
-                "redis://localhost:" + port
+                "redis://localhost:" + port,
             );
 
             return { client, context: {} };

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -46,7 +46,7 @@ describe("RedisClient", () => {
         if (testsFailed === 0) {
             await cluster.close();
         }
-    });
+    }, TIMEOUT);
 
     const getAddress = (port: number) => {
         return [{ host: "localhost", port }];

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -54,7 +54,7 @@ describe("RedisClient", () => {
 
     const getOptions = (
         port: number,
-        protocol: ProtocolVersion
+        protocol: ProtocolVersion,
     ): BaseClientConfiguration => {
         return {
             addresses: getAddress(port),
@@ -111,23 +111,23 @@ describe("RedisClient", () => {
         "info without parameters",
         async (protocol) => {
             const client = await RedisClient.createClient(
-                getOptions(port, protocol)
+                getOptions(port, protocol),
             );
             const result = await client.info();
             expect(result).toEqual(expect.stringContaining("# Server"));
             expect(result).toEqual(expect.stringContaining("# Replication"));
             expect(result).toEqual(
-                expect.not.stringContaining("# Latencystats")
+                expect.not.stringContaining("# Latencystats"),
             );
             client.close();
-        }
+        },
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "simple select test",
         async (protocol) => {
             const client = await RedisClient.createClient(
-                getOptions(port, protocol)
+                getOptions(port, protocol),
             );
             let selectResult = await client.select(0);
             expect(selectResult).toEqual("OK");
@@ -145,14 +145,14 @@ describe("RedisClient", () => {
             expect(selectResult).toEqual("OK");
             expect(await client.get(key)).toEqual(value);
             client.close();
-        }
+        },
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `can send transactions_%p`,
         async (protocol) => {
             const client = await RedisClient.createClient(
-                getOptions(port, protocol)
+                getOptions(port, protocol),
             );
             const transaction = new Transaction();
             const expectedRes = transactionTest(transaction);
@@ -161,17 +161,17 @@ describe("RedisClient", () => {
             expectedRes.push("OK");
             expect(result).toEqual(expectedRes);
             client.close();
-        }
+        },
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         "can return null on WATCH transaction failures",
         async (protocol) => {
             const client1 = await RedisClient.createClient(
-                getOptions(port, protocol)
+                getOptions(port, protocol),
             );
             const client2 = await RedisClient.createClient(
-                getOptions(port, protocol)
+                getOptions(port, protocol),
             );
             const transaction = new Transaction();
             transaction.get("key");
@@ -186,7 +186,7 @@ describe("RedisClient", () => {
 
             client1.close();
             client2.close();
-        }
+        },
     );
 
     runBaseTests<Context>({

--- a/node/tests/RedisClientInternals.test.ts
+++ b/node/tests/RedisClientInternals.test.ts
@@ -72,7 +72,7 @@ function createLeakedValue(value: ReturnType): Long {
         if ("attributes" in value) {
             pair = createLeakedAttribute(
                 value.value as string,
-                value.attributes as Record<string, string>
+                value.attributes as Record<string, string>,
             );
         } else {
             pair = createLeakedMap(value as Record<string, string>);
@@ -94,7 +94,7 @@ function sendResponse(
         message?: string;
         value?: ReturnType;
         requestErrorType?: response.RequestErrorType;
-    }
+    },
 ) {
     const new_response = response.Response.create();
     new_response.callbackIdx = callbackIndex;
@@ -125,7 +125,7 @@ function sendResponse(
 function getConnectionAndSocket(
     checkRequest?: (request: connection_request.ConnectionRequest) => boolean,
     connectionOptions?: ClusterClientConfiguration | RedisClientConfiguration,
-    isCluster?: boolean
+    isCluster?: boolean,
 ): Promise<{
     socket: net.Socket;
     connection: RedisClient | RedisClusterClient;
@@ -133,7 +133,7 @@ function getConnectionAndSocket(
 }> {
     return new Promise((resolve, reject) => {
         const temporaryFolder = fs.mkdtempSync(
-            path.join(os.tmpdir(), `socket_listener`)
+            path.join(os.tmpdir(), `socket_listener`),
         );
         const socketName = path.join(temporaryFolder, "read");
         let connectionPromise: Promise<RedisClient | RedisClusterClient>; // eslint-disable-line prefer-const
@@ -143,12 +143,12 @@ function getConnectionAndSocket(
                     const reader = Reader.create(data);
                     const request =
                         connection_request.ConnectionRequest.decodeDelimited(
-                            reader
+                            reader,
                         );
 
                     if (checkRequest && !checkRequest(request)) {
                         reject(
-                            `${JSON.stringify(request)}  did not pass condition`
+                            `${JSON.stringify(request)}  did not pass condition`,
                         );
                     }
 
@@ -186,7 +186,7 @@ function getConnectionAndSocket(
 function closeTestResources(
     connection: RedisClient | RedisClusterClient,
     server: net.Server,
-    socket: net.Socket
+    socket: net.Socket,
 ) {
     connection.close();
     server.close();
@@ -196,13 +196,13 @@ function closeTestResources(
 async function testWithResources(
     testFunction: (
         connection: RedisClient | RedisClusterClient,
-        socket: net.Socket
+        socket: net.Socket,
     ) => Promise<void>,
-    connectionOptions?: BaseClientConfiguration
+    connectionOptions?: BaseClientConfiguration,
 ) {
     const { connection, server, socket } = await getConnectionAndSocket(
         undefined,
-        connectionOptions
+        connectionOptions,
     );
 
     await testFunction(connection, socket);
@@ -213,14 +213,14 @@ async function testWithResources(
 async function testWithClusterResources(
     testFunction: (
         connection: RedisClusterClient,
-        socket: net.Socket
+        socket: net.Socket,
     ) => Promise<void>,
-    connectionOptions?: BaseClientConfiguration
+    connectionOptions?: BaseClientConfiguration,
 ) {
     const { connection, server, socket } = await getConnectionAndSocket(
         undefined,
         connectionOptions,
-        true
+        true,
     );
 
     try {
@@ -261,10 +261,10 @@ describe("SocketConnectionInternals", () => {
                     const reader = Reader.create(data);
                     const request = RedisRequest.decodeDelimited(reader);
                     expect(request.singleCommand?.requestType).toEqual(
-                        RequestType.GetString
+                        RequestType.GetString,
                     );
                     expect(
-                        request.singleCommand?.argsArray?.args?.length
+                        request.singleCommand?.argsArray?.args?.length,
                     ).toEqual(1);
 
                     sendResponse(
@@ -273,7 +273,7 @@ describe("SocketConnectionInternals", () => {
                         request.callbackIdx,
                         {
                             value: expected,
-                        }
+                        },
                     );
                 });
                 const result = await connection.get("foo");
@@ -315,10 +315,10 @@ describe("SocketConnectionInternals", () => {
                 const reader = Reader.create(data);
                 const request = RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 expect(request.singleCommand?.argsArray?.args?.length).toEqual(
-                    1
+                    1,
                 );
 
                 sendResponse(socket, ResponseType.Null, request.callbackIdx);
@@ -335,11 +335,11 @@ describe("SocketConnectionInternals", () => {
                 const request = RedisRequest.decodeDelimited(reader);
 
                 expect(
-                    request.transaction?.commands?.at(0)?.requestType
+                    request.transaction?.commands?.at(0)?.requestType,
                 ).toEqual(RequestType.SetString);
                 expect(
                     request.transaction?.commands?.at(0)?.argsArray?.args
-                        ?.length
+                        ?.length,
                 ).toEqual(2);
                 expect(request.route?.slotKeyRoute?.slotKey).toEqual("key");
                 expect(request.route?.slotKeyRoute?.slotType).toEqual(0); // Primary = 0
@@ -364,14 +364,14 @@ describe("SocketConnectionInternals", () => {
                 const request = RedisRequest.decodeDelimited(reader);
 
                 expect(
-                    request.transaction?.commands?.at(0)?.requestType
+                    request.transaction?.commands?.at(0)?.requestType,
                 ).toEqual(RequestType.Info);
                 expect(
                     request.transaction?.commands?.at(0)?.argsArray?.args
-                        ?.length
+                        ?.length,
                 ).toEqual(1);
                 expect(request.route?.simpleRoutes).toEqual(
-                    redis_request.SimpleRoutes.Random
+                    redis_request.SimpleRoutes.Random,
                 );
 
                 sendResponse(socket, ResponseType.Value, request.callbackIdx, {
@@ -391,10 +391,10 @@ describe("SocketConnectionInternals", () => {
                 const reader = Reader.create(data);
                 const request = RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.SetString
+                    RequestType.SetString,
                 );
                 expect(request.singleCommand?.argsArray?.args?.length).toEqual(
-                    2
+                    2,
                 );
 
                 sendResponse(socket, ResponseType.OK, request.callbackIdx);
@@ -411,16 +411,16 @@ describe("SocketConnectionInternals", () => {
                 const reader = Reader.create(data);
                 const request = RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 expect(request.singleCommand?.argsArray?.args?.length).toEqual(
-                    1
+                    1,
                 );
                 sendResponse(
                     socket,
                     ResponseType.RequestError,
                     request.callbackIdx,
-                    { message: error }
+                    { message: error },
                 );
             });
             const request = connection.get("foo");
@@ -436,16 +436,16 @@ describe("SocketConnectionInternals", () => {
                 const reader = Reader.create(data);
                 const request = RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 expect(request.singleCommand?.argsArray?.args?.length).toEqual(
-                    1
+                    1,
                 );
                 sendResponse(
                     socket,
                     ResponseType.ClosingError,
                     request.callbackIdx,
-                    { message: error }
+                    { message: error },
                 );
             });
             const request1 = connection.get("foo");
@@ -464,13 +464,13 @@ describe("SocketConnectionInternals", () => {
                 const request =
                     redis_request.RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 sendResponse(
                     socket,
                     ResponseType.ClosingError,
                     Number.MAX_SAFE_INTEGER,
-                    { message: error }
+                    { message: error },
                 );
             });
             const request1 = connection.get("foo");
@@ -487,7 +487,7 @@ describe("SocketConnectionInternals", () => {
                 const reader = Reader.create(data);
                 const request = RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.SetString
+                    RequestType.SetString,
                 );
                 const args = request.singleCommand?.argsArray?.args;
 
@@ -520,7 +520,7 @@ describe("SocketConnectionInternals", () => {
                 const request =
                     redis_request.RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 expect(request.singleCommand?.argsVecPointer).not.toBeNull();
                 expect(request.singleCommand?.argsArray).toBeNull();
@@ -541,7 +541,7 @@ describe("SocketConnectionInternals", () => {
                 const request =
                     redis_request.RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.GetString
+                    RequestType.GetString,
                 );
                 expect(request.singleCommand?.argsArray).not.toBeNull();
                 expect(request.singleCommand?.argsVecPointer).toBeNull();
@@ -565,7 +565,7 @@ describe("SocketConnectionInternals", () => {
             {
                 addresses: [{ host: "foo" }],
                 credentials: { username, password },
-            }
+            },
         );
         closeTestResources(connection, server, socket);
     });
@@ -577,7 +577,7 @@ describe("SocketConnectionInternals", () => {
             {
                 addresses: [{ host: "foo" }],
                 databaseId: 42,
-            }
+            },
         );
         closeTestResources(connection, server, socket);
     });
@@ -594,12 +594,12 @@ describe("SocketConnectionInternals", () => {
                 const request =
                     redis_request.RedisRequest.decodeDelimited(reader);
                 expect(request.singleCommand?.requestType).toEqual(
-                    RequestType.CustomCommand
+                    RequestType.CustomCommand,
                 );
 
                 if (request.singleCommand?.argsArray?.args?.at(0) === "SET") {
                     expect(request.route?.simpleRoutes).toEqual(
-                        redis_request.SimpleRoutes.AllPrimaries
+                        redis_request.SimpleRoutes.AllPrimaries,
                     );
                 } else if (
                     request.singleCommand?.argsArray?.args?.at(0) === "GET"
@@ -616,13 +616,13 @@ describe("SocketConnectionInternals", () => {
             });
             const result1 = await connection.customCommand(
                 ["SET", "foo", "bar"],
-                route1
+                route1,
             );
             expect(result1).toBeNull();
 
             const result2 = await connection.customCommand(
                 ["GET", "foo"],
-                route2
+                route2,
             );
             expect(result2).toBeNull();
         });

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -50,7 +50,7 @@ describe("RedisClusterClient", () => {
 
     const getOptions = (
         ports: number[],
-        protocol: ProtocolVersion
+        protocol: ProtocolVersion,
     ): BaseClientConfiguration => {
         return {
             addresses: ports.map((port) => ({
@@ -89,10 +89,10 @@ describe("RedisClusterClient", () => {
         `info with server and replication_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const info_server = getFirstResult(
-                await client.info([InfoOptions.Server])
+                await client.info([InfoOptions.Server]),
             );
             expect(info_server).toEqual(expect.stringContaining("# Server"));
 
@@ -104,46 +104,46 @@ describe("RedisClusterClient", () => {
                 "NODES",
             ]);
             expect(
-                (clusterNodes as string)?.split("master").length - 1
+                (clusterNodes as string)?.split("master").length - 1,
             ).toEqual(Object.keys(result).length);
             Object.values(result).every((item) => {
                 expect(item).toEqual(expect.stringContaining("# Replication"));
                 expect(item).toEqual(
-                    expect.not.stringContaining("# Errorstats")
+                    expect.not.stringContaining("# Errorstats"),
                 );
             });
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `info with server and randomNode route_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const result = await client.info(
                 [InfoOptions.Server],
-                "randomNode"
+                "randomNode",
             );
             expect(typeof result).toEqual("string");
             expect(result).toEqual(expect.stringContaining("# Server"));
             expect(result).toEqual(expect.not.stringContaining("# Errorstats"));
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `route by address reaches correct node_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const result = (await client.customCommand(
                 ["cluster", "nodes"],
-                "randomNode"
+                "randomNode",
             )) as string;
 
             // check that routing without explicit port works
@@ -163,7 +163,7 @@ describe("RedisClusterClient", () => {
                 {
                     type: "routeByAddress",
                     host,
-                }
+                },
             )) as string;
 
             expect(result).toEqual(secondResult);
@@ -177,38 +177,38 @@ describe("RedisClusterClient", () => {
                     type: "routeByAddress",
                     host: host2,
                     port: Number(port),
-                }
+                },
             )) as string;
 
             expect(result).toEqual(thirdResult);
 
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `fail routing by address if no port is provided_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             expect(() =>
                 client.info(undefined, {
                     type: "routeByAddress",
                     host: "foo",
-                })
+                }),
             ).toThrowError();
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `config get and config set transactions test_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const transaction = new ClusterTransaction();
             transaction.configSet({ timeout: "1000" });
@@ -217,14 +217,14 @@ describe("RedisClusterClient", () => {
             expect(result).toEqual(["OK", { timeout: "1000" }]);
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `can send transactions_%p`,
         async (protocol) => {
             const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const transaction = new ClusterTransaction();
             const expectedRes = transactionTest(transaction);
@@ -232,17 +232,17 @@ describe("RedisClusterClient", () => {
             expect(result).toEqual(expectedRes);
             client.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `can return null on WATCH transaction failures_%p`,
         async (protocol) => {
             const client1 = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const client2 = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol)
+                getOptions(cluster.ports(), protocol),
             );
             const transaction = new ClusterTransaction();
             transaction.get("key");
@@ -258,6 +258,6 @@ describe("RedisClusterClient", () => {
             client1.close();
             client2.close();
         },
-        TIMEOUT
+        TIMEOUT,
     );
 });

--- a/node/tests/RedisModules.test.ts
+++ b/node/tests/RedisModules.test.ts
@@ -31,14 +31,14 @@ describe("RedisModules", () => {
     beforeAll(async () => {
         const args = process.argv.slice(2);
         const loadModuleArgs = args.filter((arg) =>
-            arg.startsWith("--load-module=")
+            arg.startsWith("--load-module="),
         );
         const loadModuleValues = loadModuleArgs.map((arg) => arg.split("=")[1]);
         cluster = await RedisCluster.createCluster(
             true,
             3,
             0,
-            loadModuleValues
+            loadModuleValues,
         );
     }, 20000);
 
@@ -87,10 +87,10 @@ describe("RedisModules", () => {
 
     it("simple search test", async () => {
         const client = await RedisClusterClient.createClient(
-            getOptions(cluster.ports())
+            getOptions(cluster.ports()),
         );
         const info = parseInfoResponse(
-            getFirstResult(await client.info([InfoOptions.Modules])).toString()
+            getFirstResult(await client.info([InfoOptions.Modules])).toString(),
         )["module"];
         expect(info).toEqual(expect.stringContaining("search"));
         client.close();
@@ -98,10 +98,10 @@ describe("RedisModules", () => {
 
     it("simple json test", async () => {
         const client = await RedisClusterClient.createClient(
-            getOptions(cluster.ports())
+            getOptions(cluster.ports()),
         );
         const info = parseInfoResponse(
-            getFirstResult(await client.info([InfoOptions.Modules])).toString()
+            getFirstResult(await client.info([InfoOptions.Modules])).toString(),
         )["module"];
         expect(info).toEqual(expect.stringContaining("ReJSON"));
         client.close();

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -42,7 +42,7 @@ export type BaseClient = RedisClient | RedisClusterClient;
 export function runBaseTests<Context>(config: {
     init: (
         protocol: ProtocolVersion,
-        clientName?: string
+        clientName?: string,
     ) => Promise<{
         context: Context;
         client: BaseClient;
@@ -59,7 +59,7 @@ export function runBaseTests<Context>(config: {
     const runTest = async (
         test: (client: BaseClient) => Promise<void>,
         protocol: ProtocolVersion,
-        clientName?: string
+        clientName?: string,
     ) => {
         const { context, client } = await config.init(protocol, clientName);
         let testSucceeded = false;
@@ -88,7 +88,7 @@ export function runBaseTests<Context>(config: {
                 expect(result).toContain("lib-ver=unknown");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -101,12 +101,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.set("foo", "bar")).toThrow();
                 } catch (e) {
                     expect((e as ClosingError).message).toMatch(
-                        "Unable to execute requests; the client is closed. Please create a new client."
+                        "Unable to execute requests; the client is closed. Please create a new client.",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -119,7 +119,7 @@ export function runBaseTests<Context>(config: {
                 expect(result?.proto).toEqual(3);
             }, ProtocolVersion.RESP3);
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -132,7 +132,7 @@ export function runBaseTests<Context>(config: {
                 expect(result?.proto).toEqual(2);
             }, ProtocolVersion.RESP2);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -143,10 +143,10 @@ export function runBaseTests<Context>(config: {
                     expect(await client.clientGetName()).toBe("TEST_CLIENT");
                 },
                 protocol,
-                "TEST_CLIENT"
+                "TEST_CLIENT",
             );
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -169,7 +169,7 @@ export function runBaseTests<Context>(config: {
                 expect(result).toEqual("");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -203,7 +203,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.get(key)).toEqual("foobar");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -223,7 +223,7 @@ export function runBaseTests<Context>(config: {
                 expect(result).toEqual(value);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -257,7 +257,7 @@ export function runBaseTests<Context>(config: {
                 expect(mget_result).toEqual([value1, value2, null]);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -280,7 +280,7 @@ export function runBaseTests<Context>(config: {
                 expect(deletedKeysNum).toEqual(0);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -290,7 +290,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.clientGetName()).toBeNull();
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -299,7 +299,7 @@ export function runBaseTests<Context>(config: {
             await runTest(async (client: BaseClient) => {
                 const serverInfo = await client.info([InfoOptions.Server]);
                 const conf_file = parseInfoResponse(
-                    getFirstResult(serverInfo).toString()
+                    getFirstResult(serverInfo).toString(),
                 )["config_file"];
 
                 if (conf_file.length > 0) {
@@ -310,13 +310,13 @@ export function runBaseTests<Context>(config: {
                         expect(await client.configRewrite()).toThrow();
                     } catch (e) {
                         expect((e as Error).message).toMatch(
-                            "The server is running without a config file"
+                            "The server is running without a config file",
                         );
                     }
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -331,19 +331,19 @@ export function runBaseTests<Context>(config: {
                     Number(
                         parseInfoResponse(getFirstResult(OldResult).toString())[
                             "total_commands_processed"
-                        ]
-                    )
+                        ],
+                    ),
                 ).toBeGreaterThan(1);
                 expect(await client.configResetStat()).toEqual("OK");
                 const result = await client.info([InfoOptions.Stats]);
                 expect(
                     parseInfoResponse(getFirstResult(result).toString())[
                         "total_commands_processed"
-                    ]
+                    ],
                 ).toEqual("1");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -361,11 +361,11 @@ export function runBaseTests<Context>(config: {
                 };
                 expect(await client.mset(keyValueList)).toEqual("OK");
                 expect(
-                    await client.mget([key1, key2, "nonExistingKey", key3])
+                    await client.mget([key1, key2, "nonExistingKey", key3]),
                 ).toEqual([value, value, null, value]);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -382,7 +382,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.get(key)).toEqual("16.5");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -401,7 +401,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.get(key3)).toEqual("-0.5");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -415,7 +415,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.incr(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "value is not an integer"
+                        "value is not an integer",
                     );
                 }
 
@@ -423,7 +423,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.incrBy(key, 1)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "value is not an integer"
+                        "value is not an integer",
                     );
                 }
 
@@ -431,12 +431,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.incrByFloat(key, 1.5)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "value is not a valid float"
+                        "value is not a valid float",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -447,7 +447,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.ping("Hello")).toEqual("Hello");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -455,11 +455,11 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 expect(getFirstResult(await client.clientId())).toBeGreaterThan(
-                    0
+                    0,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -474,7 +474,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.get(key)).toEqual("5");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -492,7 +492,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.get(key2)).toEqual("-3");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -506,7 +506,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.decr(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "value is not an integer"
+                        "value is not an integer",
                     );
                 }
 
@@ -514,12 +514,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.decrBy(key, 3)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "value is not an integer"
+                        "value is not an integer",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -530,7 +530,7 @@ export function runBaseTests<Context>(config: {
                     "timeout",
                 ])) as Record<string, string>;
                 expect(await client.configSet({ timeout: "1000" })).toEqual(
-                    "OK"
+                    "OK",
                 );
                 const currTimeout = (await client.configGet([
                     "timeout",
@@ -540,11 +540,11 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.configSet({
                         timeout: prevTimeout["timeout"],
-                    })
+                    }),
                 ).toEqual("OK");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -563,11 +563,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hget(key, field1)).toEqual(value);
                 expect(await client.hget(key, field2)).toEqual(value);
                 expect(await client.hget(key, "nonExistingField")).toEqual(
-                    null
+                    null,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -589,11 +589,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hdel(key, [field1, field2])).toEqual(2);
                 expect(await client.hdel(key, ["nonExistingField"])).toEqual(0);
                 expect(await client.hdel("nonExistingKey", [field3])).toEqual(
-                    0
+                    0,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -614,14 +614,14 @@ export function runBaseTests<Context>(config: {
                         field1,
                         "nonExistingField",
                         field2,
-                    ])
+                    ]),
                 ).toEqual([value, null, value]);
                 expect(
-                    await client.hmget("nonExistingKey", [field1, field2])
+                    await client.hmget("nonExistingKey", [field1, field2]),
                 ).toEqual([null, null]);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -638,14 +638,14 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hset(key, fieldValueMap)).toEqual(2);
                 expect(await client.hexists(key, field1)).toEqual(true);
                 expect(await client.hexists(key, "nonExistingField")).toEqual(
-                    false
+                    false,
                 );
                 expect(await client.hexists("nonExistingKey", field2)).toEqual(
-                    false
+                    false,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -668,7 +668,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hgetall("nonExistingKey")).toEqual({});
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -684,11 +684,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hincrBy(key, field, 1)).toEqual(11);
                 expect(await client.hincrBy(key, field, 4)).toEqual(15);
                 expect(await client.hincrByFloat(key, field, 1.5)).toEqual(
-                    16.5
+                    16.5,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -702,19 +702,19 @@ export function runBaseTests<Context>(config: {
                     [field]: "10",
                 };
                 expect(
-                    await client.hincrBy("nonExistingKey", field, 1)
+                    await client.hincrBy("nonExistingKey", field, 1),
                 ).toEqual(1);
                 expect(await client.hset(key1, fieldValueMap)).toEqual(1);
                 expect(
-                    await client.hincrBy(key1, "nonExistingField", 2)
+                    await client.hincrBy(key1, "nonExistingField", 2),
                 ).toEqual(2);
                 expect(await client.hset(key2, fieldValueMap)).toEqual(1);
                 expect(
-                    await client.hincrByFloat(key2, "nonExistingField", -0.5)
+                    await client.hincrByFloat(key2, "nonExistingField", -0.5),
                 ).toEqual(-0.5);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -732,22 +732,22 @@ export function runBaseTests<Context>(config: {
                     expect(await client.hincrBy(key, field, 2)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "hash value is not an integer"
+                        "hash value is not an integer",
                     );
                 }
 
                 try {
                     expect(
-                        await client.hincrByFloat(key, field, 1.5)
+                        await client.hincrByFloat(key, field, 1.5),
                     ).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "hash value is not a float"
+                        "hash value is not a float",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -769,7 +769,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hlen("nonExistingHash")).toEqual(0);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -791,7 +791,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.hvals("nonExistingHash")).toEqual([]);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -812,12 +812,12 @@ export function runBaseTests<Context>(config: {
                     "value3",
                 ]);
                 expect(await client.lrange("nonExistingKey", 0, -1)).toEqual(
-                    []
+                    [],
                 );
                 expect(await client.lpop("nonExistingKey")).toEqual(null);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -831,7 +831,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.lpush(key, ["bar"])).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -839,7 +839,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.lpop(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -847,12 +847,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.lrange(key, 0, -1)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -873,12 +873,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.llen(key2)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -904,12 +904,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.ltrim(key, 0, 1)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -939,11 +939,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.lrem(key, 0, "value2")).toEqual(1);
                 expect(await client.lrange(key, 0, -1)).toEqual(["value1"]);
                 expect(await client.lrem("nonExistingKey", 2, "value")).toEqual(
-                    0
+                    0,
                 );
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -961,7 +961,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.rpop("nonExistingKey")).toEqual(null);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -975,7 +975,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.rpush(key, ["bar"])).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -983,12 +983,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.rpop(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -999,7 +999,7 @@ export function runBaseTests<Context>(config: {
                 const valueList = ["member1", "member2", "member3", "member4"];
                 expect(await client.sadd(key, valueList)).toEqual(4);
                 expect(
-                    await client.srem(key, ["member3", "nonExistingMember"])
+                    await client.srem(key, ["member3", "nonExistingMember"]),
                 ).toEqual(1);
                 /// compare the 2 sets.
                 expect((await client.smembers(key)).sort()).toEqual([
@@ -1011,7 +1011,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.scard(key)).toEqual(2);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1019,13 +1019,13 @@ export function runBaseTests<Context>(config: {
         async (protocol) => {
             await runTest(async (client: BaseClient) => {
                 expect(await client.srem("nonExistingKey", ["member"])).toEqual(
-                    0
+                    0,
                 );
                 expect(await client.scard("nonExistingKey")).toEqual(0);
                 expect(await client.smembers("nonExistingKey")).toEqual([]);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1039,7 +1039,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.sadd(key, ["bar"])).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -1047,7 +1047,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.srem(key, ["bar"])).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -1055,7 +1055,7 @@ export function runBaseTests<Context>(config: {
                     expect(await client.scard(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
 
@@ -1063,12 +1063,12 @@ export function runBaseTests<Context>(config: {
                     expect(await client.smembers(key)).toThrow();
                 } catch (e) {
                     expect((e as Error).message).toMatch(
-                        "Operation against a key holding the wrong kind of value"
+                        "Operation against a key holding the wrong kind of value",
                     );
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1082,12 +1082,12 @@ export function runBaseTests<Context>(config: {
                 expect(await client.exists([key1])).toEqual(1);
                 expect(await client.set(key2, value)).toEqual("OK");
                 expect(
-                    await client.exists([key1, "nonExistingKey", key2])
+                    await client.exists([key1, "nonExistingKey", key2]),
                 ).toEqual(2);
                 expect(await client.exists([key1, key1])).toEqual(2);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1102,11 +1102,11 @@ export function runBaseTests<Context>(config: {
                 expect(await client.set(key2, value)).toEqual("OK");
                 expect(await client.set(key3, value)).toEqual("OK");
                 expect(
-                    await client.unlink([key1, key2, "nonExistingKey", key3])
+                    await client.unlink([key1, key2, "nonExistingKey", key3]),
                 ).toEqual(3);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1128,8 +1128,8 @@ export function runBaseTests<Context>(config: {
                         await client.pexpire(
                             key,
                             10000,
-                            ExpireOptions.HasNoExpiry
-                        )
+                            ExpireOptions.HasNoExpiry,
+                        ),
                     ).toEqual(true);
                 }
 
@@ -1143,15 +1143,15 @@ export function runBaseTests<Context>(config: {
                         await client.expire(
                             key,
                             15,
-                            ExpireOptions.HasExistingExpiry
-                        )
+                            ExpireOptions.HasExistingExpiry,
+                        ),
                     ).toEqual(true);
                 }
 
                 expect(await client.ttl(key)).toBeLessThanOrEqual(15);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1163,8 +1163,8 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.expireAt(
                         key,
-                        Math.floor(Date.now() / 1000) + 10
-                    )
+                        Math.floor(Date.now() / 1000) + 10,
+                    ),
                 ).toEqual(true);
                 expect(await client.ttl(key)).toBeLessThanOrEqual(10);
                 const version = await getVersion();
@@ -1173,16 +1173,16 @@ export function runBaseTests<Context>(config: {
                     expect(
                         await client.expireAt(
                             key,
-                            Math.floor(Date.now() / 1000) + 50
-                        )
+                            Math.floor(Date.now() / 1000) + 50,
+                        ),
                     ).toEqual(true);
                 } else {
                     expect(
                         await client.expireAt(
                             key,
                             Math.floor(Date.now() / 1000) + 50,
-                            ExpireOptions.NewExpiryGreaterThanCurrent
-                        )
+                            ExpireOptions.NewExpiryGreaterThanCurrent,
+                        ),
                     ).toEqual(true);
                 }
 
@@ -1196,13 +1196,13 @@ export function runBaseTests<Context>(config: {
                         await client.pexpireAt(
                             key,
                             Date.now() + 50000,
-                            ExpireOptions.HasExistingExpiry
-                        )
+                            ExpireOptions.HasExistingExpiry,
+                        ),
                     ).toEqual(false);
                 }
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1221,21 +1221,21 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.expireAt(
                         key,
-                        Math.floor(Date.now() / 1000) - 50 /// timeout in the past
-                    )
+                        Math.floor(Date.now() / 1000) - 50, /// timeout in the past
+                    ),
                 ).toEqual(true);
                 expect(await client.ttl(key)).toEqual(-2);
                 expect(await client.set(key, "foo")).toEqual("OK");
                 expect(
                     await client.pexpireAt(
                         key,
-                        Date.now() - 50000 /// timeout in the past
-                    )
+                        Date.now() - 50000, /// timeout in the past
+                    ),
                 ).toEqual(true);
                 expect(await client.ttl(key)).toEqual(-2);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1248,19 +1248,19 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.expireAt(
                         key,
-                        Math.floor(Date.now() / 1000) + 50 /// timeout in the past
-                    )
+                        Math.floor(Date.now() / 1000) + 50, /// timeout in the past
+                    ),
                 ).toEqual(false);
                 expect(
                     await client.pexpireAt(
                         key,
-                        Date.now() + 50000 /// timeout in the past
-                    )
+                        Date.now() + 50000, /// timeout in the past
+                    ),
                 ).toEqual(false);
                 expect(await client.ttl(key)).toEqual(-2);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1274,13 +1274,13 @@ export function runBaseTests<Context>(config: {
                 expect(await client.invokeScript(script)).toEqual("Hello");
 
                 script = new Script(
-                    "return redis.call('SET', KEYS[1], ARGV[1])"
+                    "return redis.call('SET', KEYS[1], ARGV[1])",
                 );
                 expect(
                     await client.invokeScript(script, {
                         keys: [key1],
                         args: ["value1"],
-                    })
+                    }),
                 ).toEqual("OK");
 
                 /// Reuse the same script with different parameters.
@@ -1288,20 +1288,20 @@ export function runBaseTests<Context>(config: {
                     await client.invokeScript(script, {
                         keys: [key2],
                         args: ["value2"],
-                    })
+                    }),
                 ).toEqual("OK");
 
                 script = new Script("return redis.call('GET', KEYS[1])");
                 expect(
-                    await client.invokeScript(script, { keys: [key1] })
+                    await client.invokeScript(script, { keys: [key1] }),
                 ).toEqual("value1");
 
                 expect(
-                    await client.invokeScript(script, { keys: [key2] })
+                    await client.invokeScript(script, { keys: [key2] }),
                 ).toEqual("value2");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1315,7 +1315,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zaddIncr(key, "one", 2)).toEqual(3.0);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1327,29 +1327,29 @@ export function runBaseTests<Context>(config: {
                 expect(
                     await client.zadd(key, membersScores, {
                         conditionalChange: "onlyIfExists",
-                    })
+                    }),
                 ).toEqual(0);
 
                 expect(
                     await client.zadd(key, membersScores, {
                         conditionalChange: "onlyIfDoesNotExist",
-                    })
+                    }),
                 ).toEqual(3);
 
                 expect(
                     await client.zaddIncr(key, "one", 5.0, {
                         conditionalChange: "onlyIfDoesNotExist",
-                    })
+                    }),
                 ).toEqual(null);
 
                 expect(
                     await client.zaddIncr(key, "one", 5.0, {
                         conditionalChange: "onlyIfExists",
-                    })
+                    }),
                 ).toEqual(6.0);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1369,8 +1369,8 @@ export function runBaseTests<Context>(config: {
                         {
                             updateOptions: "scoreGreaterThanCurrent",
                         },
-                        true
-                    )
+                        true,
+                    ),
                 ).toEqual(1);
 
                 expect(
@@ -1380,24 +1380,24 @@ export function runBaseTests<Context>(config: {
                         {
                             updateOptions: "scoreLessThanCurrent",
                         },
-                        true
-                    )
+                        true,
+                    ),
                 ).toEqual(0);
 
                 expect(
                     await client.zaddIncr(key, "one", -3.0, {
                         updateOptions: "scoreLessThanCurrent",
-                    })
+                    }),
                 ).toEqual(7.0);
 
                 expect(
                     await client.zaddIncr(key, "one", -3.0, {
                         updateOptions: "scoreGreaterThanCurrent",
-                    })
+                    }),
                 ).toEqual(null);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1409,14 +1409,14 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zadd(key, membersScores)).toEqual(3);
                 expect(await client.zrem(key, ["one"])).toEqual(1);
                 expect(await client.zrem(key, ["one", "two", "three"])).toEqual(
-                    2
+                    2,
                 );
                 expect(
-                    await client.zrem("non_existing_set", ["member"])
+                    await client.zrem("non_existing_set", ["member"]),
                 ).toEqual(0);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1431,7 +1431,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zcard(key)).toEqual(2);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1444,17 +1444,17 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zadd(key1, membersScores)).toEqual(3);
                 expect(await client.zscore(key1, "one")).toEqual(1.0);
                 expect(await client.zscore(key1, "nonExistingMember")).toEqual(
-                    null
+                    null,
                 );
                 expect(
-                    await client.zscore("nonExistingKey", "nonExistingMember")
+                    await client.zscore("nonExistingKey", "nonExistingMember"),
                 ).toEqual(null);
 
                 expect(await client.set(key2, "foo")).toEqual("OK");
                 await expect(client.zscore(key2, "foo")).rejects.toThrow();
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1469,48 +1469,48 @@ export function runBaseTests<Context>(config: {
                     await client.zcount(
                         key1,
                         "negativeInfinity",
-                        "positiveInfinity"
-                    )
+                        "positiveInfinity",
+                    ),
                 ).toEqual(3);
                 expect(
                     await client.zcount(
                         key1,
                         { bound: 1, isInclusive: false },
-                        { bound: 3, isInclusive: false }
-                    )
+                        { bound: 3, isInclusive: false },
+                    ),
                 ).toEqual(1);
                 expect(
                     await client.zcount(
                         key1,
                         { bound: 1, isInclusive: false },
-                        { bound: 3 }
-                    )
+                        { bound: 3 },
+                    ),
                 ).toEqual(2);
                 expect(
                     await client.zcount(key1, "negativeInfinity", {
                         bound: 3,
-                    })
+                    }),
                 ).toEqual(3);
                 expect(
                     await client.zcount(key1, "positiveInfinity", {
                         bound: 3,
-                    })
+                    }),
                 ).toEqual(0);
                 expect(
                     await client.zcount(
                         "nonExistingKey",
                         "negativeInfinity",
-                        "positiveInfinity"
-                    )
+                        "positiveInfinity",
+                    ),
                 ).toEqual(0);
 
                 expect(await client.set(key2, "foo")).toEqual("OK");
                 await expect(
-                    client.zcount(key2, "negativeInfinity", "positiveInfinity")
+                    client.zcount(key2, "negativeInfinity", "positiveInfinity"),
                 ).rejects.toThrow();
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1551,7 +1551,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.type(key)).toEqual("none");
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1562,7 +1562,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.echo(message)).toEqual(message);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1582,13 +1582,16 @@ export function runBaseTests<Context>(config: {
                 const listKey2Value = uuidv4();
 
                 expect(
-                    await client.lpush(listName, [listKey1Value, listKey2Value])
+                    await client.lpush(listName, [
+                        listKey1Value,
+                        listKey2Value,
+                    ]),
                 ).toEqual(2);
                 // An error is returned when key holds a non-string value
                 await expect(client.strlen(listName)).rejects.toThrow();
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1599,7 +1602,10 @@ export function runBaseTests<Context>(config: {
                 const listKey1Value = uuidv4();
                 const listKey2Value = uuidv4();
                 expect(
-                    await client.lpush(listName, [listKey1Value, listKey2Value])
+                    await client.lpush(listName, [
+                        listKey1Value,
+                        listKey2Value,
+                    ]),
                 ).toEqual(2);
                 expect(await client.lindex(listName, 0)).toEqual(listKey2Value);
                 expect(await client.lindex(listName, 1)).toEqual(listKey1Value);
@@ -1607,7 +1613,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.lindex(listName, 3)).toEqual(null);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1628,7 +1634,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zpopmin("notExsitingKey")).toEqual({});
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1649,7 +1655,7 @@ export function runBaseTests<Context>(config: {
                 expect(await client.zpopmax("notExsitingKey")).toEqual({});
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
@@ -1667,18 +1673,25 @@ export function runBaseTests<Context>(config: {
                 expect(result).toBeGreaterThan(0);
                 expect(result).toBeLessThanOrEqual(10000);
 
-                expect(await client.expireAt(key, Math.floor(Date.now() / 1000) + 20)).toEqual(true);
+                expect(
+                    await client.expireAt(
+                        key,
+                        Math.floor(Date.now() / 1000) + 20,
+                    ),
+                ).toEqual(true);
                 result = await client.pttl(key);
                 expect(result).toBeGreaterThan(0);
                 expect(result).toBeLessThanOrEqual(20000);
 
-                expect(await client.pexpireAt(key, Date.now() + 30000)).toEqual(true);
+                expect(await client.pexpireAt(key, Date.now() + 30000)).toEqual(
+                    true,
+                );
                 result = await client.pttl(key);
                 expect(result).toBeGreaterThan(0);
                 expect(result).toBeLessThanOrEqual(30000);
             }, protocol);
         },
-        config.timeout
+        config.timeout,
     );
 }
 
@@ -1704,7 +1717,7 @@ export function runCommonTests<Context>(config: {
         async () => {
             await runTest((client: Client) => GetAndSetRandomValue(client));
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -1718,7 +1731,7 @@ export function runCommonTests<Context>(config: {
                 expect(result).toEqual(value);
             });
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -1730,7 +1743,7 @@ export function runCommonTests<Context>(config: {
                 expect(result).toEqual(null);
             });
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -1744,7 +1757,7 @@ export function runCommonTests<Context>(config: {
                 expect(result).toEqual("");
             });
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -1771,7 +1784,7 @@ export function runCommonTests<Context>(config: {
                 expect(result).toEqual(value);
             });
         },
-        config.timeout
+        config.timeout,
     );
 
     it(
@@ -1796,6 +1809,6 @@ export function runCommonTests<Context>(config: {
                 await Promise.all(operations);
             });
         },
-        config.timeout
+        config.timeout,
     );
 }

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -35,13 +35,13 @@ export function flushallOnPort(port: number): Promise<void> {
             } else {
                 resolve();
             }
-        })
+        }),
     );
 }
 
 /// This function takes the first result of the response if it got more than one response (like cluster responses).
 export function getFirstResult(
-    res: string | number | Record<string, string> | Record<string, number>
+    res: string | number | Record<string, string> | Record<string, number>,
 ): string | number {
     if (typeof res == "string" || typeof res == "number") {
         return res;
@@ -51,7 +51,7 @@ export function getFirstResult(
 }
 
 export function transactionTest(
-    baseTransaction: Transaction | ClusterTransaction
+    baseTransaction: Transaction | ClusterTransaction,
 ): ReturnType[] {
     const key1 = "{key}" + uuidv4();
     const key2 = "{key}" + uuidv4();
@@ -192,7 +192,7 @@ export class RedisCluster {
         cluster_mode: boolean,
         shardCount: number,
         replicaCount: number,
-        loadModule?: string[]
+        loadModule?: string[],
     ): Promise<RedisCluster> {
         return new Promise<RedisCluster>((resolve, reject) => {
             let command = `python3 ../utils/cluster_manager.py start -r ${replicaCount} -n ${shardCount}`;
@@ -204,7 +204,7 @@ export class RedisCluster {
             if (loadModule) {
                 if (loadModule.length === 0) {
                     throw new Error(
-                        "Please provide the path(s) to the module(s) you want to load."
+                        "Please provide the path(s) to the module(s) you want to load.",
                     );
                 }
 
@@ -241,8 +241,8 @@ export class RedisCluster {
                     } else {
                         resolve();
                     }
-                }
-            )
+                },
+            ),
         );
     }
 }


### PR DESCRIPTION
As we recommend in our DEVELOPER.md for Node to use prettier, we should follow the lint of what prettier give as a default. 

As Node developers, we encountered a lot the borden of fixing unwanted lints from prettier, that are actually needed lints, but are not part of the PR context, and for saving our time and nerves I created new workspace with fresh prettier and let it fix the TS files so we don't need to fight with it anymore - all what developers need to do is to use the default of prettier.

Added prettier scripts for check and format, added instructions for usage, added to the CI, and aligned all the file with the standard. 

Changed npm-cd workflow to fit the changes - https://github.com/aws/glide-for-redis/pull/1081

Changed lint-ts to instead of receptively create a task for each folder and ending running lint on the whole repo, to loop on the ts folders. end lint them specifically  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
