### PR TITLE
Bump `arduino/setup-protoc` version in CI

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -52,7 +52,7 @@ runs:
               targets: ${{ inputs.target }}
 
         - name: Install protoc (protobuf)
-          uses: arduino/setup-protoc@v2.1.0
+          uses: arduino/setup-protoc@v3
           with:
               version: "25.1"
               repo-token: ${{ inputs.github-token }}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
New version uses node 20, so won't see deprecation warnings.
See example: https://github.com/aws/glide-for-redis/actions/runs/7996878929
A screenshot for history, because old CI run are purged:
![image](https://github.com/aws/glide-for-redis/assets/88679692/cfbe697d-8864-4717-96f3-7869d392aada)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
