### PR TITLE
Java: Added Hmget, Hexists and Hgetall to BaseClient and BaseTransaction. (Hash Commands)

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -8,7 +8,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.HashDel;
+import static redis_request.RedisRequestOuterClass.RequestType.HashExists;
 import static redis_request.RedisRequestOuterClass.RequestType.HashGet;
+import static redis_request.RedisRequestOuterClass.RequestType.HashGetAll;
+import static redis_request.RedisRequestOuterClass.RequestType.HashMGet;
 import static redis_request.RedisRequestOuterClass.RequestType.HashSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
@@ -169,6 +172,10 @@ public abstract class BaseClient
         return handleRedisResponse(String.class, true, response);
     }
 
+    protected Boolean handleBooleanResponse(Response response) throws RedisException {
+        return handleRedisResponse(Boolean.class, false, response);
+    }
+
     protected Long handleLongResponse(Response response) throws RedisException {
         return handleRedisResponse(Long.class, false, response);
     }
@@ -286,6 +293,24 @@ public abstract class BaseClient
     public CompletableFuture<Long> hdel(@NonNull String key, @NonNull String[] fields) {
         String[] args = ArrayUtils.addFirst(fields, key);
         return commandManager.submitNewCommand(HashDel, args, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<String[]> hmget(@NonNull String key, @NonNull String[] fields) {
+        String[] arguments = ArrayUtils.addFirst(fields, key);
+        return commandManager.submitNewCommand(
+                HashMGet, arguments, response -> castArray(handleArrayResponse(response), String.class));
+    }
+
+    @Override
+    public CompletableFuture<Boolean> hexists(@NonNull String key, @NonNull String field) {
+        return commandManager.submitNewCommand(
+                HashExists, new String[] {key, field}, this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, String>> hgetall(@NonNull String key) {
+        return commandManager.submitNewCommand(HashGetAll, new String[] {key}, this::handleMapResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/HashCommands.java
+++ b/java/client/src/main/java/glide/api/commands/HashCommands.java
@@ -45,4 +45,40 @@ public interface HashCommands {
      *     If <code>key</code> does not exist, it is treated as an empty hash and it returns 0.<br>
      */
     CompletableFuture<Long> hdel(String key, String[] fields);
+
+    /**
+     * Returns the values associated with the specified fields in the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hmget/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @param fields The fields in the hash stored at <code>key</code> to retrieve from the database.
+     * @return An array of values associated with the given fields, in the same order as they are
+     *     requested.<br>
+     *     For every field that does not exist in the hash, a null value is returned.<br>
+     *     If <code>key</code> does not exist, it is treated as an empty hash, and it returns an array
+     *     of null values.<br>
+     */
+    CompletableFuture<String[]> hmget(String key, String[] fields);
+
+    /**
+     * Returns if <code>field</code> is an existing field in the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hexists/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @param field The field to check in the hash stored at <code>key</code>.
+     * @return <code>True</code> the hash contains <code>field</code>. If the hash does not contain
+     *     <code>field</code>, or if <code>key</code> does not exist, it returns <code>False</code>.
+     */
+    CompletableFuture<Boolean> hexists(String key, String field);
+
+    /**
+     * Returns all fields and values of the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hgetall/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @return A map of fields and their values stored in the hash.<br>
+     *     If <code>key</code> does not exist, it returns an empty map.<br>
+     *     If <code>key</code> holds a value that is not a hash, an error is raised.<br>
+     */
+    CompletableFuture<Map<String, String>> hgetall(String key);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -7,7 +7,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.HashDel;
+import static redis_request.RedisRequestOuterClass.RequestType.HashExists;
 import static redis_request.RedisRequestOuterClass.RequestType.HashGet;
+import static redis_request.RedisRequestOuterClass.RequestType.HashGetAll;
+import static redis_request.RedisRequestOuterClass.RequestType.HashMGet;
 import static redis_request.RedisRequestOuterClass.RequestType.HashSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
@@ -342,6 +345,58 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(fields, key));
 
         protobufTransaction.addCommands(buildCommand(HashDel, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the values associated with the specified fields in the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hmget/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @param fields The fields in the hash stored at <code>key</code> to retrieve from the database.
+     * @return Command Response - An array of values associated with the given fields, in the same
+     *     order as they are requested.<br>
+     *     For every field that does not exist in the hash, a null value is returned.<br>
+     *     If <code>key</code> does not exist, it is treated as an empty hash, and it returns an array
+     *     of null values.<br>
+     */
+    public T hmget(@NonNull String key, @NonNull String[] fields) {
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(fields, key));
+
+        protobufTransaction.addCommands(buildCommand(HashMGet, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns if <code>field</code> is an existing field in the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hexists/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @param field The field to check in the hash stored at <code>key</code>.
+     * @return Command Response - <code>True</code> The hash contains <code>field</code>. If the hash
+     *     does not contain <code>field</code>, or if <code>key</code> does not exist, it returns
+     *     <code>False</code>.
+     */
+    public T hexists(@NonNull String key, @NonNull String field) {
+        ArgsArray commandArgs = buildArgs(key, field);
+
+        protobufTransaction.addCommands(buildCommand(HashExists, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns all fields and values of the hash stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/hgetall/">redis.io</a> for details.
+     * @param key The key of the hash.
+     * @return Command Response - A map of fields and their values stored in the hash.<br>
+     *     If <code>key</code> does not exist, it returns an empty map.<br>
+     *     If <code>key</code> holds a value that is not a hash, an error is raised.<br>
+     */
+    public T hgetall(@NonNull String key) {
+        ArgsArray commandArgs = buildArgs(key);
+
+        protobufTransaction.addCommands(buildCommand(HashGetAll, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -17,7 +17,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.HashDel;
+import static redis_request.RedisRequestOuterClass.RequestType.HashExists;
 import static redis_request.RedisRequestOuterClass.RequestType.HashGet;
+import static redis_request.RedisRequestOuterClass.RequestType.HashGetAll;
+import static redis_request.RedisRequestOuterClass.RequestType.HashMGet;
 import static redis_request.RedisRequestOuterClass.RequestType.HashSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
@@ -521,6 +524,76 @@ public class RedisClientTest {
         // exercise
         CompletableFuture<Long> response = service.hdel(key, fields);
         Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void hmget_success() {
+        // setup
+        String key = "testKey";
+        String[] fields = {"testField1", "testField2"};
+        String[] args = {"testKey", "testField1", "testField2"};
+        String[] value = {"testValue1", "testValue2"};
+
+        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+        when(commandManager.<String[]>submitNewCommand(eq(HashMGet), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String[]> response = service.hmget(key, fields);
+        String[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void hexists_success() {
+        // setup
+        String key = "testKey";
+        String field = "testField";
+        String[] args = new String[] {key, field};
+        Boolean value = true;
+
+        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+        when(commandManager.<Boolean>submitNewCommand(eq(HashExists), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.hexists(key, field);
+        Boolean payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void hgetall_success() {
+        // setup
+        String key = "testKey";
+        String[] args = new String[] {key};
+        Map<String, String> value = new LinkedHashMap<>();
+        value.put("key1", "value1");
+        value.put("key2", "value2");
+
+        CompletableFuture<Map<String, String>> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn(value);
+        when(commandManager.<Map<String, String>>submitNewCommand(eq(HashGetAll), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, String>> response = service.hgetall(key);
+        Map<String, String> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -7,7 +7,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.HashDel;
+import static redis_request.RedisRequestOuterClass.RequestType.HashExists;
 import static redis_request.RedisRequestOuterClass.RequestType.HashGet;
+import static redis_request.RedisRequestOuterClass.RequestType.HashGetAll;
+import static redis_request.RedisRequestOuterClass.RequestType.HashMGet;
 import static redis_request.RedisRequestOuterClass.RequestType.HashSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
@@ -104,6 +107,16 @@ public class ClusterTransactionTests {
 
         transaction.hdel("key", new String[] {"field"});
         results.add(Pair.of(HashDel, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hmget("key", new String[] {"field"});
+        results.add(Pair.of(HashMGet, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hexists("key", "field");
+        results.add(
+                Pair.of(HashExists, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hgetall("key");
+        results.add(Pair.of(HashGetAll, ArgsArray.newBuilder().addArgs("key").build()));
 
         transaction.sadd("key", new String[] {"value"});
         results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -7,7 +7,10 @@ import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.GetString;
 import static redis_request.RedisRequestOuterClass.RequestType.HashDel;
+import static redis_request.RedisRequestOuterClass.RequestType.HashExists;
 import static redis_request.RedisRequestOuterClass.RequestType.HashGet;
+import static redis_request.RedisRequestOuterClass.RequestType.HashGetAll;
+import static redis_request.RedisRequestOuterClass.RequestType.HashMGet;
 import static redis_request.RedisRequestOuterClass.RequestType.HashSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
@@ -103,6 +106,16 @@ public class TransactionTests {
 
         transaction.hdel("key", new String[] {"field"});
         results.add(Pair.of(HashDel, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hmget("key", new String[] {"field"});
+        results.add(Pair.of(HashMGet, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hexists("key", "field");
+        results.add(
+                Pair.of(HashExists, ArgsArray.newBuilder().addArgs("key").addArgs("field").build()));
+
+        transaction.hgetall("key");
+        results.add(Pair.of(HashGetAll, ArgsArray.newBuilder().addArgs("key").build()));
 
         transaction.sadd("key", new String[] {"value"});
         results.add(Pair.of(SAdd, ArgsArray.newBuilder().addArgs("key").addArgs("value").build()));

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -39,6 +39,9 @@ public class TransactionTestUtilities {
 
         baseTransaction.hset(key4, Map.of(field1, value1, field2, value2));
         baseTransaction.hget(key4, field1);
+        baseTransaction.hexists(key4, field2);
+        baseTransaction.hmget(key4, new String[] {field1, "non_existing_field", field2});
+        baseTransaction.hgetall(key4);
         baseTransaction.hdel(key4, new String[] {field1});
 
         baseTransaction.sadd(key5, new String[] {"baz", "foo"});
@@ -64,6 +67,9 @@ public class TransactionTestUtilities {
             0.5,
             2L,
             value1,
+            true,
+            new String[] {value1, null, value2},
+            Map.of(field1, value1, field2, value2),
             1L,
             2L,
             1L,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the Hmget, Hexists and Hgetall command to the java wrapper.

Example:
```
Map<String, String> fieldValueMap = client.hgetall(key).get();
String[] values = client.hmget(key, new String[] {field1, "non_existing_field", field2}).get();
Boolean success = client.hexists(key, field1).get();

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
