### PR TITLE
CI/MacOS: Fixed brew to update and upgrade before installing dependencies

### DIFF
--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -31,6 +31,8 @@ runs:
           shell: bash
           if: "${{ inputs.os == 'macos-latest' }}"
           run: |
+              brew update
+              brew upgrade || true
               brew install git gcc pkgconfig openssl redis coreutils
 
         - name: Install software dependencies for Ubuntu


### PR DESCRIPTION
This fix is missing from #1094 