### PR TITLE
Java: improved benchmark prints and results

### DIFF
--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/Benchmarking.java
@@ -84,24 +84,24 @@ public class Benchmarking {
 
     public static void printResults(
             Map<ChosenAction, LatencyResults> resultsMap, double duration, int iterations) {
-        System.out.printf("Runtime s: %f%n", duration);
+        System.out.printf("Runtime (sec): %.3f%n", duration);
         System.out.printf("Iterations: %d%n", iterations);
-        System.out.printf("TPS: %f%n", iterations / duration);
-        int totalHits = 0;
+        System.out.printf("TPS: %d%n", (int) (iterations / duration));
+        int totalRequests = 0;
         for (Map.Entry<ChosenAction, LatencyResults> entry : resultsMap.entrySet()) {
             ChosenAction action = entry.getKey();
             LatencyResults results = entry.getValue();
 
             System.out.printf("===> %s <===%n", action);
-            System.out.printf("avg. time ms: %f%n", results.avgLatency);
-            System.out.printf("std dev ms: %f%n", results.stdDeviation);
-            System.out.printf("p50 latency ms: %f%n", results.p50Latency);
-            System.out.printf("p90 latency ms: %f%n", results.p90Latency);
-            System.out.printf("p99 latency ms: %f%n", results.p99Latency);
-            System.out.printf("Total hits: %d%n", results.totalHits);
-            totalHits += results.totalHits;
+            System.out.printf("avg. latency (ms): %.3f%n", results.avgLatency);
+            System.out.printf("std dev (ms): %.3f%n", results.stdDeviation);
+            System.out.printf("p50 latency (ms): %.3f%n", results.p50Latency);
+            System.out.printf("p90 latency (ms): %.3f%n", results.p90Latency);
+            System.out.printf("p99 latency (ms): %.3f%n", results.p99Latency);
+            System.out.printf("Total requests: %d%n", results.totalRequests);
+            totalRequests += results.totalRequests;
         }
-        System.out.println("Total hits: " + totalHits);
+        System.out.println("Total requests: " + totalRequests);
     }
 
     public static void testClientSetGet(
@@ -187,7 +187,7 @@ public class Benchmarking {
                     clients.forEach(Client::closeConnection);
 
                     if (config.resultsFile.isPresent()) {
-                        double tps = iterationCounter.get() * NANO_TO_SECONDS / (after - started);
+                        int tps = (int) (iterationCounter.get() * NANO_TO_SECONDS / (after - started));
                         JsonWriter.Write(
                                 calculatedResults,
                                 config.resultsFile.get(),

--- a/java/benchmarks/src/main/java/glide/benchmarks/utils/LatencyResults.java
+++ b/java/benchmarks/src/main/java/glide/benchmarks/utils/LatencyResults.java
@@ -7,22 +7,30 @@ import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 
 /** Raw timing results in nanoseconds */
 public class LatencyResults {
-    // measurements are done in nano-seconds, but it should be converted to seconds later
-    static final double SECONDS_TO_NANO = 1e-9;
+    // measurements are done in nano-seconds, but latencies should be converted to milliseconds
+    static final double NANO_TO_MILLI = 1e-6;
 
     public final double avgLatency;
     public final double p50Latency;
     public final double p90Latency;
     public final double p99Latency;
     public final double stdDeviation;
-    public final int totalHits;
+    public final int totalRequests;
+
+    private double TruncateDecimal(double number, int digits) {
+        int stepper = (int) Math.pow((double) 10, (double) digits);
+        return Math.floor(number * stepper) / stepper;
+    }
 
     public LatencyResults(double[] latencies) {
-        avgLatency = SECONDS_TO_NANO * Arrays.stream(latencies).sum() / latencies.length;
-        p50Latency = SECONDS_TO_NANO * new Percentile().evaluate(latencies, 50);
-        p90Latency = SECONDS_TO_NANO * new Percentile().evaluate(latencies, 90);
-        p99Latency = SECONDS_TO_NANO * new Percentile().evaluate(latencies, 99);
-        stdDeviation = SECONDS_TO_NANO * new StandardDeviation().evaluate(latencies, avgLatency);
-        totalHits = latencies.length;
+        avgLatency =
+                TruncateDecimal((NANO_TO_MILLI * Arrays.stream(latencies).sum() / latencies.length), 3);
+        p50Latency = TruncateDecimal((NANO_TO_MILLI * new Percentile().evaluate(latencies, 50)), 3);
+        p90Latency = TruncateDecimal((NANO_TO_MILLI * new Percentile().evaluate(latencies, 90)), 3);
+        p99Latency = TruncateDecimal((NANO_TO_MILLI * new Percentile().evaluate(latencies, 99)), 3);
+        stdDeviation =
+                TruncateDecimal(
+                        (NANO_TO_MILLI * new StandardDeviation().evaluate(latencies, avgLatency)), 3);
+        totalRequests = latencies.length;
     }
 }


### PR DESCRIPTION
1. Latencies were calculated in seconds, however they are printed as `ms`. Fixed latencies to be calculated in milliseconds.
2. Truncated all latencies to 3 decimal places
3. Converted TPS to int
4. Changed totalHits to totalRequests, as 'hits' in Redis refer to getting/setting an existing key

Prev output:
```
Runtime s: 8.412975
Iterations: 1000000
TPS: 118864.015717
===> SET <===
avg. time ms: 0.000834
std dev ms: 0.000627
p50 latency ms: 0.000768
p90 latency ms: 0.000924
p99 latency ms: 0.002636
Total hits: 199776
===> GET_NON_EXISTING <===
avg. time ms: 0.000830
std dev ms: 0.000590
p50 latency ms: 0.000767
p90 latency ms: 0.000920
p99 latency ms: 0.002542
Total hits: 160035
===> GET_EXISTING <===
avg. time ms: 0.000831
std dev ms: 0.000640
p50 latency ms: 0.000767
p90 latency ms: 0.000921
p99 latency ms: 0.002555
Total hits: 640189
Total hits: 1000000
```

New output:
```
Runtime (sec): 8.238
Iterations: 1000000
TPS: 121389
===> SET <===
avg. latency (ms): 0.818
std dev (ms): 0.380
p50 latency (ms): 0.773
p90 latency (ms): 0.947
p99 latency (ms): 1.823
Total requests: 199742
===> GET_NON_EXISTING <===
avg. latency (ms): 0.816
std dev (ms): 0.415
p50 latency (ms): 0.773
p90 latency (ms): 0.945
p99 latency (ms): 1.800
Total requests: 159496
===> GET_EXISTING <===
avg. latency (ms): 0.816
std dev (ms): 0.378
p50 latency (ms): 0.772
p90 latency (ms): 0.947
p99 latency (ms): 1.816
Total requests: 640762
Total requests: 1000000