### PR TITLE
Java: Use 3rd party lib for version checking. (#130)

### DIFF
--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     // junit
     testImplementation 'org.junit.jupiter:junit-jupiter:5.6.2'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
+
+    // semver4j for semantic versioning
+    implementation 'com.vdurmont:semver4j:3.1.0'
 }
 
 def standaloneRedisPorts = []

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -750,7 +750,7 @@ public class SharedCommandTests {
 
         // set command clears the timeout.
         assertEquals(OK, client.set(key, "pexpire_timeout").get());
-        if (REDIS_VERSION.feature() < 7) {
+        if (REDIS_VERSION.isLowerThan("7.0.0")) {
             assertTrue(client.pexpire(key, 10000L).get());
         } else {
             assertTrue(client.pexpire(key, 10000L, ExpireOptions.HAS_NO_EXPIRY).get());
@@ -758,7 +758,7 @@ public class SharedCommandTests {
         assertTrue(client.ttl(key).get() <= 10L);
 
         // TTL will be updated to the new value = 15
-        if (REDIS_VERSION.feature() < 7) {
+        if (REDIS_VERSION.isLowerThan("7.0.0")) {
             assertTrue(client.expire(key, 15L).get());
         } else {
             assertTrue(client.expire(key, 15L, ExpireOptions.HAS_EXISTING_EXPIRY).get());
@@ -776,7 +776,7 @@ public class SharedCommandTests {
         assertTrue(client.ttl(key).get() <= 10L);
 
         // extend TTL
-        if (REDIS_VERSION.feature() < 7) {
+        if (REDIS_VERSION.isLowerThan("7.0.0")) {
             assertTrue(client.expireAt(key, Instant.now().getEpochSecond() + 50L).get());
         } else {
             assertTrue(
@@ -789,7 +789,7 @@ public class SharedCommandTests {
         }
         assertTrue(client.ttl(key).get() <= 50L);
 
-        if (REDIS_VERSION.feature() < 7) {
+        if (REDIS_VERSION.isLowerThan("7.0.0")) {
             assertTrue(client.pexpireAt(key, Instant.now().toEpochMilli() + 50000L).get());
         } else {
             // set command clears the timeout.

--- a/java/integTest/src/test/java/glide/TestConfiguration.java
+++ b/java/integTest/src/test/java/glide/TestConfiguration.java
@@ -1,15 +1,14 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
-import java.lang.Runtime.Version;
+import com.vdurmont.semver4j.Semver;
 import java.util.Arrays;
 
 public final class TestConfiguration {
     // All redis servers are hosted on localhost
     public static final int[] STANDALONE_PORTS = getPortsFromProperty("test.redis.standalone.ports");
     public static final int[] CLUSTER_PORTS = getPortsFromProperty("test.redis.cluster.ports");
-    public static final Version REDIS_VERSION =
-            Version.parse(System.getProperty("test.redis.version"));
+    public static final Semver REDIS_VERSION = new Semver(System.getProperty("test.redis.version"));
 
     private static int[] getPortsFromProperty(String propName) {
         return Arrays.stream(System.getProperty(propName).split(","))

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -60,7 +60,7 @@ public class CommandTests {
                     "Cluster",
                     "Keyspace");
     public static final List<String> EVERYTHING_INFO_SECTIONS =
-            REDIS_VERSION.feature() >= 7
+            REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")
                     // Latencystats was added in redis 7
                     ? List.of(
                             "Server",
@@ -204,7 +204,7 @@ public class CommandTests {
     @SneakyThrows
     public void info_with_multiple_options() {
         InfoOptions.InfoOptionsBuilder builder = InfoOptions.builder().section(CLUSTER);
-        if (REDIS_VERSION.feature() >= 7) {
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             builder.section(CPU).section(MEMORY);
         }
         InfoOptions options = builder.build();
@@ -249,7 +249,7 @@ public class CommandTests {
                 (String) ((Object[]) ((Object[]) ((Object[]) slotData.getSingleValue())[0])[2])[2];
 
         InfoOptions.InfoOptionsBuilder builder = InfoOptions.builder().section(CLIENTS);
-        if (REDIS_VERSION.feature() >= 7) {
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             builder.section(COMMANDSTATS).section(REPLICATION);
         }
         InfoOptions options = builder.build();
@@ -267,7 +267,7 @@ public class CommandTests {
     @SneakyThrows
     public void info_with_multi_node_route_and_options() {
         InfoOptions.InfoOptionsBuilder builder = InfoOptions.builder().section(CLIENTS);
-        if (REDIS_VERSION.feature() >= 7) {
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             builder.section(COMMANDSTATS).section(REPLICATION);
         }
         InfoOptions options = builder.build();

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -99,7 +99,7 @@ public class CommandTests {
     @SneakyThrows
     public void info_with_multiple_options() {
         InfoOptions.InfoOptionsBuilder builder = InfoOptions.builder().section(CLUSTER);
-        if (REDIS_VERSION.feature() >= 7) {
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             builder.section(CPU).section(MEMORY);
         }
         InfoOptions options = builder.build();


### PR DESCRIPTION
The built-in library is unable to parse versions such as 7.2.0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
