### PR TITLE
Disable semgrep on push and pull_request untill we have creds for the entire team - currently SEMGREP_APP_TOKEN works only for ikolomi account

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,15 +2,15 @@ name: Semgrep
 
 on:
   # Scan changed files in PRs (diff-aware scanning):
-  pull_request: {}
+#   pull_request: {}
   # Scan on-demand through GitHub Actions interface:
   workflow_dispatch:
     inputs:
         branch:
           description: 'The branch to run against the semgrep tool'
           required: true
-  push:
-    branches: ["master", "main"]
+#   push:
+#     branches: ["master", "main"]
   # Schedule the CI job (this method uses cron syntax):
   schedule:
     - cron: '0 8 * * *' # Sets Semgrep to scan every day at 08:00 UTC.


### PR DESCRIPTION
https://github.com/aws/glide-for-redis/issues/995
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
