### PR TITLE
Make socket listener tests more readable.

### DIFF
--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -94,7 +94,6 @@ mod socket_listener {
         assert_response(
             buffer,
             Some(socket),
-            0,
             expected_callback,
             None,
             ResponseType::Null,
@@ -105,7 +104,6 @@ mod socket_listener {
         assert_response(
             buffer,
             Some(socket),
-            0,
             expected_callback,
             Some(Value::Okay),
             ResponseType::Value,
@@ -118,7 +116,7 @@ mod socket_listener {
         expected_callback: u32,
         error_type: ResponseType,
     ) -> Response {
-        assert_response(buffer, Some(socket), 0, expected_callback, None, error_type)
+        assert_response(buffer, Some(socket), expected_callback, None, error_type)
     }
 
     fn assert_value_response(
@@ -130,7 +128,6 @@ mod socket_listener {
         assert_response(
             buffer,
             socket,
-            0,
             expected_callback,
             Some(value),
             ResponseType::Value,
@@ -145,7 +142,6 @@ mod socket_listener {
     fn assert_response(
         buffer: &mut Vec<u8>,
         socket: Option<&mut UnixStream>,
-        cursor: usize,
         expected_callback: u32,
         expected_value: Option<Value>,
         expected_response_type: ResponseType,
@@ -154,7 +150,7 @@ mod socket_listener {
             let _size = read_from_socket(buffer, socket);
         }
         let (message_length, header_bytes) = parse_header(buffer);
-        let response = decode_response(buffer, cursor + header_bytes, message_length as usize);
+        let response = decode_response(buffer, header_bytes, message_length as usize);
         assert_eq!(response.callback_idx, expected_callback);
         match response.value {
             Some(response::Value::RespPointer(pointer)) => {

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -121,6 +121,22 @@ mod socket_listener {
         assert_response(buffer, Some(socket), 0, expected_callback, None, error_type)
     }
 
+    fn assert_value_response(
+        buffer: &mut Vec<u8>,
+        socket: Option<&mut UnixStream>,
+        expected_callback: u32,
+        value: Value,
+    ) -> Response {
+        assert_response(
+            buffer,
+            socket,
+            0,
+            expected_callback,
+            Some(value),
+            ResponseType::Value,
+        )
+    }
+
     fn read_from_socket(buffer: &mut Vec<u8>, socket: &mut UnixStream) -> usize {
         buffer.resize(100, 0_u8);
         socket.read(buffer).unwrap()
@@ -530,14 +546,11 @@ mod socket_listener {
         buffer.clear();
         write_get(&mut buffer, CALLBACK2_INDEX, key.as_str(), args_pointer);
         test_basics.socket.write_all(&buffer).unwrap();
-
-        assert_response(
+        assert_value_response(
             &mut buffer,
             Some(&mut test_basics.socket),
-            0,
             CALLBACK2_INDEX,
-            Some(Value::BulkString(value.into_bytes())),
-            ResponseType::Value,
+            Value::BulkString(value.into_bytes()),
         );
     }
 
@@ -578,13 +591,11 @@ mod socket_listener {
         );
         test_basics.socket.write_all(&buffer).unwrap();
 
-        assert_response(
+        assert_value_response(
             &mut buffer,
             Some(&mut test_basics.socket),
-            0,
             CALLBACK2_INDEX,
-            Some(Value::BulkString(value.into_bytes())),
-            ResponseType::Value,
+            Value::BulkString(value.into_bytes()),
         );
     }
 
@@ -797,13 +808,11 @@ mod socket_listener {
             assert_ne!(0, next_read);
             size += next_read;
         }
-        assert_response(
+        assert_value_response(
             &mut buffer,
             None,
-            0,
             CALLBACK2_INDEX,
-            Some(Value::BulkString(value.into_bytes())),
-            ResponseType::Value,
+            Value::BulkString(value.into_bytes()),
         );
     }
 
@@ -1058,18 +1067,16 @@ mod socket_listener {
         write_transaction_request(&mut buffer, CALLBACK_INDEX, commands);
         socket.write_all(&buffer).unwrap();
 
-        assert_response(
+        assert_value_response(
             &mut buffer,
             Some(&mut socket),
-            0,
             CALLBACK_INDEX,
-            Some(Value::Array(vec![
+            Value::Array(vec![
                 Value::Okay,
                 Value::BulkString(vec![b'b', b'a', b'r']),
                 Value::Okay,
                 Value::Nil,
-            ])),
-            ResponseType::Value,
+            ]),
         );
     }
 
@@ -1104,13 +1111,11 @@ mod socket_listener {
 
         socket.write_all(&buffer).unwrap();
 
-        assert_response(
+        assert_value_response(
             &mut buffer,
             Some(&mut test_basics.socket),
-            0,
             CALLBACK_INDEX,
-            Some(Value::BulkString(value.into_bytes())),
-            ResponseType::Value,
+            Value::BulkString(value.into_bytes()),
         );
     }
 

--- a/glide-core/tests/test_socket_listener.rs
+++ b/glide-core/tests/test_socket_listener.rs
@@ -92,9 +92,13 @@ mod socket_listener {
         args_pointer: bool,
     }
 
-    fn assert_value(pointer: u64, expected_value: Option<Value>) {
+    fn pointer_to_value(pointer: u64) -> Box<Value> {
         let pointer = pointer as *mut Value;
-        let received_value = unsafe { Box::from_raw(pointer) };
+        unsafe { Box::from_raw(pointer) }
+    }
+
+    fn assert_value(pointer: u64, expected_value: Option<Value>) {
+        let received_value = pointer_to_value(pointer);
         assert!(expected_value.is_some());
         assert_eq!(*received_value, expected_value.unwrap());
     }
@@ -683,8 +687,7 @@ mod socket_listener {
         let Some(response::Value::RespPointer(pointer)) = response.value else {
             panic!("Unexpected response {:?}", response.value);
         };
-        let pointer = pointer as *mut Value;
-        let received_value = unsafe { Box::from_raw(pointer) };
+        let received_value = pointer_to_value(pointer);
         let Value::Map(values) = *received_value else {
             panic!("Unexpected value {:?}", received_value);
         };
@@ -722,8 +725,7 @@ mod socket_listener {
         let Some(response::Value::RespPointer(pointer)) = response.value else {
             panic!("Unexpected response {:?}", response.value);
         };
-        let pointer = pointer as *mut Value;
-        let received_value = unsafe { Box::from_raw(pointer) };
+        let received_value = pointer_to_value(pointer);
         let first_value = String::from_redis_value(&received_value).unwrap();
         let (host, port) = first_value
             .split('\n')
@@ -752,8 +754,7 @@ mod socket_listener {
         let Some(response::Value::RespPointer(pointer)) = response.value else {
             panic!("Unexpected response {:?}", response.value);
         };
-        let pointer = pointer as *mut Value;
-        let received_value = unsafe { Box::from_raw(pointer) };
+        let received_value = pointer_to_value(pointer);
         let second_value = String::from_redis_value(&received_value).unwrap();
 
         assert_eq!(first_value, second_value);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The tests are made simpler by 
1. moving repeated logic to side functions, thus reducing the focusing the tests on their intention, rather than implementation details.
2. replacing booleans with enums, in order to make the test configuration more readable. `setup_basics(true, false, true)` is hard to decipher, and requires reading the function's signature in order to understand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
