### PR TITLE
Reconnect standalone connection on unrecoverable errors.

### DIFF
--- a/glide-core/src/client/standalone_client.rs
+++ b/glide-core/src/client/standalone_client.rs
@@ -225,7 +225,7 @@ impl StandaloneClient {
         let mut connection = reconnecting_connection.get_connection().await?;
         let result = connection.send_packed_command(cmd).await;
         match result {
-            Err(err) if err.is_connection_dropped() => {
+            Err(err) if err.is_unrecoverable_error() => {
                 log_warn("send request", format!("received disconnect error `{err}`"));
                 reconnecting_connection.reconnect();
                 Err(err)
@@ -321,7 +321,7 @@ impl StandaloneClient {
             .send_packed_commands(pipeline, offset, count)
             .await;
         match result {
-            Err(err) if err.is_connection_dropped() => {
+            Err(err) if err.is_unrecoverable_error() => {
                 log_warn(
                     "pipeline request",
                     format!("received disconnect error `{err}`"),


### PR DESCRIPTION
These errors represent any situation in which the connection has reached a state in which it is no longer usable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
