### PR TITLE
Java: Move ping() commands out of baseclient

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -22,7 +22,6 @@ import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrByFloat;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
-import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.SAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.SCard;
 import static redis_request.RedisRequestOuterClass.RequestType.SMembers;
@@ -30,7 +29,6 @@ import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 
-import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericBaseCommands;
 import glide.api.commands.HashCommands;
 import glide.api.commands.SetCommands;
@@ -61,12 +59,7 @@ import response.ResponseOuterClass.Response;
 /** Base Client class for Redis */
 @AllArgsConstructor
 public abstract class BaseClient
-        implements AutoCloseable,
-                GenericBaseCommands,
-                ConnectionManagementCommands,
-                StringCommands,
-                HashCommands,
-                SetCommands {
+        implements AutoCloseable, GenericBaseCommands, StringCommands, HashCommands, SetCommands {
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
@@ -212,16 +205,6 @@ public abstract class BaseClient
     @SuppressWarnings("unchecked") // raw Set cast to Set<String>
     protected Set<String> handleSetResponse(Response response) throws RedisException {
         return handleRedisResponse(Set.class, false, response);
-    }
-
-    @Override
-    public CompletableFuture<String> ping() {
-        return commandManager.submitNewCommand(Ping, new String[0], this::handleStringResponse);
-    }
-
-    @Override
-    public CompletableFuture<String> ping(@NonNull String str) {
-        return commandManager.submitNewCommand(Ping, new String[] {str}, this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -3,8 +3,8 @@ package glide.api;
 
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
-import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.Select;
 
 import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericCommands;

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -4,7 +4,9 @@ package glide.api;
 import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
+import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 
+import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericCommands;
 import glide.api.commands.ServerManagementCommands;
 import glide.api.models.Transaction;
@@ -19,7 +21,8 @@ import lombok.NonNull;
  * Async (non-blocking) client for Redis in Standalone mode. Use {@link #CreateClient} to request a
  * client to Redis.
  */
-public class RedisClient extends BaseClient implements GenericCommands, ServerManagementCommands {
+public class RedisClient extends BaseClient
+        implements GenericCommands, ServerManagementCommands, ConnectionManagementCommands {
 
     protected RedisClient(ConnectionManager connectionManager, CommandManager commandManager) {
         super(connectionManager, commandManager);
@@ -44,6 +47,17 @@ public class RedisClient extends BaseClient implements GenericCommands, ServerMa
     @Override
     public CompletableFuture<Object[]> exec(Transaction transaction) {
         return commandManager.submitNewCommand(transaction, this::handleArrayOrNullResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> ping() {
+        return commandManager.submitNewCommand(Ping, new String[0], this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> ping(@NonNull String message) {
+        return commandManager.submitNewCommand(
+                Ping, new String[] {message}, this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -87,14 +87,25 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
+    public CompletableFuture<String> ping() {
+        return commandManager.submitNewCommand(Ping, new String[0], this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> ping(@NonNull String message) {
+        return commandManager.submitNewCommand(
+                Ping, new String[] {message}, this::handleStringResponse);
+    }
+
+    @Override
     public CompletableFuture<String> ping(@NonNull Route route) {
         return commandManager.submitNewCommand(Ping, new String[0], route, this::handleStringResponse);
     }
 
     @Override
-    public CompletableFuture<String> ping(@NonNull String str, @NonNull Route route) {
+    public CompletableFuture<String> ping(@NonNull String message, @NonNull Route route) {
         return commandManager.submitNewCommand(
-                Ping, new String[] {str}, route, this::handleStringResponse);
+                Ping, new String[] {message}, route, this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementClusterCommands.java
@@ -12,12 +12,29 @@ import java.util.concurrent.CompletableFuture;
 public interface ConnectionManagementClusterCommands {
 
     /**
+     * Ping the Redis server. The command will be routed to all primaries.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @return <code>String</code> with <code>"PONG"</code>.
+     */
+    CompletableFuture<String> ping();
+
+    /**
+     * Ping the Redis server. The command will be routed to all primaries.
+     *
+     * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
+     * @param message The server will respond with a copy of the message.
+     * @return <code>String</code> with a copy of the argument <code>message</code>.
+     */
+    CompletableFuture<String> ping(String message);
+
+    /**
      * Ping the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
-     * @return Response from Redis containing a <code>String</code> with "PONG".
+     * @return <code>String</code> with <code>"PONG"</code>.
      */
     CompletableFuture<String> ping(Route route);
 
@@ -25,11 +42,10 @@ public interface ConnectionManagementClusterCommands {
      * Ping the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
-     * @param str The ping argument that will be returned.
+     * @param message The ping argument that will be returned.
      * @param route Routing configuration for the command. Client will route the command to the nodes
      *     defined.
-     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>
-     *     str</code>.
+     * @return <code>String</code> with a copy of the argument <code>message</code>.
      */
-    CompletableFuture<String> ping(String str, Route route);
+    CompletableFuture<String> ping(String message, Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ConnectionManagementCommands.java
@@ -14,7 +14,7 @@ public interface ConnectionManagementCommands {
      * Ping the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
-     * @return Response from Redis containing a <code>String</code> with "PONG".
+     * @return <code>String</code> with <code>"PONG"</code>.
      */
     CompletableFuture<String> ping();
 
@@ -22,9 +22,8 @@ public interface ConnectionManagementCommands {
      * Ping the Redis server.
      *
      * @see <a href="https://redis.io/commands/ping/">redis.io</a> for details.
-     * @param str The ping argument that will be returned.
-     * @return Response from Redis containing a <code>String</code> with a copy of the argument <code>
-     *     str</code>.
+     * @param message The server will respond with a copy of the message.
+     * @return <code>String</code> with a copy of the argument <code>message</code>.
      */
-    CompletableFuture<String> ping(String str);
+    CompletableFuture<String> ping(String message);
 }

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -148,6 +148,48 @@ public class RedisClusterClientTest {
         CompletableFuture<String> testResponse = mock(CompletableFuture.class);
         when(testResponse.get()).thenReturn("PONG");
 
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(Ping), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.ping();
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals("PONG", payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void ping_with_message_returns_success() {
+        // setup
+        String message = "RETURN OF THE PONG";
+        String[] arguments = new String[] {message};
+        CompletableFuture<String> testResponse = new CompletableFuture();
+        testResponse.complete(message);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(Ping), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.ping(message);
+        String pong = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(message, pong);
+    }
+
+    @SneakyThrows
+    @Test
+    public void ping_with_route_returns_success() {
+        // setup
+        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
+        when(testResponse.get()).thenReturn("PONG");
+
         Route route = ALL_NODES;
 
         // match on protobuf request
@@ -165,7 +207,7 @@ public class RedisClusterClientTest {
 
     @SneakyThrows
     @Test
-    public void ping_with_message_returns_success() {
+    public void ping_with_message_with_route_returns_success() {
         // setup
         String message = "RETURN OF THE PONG";
         String[] arguments = new String[] {message};

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -80,22 +80,6 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest
     @MethodSource("getClients")
-    public void ping(BaseClient client) {
-        String data = client.ping().get();
-        assertEquals("PONG", data);
-    }
-
-    @SneakyThrows
-    @ParameterizedTest
-    @MethodSource("getClients")
-    public void ping_with_message(BaseClient client) {
-        String data = client.ping("H3LL0").get();
-        assertEquals("H3LL0", data);
-    }
-
-    @SneakyThrows
-    @ParameterizedTest
-    @MethodSource("getClients")
     public void unlink_multiple_keys(BaseClient client) {
         String key1 = "{key}" + UUID.randomUUID();
         String key2 = "{key}" + UUID.randomUUID();

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -132,6 +132,20 @@ public class CommandTests {
 
     @Test
     @SneakyThrows
+    public void ping() {
+        String data = clusterClient.ping().get();
+        assertEquals("PONG", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_message() {
+        String data = clusterClient.ping("H3LL0").get();
+        assertEquals("H3LL0", data);
+    }
+
+    @Test
+    @SneakyThrows
     public void ping_with_route() {
         String data = clusterClient.ping(ALL_NODES).get();
         assertEquals("PONG", data);

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -72,6 +72,20 @@ public class CommandTests {
 
     @Test
     @SneakyThrows
+    public void ping() {
+        String data = regularClient.ping().get();
+        assertEquals("PONG", data);
+    }
+
+    @Test
+    @SneakyThrows
+    public void ping_with_message() {
+        String data = regularClient.ping("H3LL0").get();
+        assertEquals("H3LL0", data);
+    }
+
+    @Test
+    @SneakyThrows
     public void info_without_options() {
         String data = regularClient.info().get();
         for (String section : DEFAULT_INFO_SECTIONS) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Move `ping()` commands on the java side to be consistent with other clients.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
