### PR TITLE
Java: Fixed flakey test for cluster route by address reaches correct node.

### DIFF
--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -4,6 +4,8 @@ package glide;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import glide.api.models.ClusterValue;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -22,5 +24,25 @@ public class TestUtilities {
     /** Extract first value from {@link ClusterValue} assuming it contains a multi-value. */
     public static <T> T getFirstEntryFromMultiValue(ClusterValue<T> data) {
         return data.getMultiValue().get(data.getMultiValue().keySet().toArray(String[]::new)[0]);
+    }
+
+    /**
+     * Replaces 'ping-sent' and 'pong-recv' timestamps in Redis Cluster Nodes output with
+     * placeholders.
+     */
+    public static String removeTimeStampsFromClusterNodesOutput(String rawOutput) {
+        return Arrays.stream(rawOutput.split("\n"))
+                .map(
+                        line -> {
+                            String[] parts = line.split(" ");
+                            // Format for CLUSTER NODES COMMAND: <id> <ip:port@cport[,hostname]> <flags> <master>
+                            // <ping-sent> <pong-recv> <config-epoch> <link-state> <slot> <slot> ... <slot>
+                            if (parts.length > 6) {
+                                parts[4] = "ping-sent";
+                                parts[5] = "pong-recv";
+                            }
+                            return String.join(" ", parts);
+                        })
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -5,6 +5,7 @@ import static glide.TestConfiguration.CLUSTER_PORTS;
 import static glide.TestConfiguration.REDIS_VERSION;
 import static glide.TestUtilities.getFirstEntryFromMultiValue;
 import static glide.TestUtilities.getValueFromInfo;
+import static glide.TestUtilities.removeTimeStampsFromClusterNodesOutput;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.commands.InfoOptions.Section.CLIENTS;
 import static glide.api.models.commands.InfoOptions.Section.CLUSTER;
@@ -374,11 +375,12 @@ public class CommandTests {
     @SneakyThrows
     public void cluster_route_by_address_reaches_correct_node() {
         String initialNode =
-                (String)
-                        clusterClient
-                                .customCommand(new String[] {"cluster", "nodes"}, RANDOM)
-                                .get()
-                                .getSingleValue();
+                removeTimeStampsFromClusterNodesOutput(
+                        (String)
+                                clusterClient
+                                        .customCommand(new String[] {"cluster", "nodes"}, RANDOM)
+                                        .get()
+                                        .getSingleValue());
 
         String host =
                 Arrays.stream(initialNode.split("\n"))
@@ -389,22 +391,24 @@ public class CommandTests {
         assertNotNull(host);
 
         String specifiedClusterNode1 =
-                (String)
-                        clusterClient
-                                .customCommand(new String[] {"cluster", "nodes"}, new ByAddressRoute(host))
-                                .get()
-                                .getSingleValue();
+                removeTimeStampsFromClusterNodesOutput(
+                        (String)
+                                clusterClient
+                                        .customCommand(new String[] {"cluster", "nodes"}, new ByAddressRoute(host))
+                                        .get()
+                                        .getSingleValue());
         assertEquals(initialNode, specifiedClusterNode1);
 
         String[] splitHost = host.split(":");
         String specifiedClusterNode2 =
-                (String)
-                        clusterClient
-                                .customCommand(
-                                        new String[] {"cluster", "nodes"},
-                                        new ByAddressRoute(splitHost[0], Integer.parseInt(splitHost[1])))
-                                .get()
-                                .getSingleValue();
+                removeTimeStampsFromClusterNodesOutput(
+                        (String)
+                                clusterClient
+                                        .customCommand(
+                                                new String[] {"cluster", "nodes"},
+                                                new ByAddressRoute(splitHost[0], Integer.parseInt(splitHost[1])))
+                                        .get()
+                                        .getSingleValue());
         assertEquals(initialNode, specifiedClusterNode2);
     }
 

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -374,6 +374,7 @@ public class CommandTests {
     @Test
     @SneakyThrows
     public void cluster_route_by_address_reaches_correct_node() {
+        // Masks timestamps in the cluster nodes output to avoid flakiness due to dynamic values.
         String initialNode =
                 removeTimeStampsFromClusterNodesOutput(
                         (String)


### PR DESCRIPTION
*Issue #, if available:*
The test cluster_route_by_address_reaches_correct_node test was flaky due to timestamp fields in the CLUSTER NODES command output. These fields were "ping-sent" and "pong-recv" . To resolve this, I modified the test to mask the timestamps, focusing only on stable fields. You can find more info about this at https://redis.io/commands/cluster-nodes/. I also believe that the Node and the Python clients equivalent test would be flaky if these fields are not removed. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
