### PR TITLE
Java: Increased timeout for workflow as CI timed out.

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
     build-and-test-java-client:
-        timeout-minutes: 25
+        timeout-minutes: 35
         strategy:
             # Run all jobs
             fail-fast: false


### PR DESCRIPTION
*Issue #, if available:*
The CI timeout was increased from 25 minutes to 35 minutes due to the failure of CI for some pull requests. This change was necessary because adding more tests caused the previous timeout limit to be exceeded.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
