### PR TITLE
Increased Python & Node MacOS github actions timeout

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -93,7 +93,7 @@ jobs:
 
     build-macos-latest:
         runs-on: macos-latest
-        timeout-minutes: 15
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v4
               with:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -20,6 +20,7 @@ jobs:
         if: github.repository_owner == 'aws'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
+        timeout-minutes: 25
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -130,7 +130,7 @@ jobs:
 
     build-macos-latest:
         runs-on: macos-latest
-        timeout-minutes: 15
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
Due to recent fixes #1094 #1098 in MacOS CI in node and python the overall CI time was increased. 
