### PR TITLE
CD: Automate the activation of the self hosted runner

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -7,6 +7,7 @@ on:
       paths:
         - .github/workflows/npm-cd.yml
         - .github/workflows/build-node-wrapper/action.yml
+        - .github/workflows/start-self-hosted-runner/action.yml
     push:
         tags:
             - "v*.*"
@@ -16,7 +17,21 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    start-self-hosted-runner:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Start self hosted EC2 runner
+          uses: ./.github/workflows/start-self-hosted-runner
+          with:
+              aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+              aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+              aws-region: ${{ secrets.AWS_REGION }}
+              ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
+
     publish-binaries:
+        needs: start-self-hosted-runner
         if: github.repository_owner == 'aws'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
@@ -54,6 +69,10 @@ jobs:
                           TARGET: aarch64-apple-darwin,
                       }
         steps:
+            - name: Setup self-hosted runner access
+              if: ${{ contains(matrix.build.RUNNER, 'self-hosted') }}
+              run: sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work/glide-for-redis
+
             - name: Checkout
               uses: actions/checkout@v4
               with:

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -7,6 +7,7 @@ on:
       paths:
         - .github/workflows/pypi-cd.yml
         - .github/workflows/build-python-wrapper/action.yml
+        - .github/workflows/start-self-hosted-runner/action.yml
     push:
         tags:
             - "v*.*"
@@ -16,7 +17,21 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    start-self-hosted-runner:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+          - name: Start self hosted EC2 runner
+            uses: ./.github/workflows/start-self-hosted-runner
+            with:
+                aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.AWS_REGION }}
+                ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
+
     publish-binaries:
+        needs: start-self-hosted-runner
         if: github.repository_owner == 'aws'
         name: Publish packages to PyPi
         runs-on: ${{ matrix.build.RUNNER }}
@@ -55,6 +70,10 @@ jobs:
                           TARGET: aarch64-apple-darwin,
                       }
         steps:
+            - name: Setup self-hosted runner access
+              if: ${{ contains(matrix.build.RUNNER, 'self-hosted') }}
+              run: sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work/glide-for-redis
+
             - name: Checkout
               uses: actions/checkout@v4
               with:

--- a/.github/workflows/start-self-hosted-runner/action.yml
+++ b/.github/workflows/start-self-hosted-runner/action.yml
@@ -1,0 +1,32 @@
+name: Start self hosted EC2 runner
+
+inputs:
+    aws-region:
+        description: AWS Region, e.g. us-east-1
+        required: true
+    aws-access-key-id:
+        description: AWS Access Key ID. Provide this key if you want to assume a role using access keys rather than a web identity token.
+        required: true
+    aws-secret-access-key:
+        description: AWS Secret Access Key. Required if aws-access-key-id is provided.
+        required: true
+    ec2-instance-id:
+        description: AWS EC2 instance ID for the self hosted runner
+        required: true
+
+runs:
+    using: "composite"
+    steps:
+        - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+              aws-access-key-id: ${{ inputs.aws-access-key-id }}
+              aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+              aws-region: ${{ inputs.aws-region }}
+        - name: Start EC2 self hosted runner
+          shell: bash
+          run: |
+              sudo apt update
+              sudo apt install awscli -y
+              aws ssm send-command --instance-ids ${{ inputs.ec2-instance-id }} --document-name  StartGithubSelfHostedRunner --output text
+              aws ssm list-command-invocations 


### PR DESCRIPTION
In order to automatically activate the runner, we did:
1. SSM installed on the EC2 host
2. Created an SSM document to start the runner process on the host
3. IAM user was created for github actions, keys were stored as secrets in github
4. The CD jobs will wait for the runner to be activated
5. The CD job will change ownership permissions for the _work folder to allow checking out the repository (see https://github.com/actions/checkout/issues/211#issuecomment-611986243)

https://github.com/machulav/ec2-github-runner/  haven't been used since it requires an org:admin access in order to generate a registration key for the runner, which `aws` org doesn't provide.

Closes #656 