### PR TITLE
C#: Strict rules

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
     run-tests:
-        timeout-minutes: 15
+        timeout-minutes: 25
         strategy:
             fail-fast: false
             matrix:

--- a/benchmarks/csharp/Program.cs
+++ b/benchmarks/csharp/Program.cs
@@ -1,6 +1,4 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -21,46 +19,40 @@ public static class MainClass
     public class CommandLineOptions
     {
         [Option('r', "resultsFile", Required = false, HelpText = "Set the file to which the JSON results are written.")]
-        public string resultsFile { get; set; } = "../results/csharp-results.json";
+        public string ResultsFile { get; set; } = "../results/csharp-results.json";
 
         [Option('d', "dataSize", Required = false, HelpText = "The size of the sent data in bytes.")]
-        public int dataSize { get; set; } = 100;
+        public int DataSize { get; set; } = 100;
 
         [Option('c', "concurrentTasks", Required = false, HelpText = "The number of concurrent operations to perform.", Default = new[] { 1, 10, 100, 1000 })]
-        public IEnumerable<int> concurrentTasks { get; set; } = Enumerable.Empty<int>();
+        public IEnumerable<int> ConcurrentTasks { get; set; } = [];
 
         [Option('l', "clients", Required = false, HelpText = "Which clients should run")]
-        public string clientsToRun { get; set; } = "all";
+        public string ClientsToRun { get; set; } = "all";
 
         [Option('h', "host", Required = false, HelpText = "What host to target")]
-        public string host { get; set; } = "localhost";
+        public string Host { get; set; } = "localhost";
 
         [Option('C', "clientCount", Required = false, HelpText = "Number of clients to run concurrently", Default = new[] { 1 })]
-        public IEnumerable<int> clientCount { get; set; } = Enumerable.Empty<int>();
+        public IEnumerable<int> ClientCount { get; set; } = [];
 
         [Option('t', "tls", HelpText = "Should benchmark a TLS server")]
-        public bool tls { get; set; } = false;
+        public bool Tls { get; set; } = false;
 
 
         [Option('m', "minimal", HelpText = "Should use a minimal number of actions")]
-        public bool minimal { get; set; } = false;
+        public bool Minimal { get; set; } = false;
     }
 
     private const int PORT = 6379;
-    private static string getAddress(string host)
-    {
-        return $"{host}:{PORT}";
-    }
+    private static string GetAddress(string host) => $"{host}:{PORT}";
 
-    private static string getAddressForStackExchangeRedis(string host, bool useTLS)
-    {
-        return $"{getAddress(host)},ssl={useTLS}";
-    }
+    private static string GetAddressForStackExchangeRedis(string host, bool useTLS) => $"{GetAddress(host)},ssl={useTLS}";
 
-    private static string getAddressWithRedisPrefix(string host, bool useTLS)
+    private static string GetAddressWithRedisPrefix(string host, bool useTLS)
     {
-        var protocol = useTLS ? "rediss" : "redis";
-        return $"{protocol}://{getAddress(host)}";
+        string protocol = useTLS ? "rediss" : "redis";
+        return $"{protocol}://{GetAddress(host)}";
     }
     private const double PROB_GET = 0.8;
 
@@ -68,99 +60,84 @@ public static class MainClass
     private const int SIZE_GET_KEYSPACE = 3750000; // 3.75 million
     private const int SIZE_SET_KEYSPACE = 3000000; // 3 million
 
-    private static readonly Random randomizer = new();
-    private static long started_tasks_counter = 0;
-    private static readonly List<Dictionary<string, object>> bench_json_results = new();
+    private static readonly Random Randomizer = new();
+    private static long s_started_tasks_counter = 0;
+    private static readonly List<Dictionary<string, object>> BenchJsonResults = [];
 
-    private static string generate_value(int size)
-    {
-        return new string('0', size);
-    }
+    private static string GenerateValue(int size) => new('0', size);
 
-    private static string generate_key_set()
-    {
-        return (randomizer.Next(SIZE_SET_KEYSPACE) + 1).ToString();
-    }
-    private static string generate_key_get()
-    {
-        return (randomizer.Next(SIZE_SET_KEYSPACE, SIZE_GET_KEYSPACE) + 1).ToString();
-    }
+    private static string GenerateKeySet() => (Randomizer.Next(SIZE_SET_KEYSPACE) + 1).ToString();
+    private static string GenerateKeyGet() => (Randomizer.Next(SIZE_SET_KEYSPACE, SIZE_GET_KEYSPACE) + 1).ToString();
 
-    private static ChosenAction choose_action()
-    {
-        if (randomizer.NextDouble() > PROB_GET)
-        {
-            return ChosenAction.SET;
-        }
-        if (randomizer.NextDouble() > PROB_GET_EXISTING_KEY)
-        {
-            return ChosenAction.GET_NON_EXISTING;
-        }
-        return ChosenAction.GET_EXISTING;
-    }
+    private static ChosenAction ChooseAction() =>
+        Randomizer.NextDouble() > PROB_GET
+            ? ChosenAction.SET
+            : Randomizer.NextDouble() > PROB_GET_EXISTING_KEY ? ChosenAction.GET_NON_EXISTING : ChosenAction.GET_EXISTING;
 
     /// copied from https://stackoverflow.com/questions/8137391/percentile-calculation
     private static double Percentile(double[] sequence, double excelPercentile)
     {
         Array.Sort(sequence);
-        int N = sequence.Length;
-        double n = (N - 1) * excelPercentile + 1;
-        if (n == 1d) return sequence[0];
-        else if (n == N) return sequence[N - 1];
+        double n = ((sequence.Length - 1) * excelPercentile) + 1;
+        if (n == 1d)
+        {
+            return sequence[0];
+        }
+        else if (n == sequence.Length)
+        {
+            return sequence[^1];
+        }
         else
         {
             int k = (int)n;
             double d = n - k;
-            return sequence[k - 1] + d * (sequence[k] - sequence[k - 1]);
+            return sequence[k - 1] + (d * (sequence[k] - sequence[k - 1]));
         }
     }
 
-    private static double calculate_latency(IEnumerable<double> latency_list, double percentile_point)
+    private static double CalculateLatency(IEnumerable<double> latency_list, double percentile_point) => Math.Round(Percentile(latency_list.ToArray(), percentile_point), 2);
+
+    private static void PrintResults(string resultsFile)
     {
-        return Math.Round(Percentile(latency_list.ToArray(), percentile_point), 2);
+        using FileStream createStream = File.Create(resultsFile);
+        JsonSerializer.Serialize(createStream, BenchJsonResults);
     }
 
-    private static void print_results(string resultsFile)
-    {
-        using (FileStream createStream = File.Create(resultsFile))
-        {
-            JsonSerializer.Serialize(createStream, bench_json_results);
-        }
-    }
-
-    private static async Task redis_benchmark(
+    private static async Task RedisBenchmark(
         ClientWrapper[] clients,
         long total_commands,
         string data,
         Dictionary<ChosenAction, ConcurrentBag<double>> action_latencies)
     {
-        var stopwatch = new Stopwatch();
+        Stopwatch stopwatch = new();
         do
         {
-            Interlocked.Increment(ref started_tasks_counter);
-            var index = (int)(started_tasks_counter % clients.Length);
-            var client = clients[index];
-            var action = choose_action();
+            _ = Interlocked.Increment(ref s_started_tasks_counter);
+            int index = (int)(s_started_tasks_counter % clients.Length);
+            ClientWrapper client = clients[index];
+            ChosenAction action = ChooseAction();
             stopwatch.Start();
             switch (action)
             {
                 case ChosenAction.GET_EXISTING:
-                    await client.get(generate_key_set());
+                    _ = await client.Get(GenerateKeySet());
                     break;
                 case ChosenAction.GET_NON_EXISTING:
-                    await client.get(generate_key_get());
+                    _ = await client.Get(GenerateKeyGet());
                     break;
                 case ChosenAction.SET:
-                    await client.set(generate_key_set(), data);
+                    await client.Set(GenerateKeySet(), data);
+                    break;
+                default:
                     break;
             }
             stopwatch.Stop();
-            var latency_list = action_latencies[action];
+            ConcurrentBag<double> latency_list = action_latencies[action];
             latency_list.Add(((double)stopwatch.ElapsedMilliseconds) / 1000);
-        } while (started_tasks_counter < total_commands);
+        } while (s_started_tasks_counter < total_commands);
     }
 
-    private static async Task<long> create_bench_tasks(
+    private static async Task<long> CreateBenchTasks(
         ClientWrapper[] clients,
         int total_commands,
         string data,
@@ -168,13 +145,13 @@ public static class MainClass
         Dictionary<ChosenAction, ConcurrentBag<double>> action_latencies
     )
     {
-        started_tasks_counter = 0;
-        var stopwatch = Stopwatch.StartNew();
-        var running_tasks = new List<Task>();
-        for (var i = 0; i < num_of_concurrent_tasks; i++)
+        s_started_tasks_counter = 0;
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        List<Task> running_tasks = [];
+        for (int i = 0; i < num_of_concurrent_tasks; i++)
         {
             running_tasks.Add(
-                redis_benchmark(clients, total_commands, data, action_latencies)
+                RedisBenchmark(clients, total_commands, data, action_latencies)
             );
         }
         await Task.WhenAll(running_tasks);
@@ -182,22 +159,19 @@ public static class MainClass
         return stopwatch.ElapsedMilliseconds;
     }
 
-    private static Dictionary<string, object> latency_results(
+    private static Dictionary<string, object> LatencyResults(
         string prefix,
         ConcurrentBag<double> latencies
-    )
+    ) => new()
     {
-        return new Dictionary<string, object>
-        {
-            {prefix + "_p50_latency", calculate_latency(latencies, 0.5)},
-            {prefix + "_p90_latency", calculate_latency(latencies, 0.9)},
-            {prefix + "_p99_latency", calculate_latency(latencies, 0.99)},
+            {prefix + "_p50_latency", CalculateLatency(latencies, 0.5)},
+            {prefix + "_p90_latency", CalculateLatency(latencies, 0.9)},
+            {prefix + "_p99_latency", CalculateLatency(latencies, 0.99)},
             {prefix + "_average_latency", Math.Round(latencies.Average(), 3)},
             {prefix + "_std_dev", latencies.StandardDeviation()},
         };
-    }
 
-    private static async Task run_clients(
+    private static async Task RunClients(
         ClientWrapper[] clients,
         string client_name,
         int total_commands,
@@ -205,32 +179,32 @@ public static class MainClass
         int num_of_concurrent_tasks
     )
     {
-        Console.WriteLine($"Starting {client_name} data size: {data_size} concurrency: {num_of_concurrent_tasks} client count: {clients.Length} {DateTime.UtcNow.ToString("HH:mm:ss")}");
-        var action_latencies = new Dictionary<ChosenAction, ConcurrentBag<double>>() {
+        Console.WriteLine($"Starting {client_name} data size: {data_size} concurrency: {num_of_concurrent_tasks} client count: {clients.Length} {DateTime.UtcNow:HH:mm:ss}");
+        Dictionary<ChosenAction, ConcurrentBag<double>> action_latencies = new() {
             {ChosenAction.GET_NON_EXISTING, new()},
             {ChosenAction.GET_EXISTING, new()},
             {ChosenAction.SET, new()},
         };
-        var data = generate_value(data_size);
-        var elapsed_milliseconds = await create_bench_tasks(
+        string data = GenerateValue(data_size);
+        long elapsed_milliseconds = await CreateBenchTasks(
             clients,
             total_commands,
             data,
             num_of_concurrent_tasks,
             action_latencies
         );
-        var tps = Math.Round((double)started_tasks_counter / ((double)elapsed_milliseconds / 1000));
+        double tps = Math.Round(s_started_tasks_counter / ((double)elapsed_milliseconds / 1000));
 
-        var get_non_existing_latencies = action_latencies[ChosenAction.GET_NON_EXISTING];
-        var get_non_existing_latency_results = latency_results("get_non_existing", get_non_existing_latencies);
+        ConcurrentBag<double> get_non_existing_latencies = action_latencies[ChosenAction.GET_NON_EXISTING];
+        Dictionary<string, object> get_non_existing_latency_results = LatencyResults("get_non_existing", get_non_existing_latencies);
 
-        var get_existing_latencies = action_latencies[ChosenAction.GET_EXISTING];
-        var get_existing_latency_results = latency_results("get_existing", get_existing_latencies);
+        ConcurrentBag<double> get_existing_latencies = action_latencies[ChosenAction.GET_EXISTING];
+        Dictionary<string, object> get_existing_latency_results = LatencyResults("get_existing", get_existing_latencies);
 
-        var set_latencies = action_latencies[ChosenAction.SET];
-        var set_latency_results = latency_results("set", set_latencies);
+        ConcurrentBag<double> set_latencies = action_latencies[ChosenAction.SET];
+        Dictionary<string, object> set_latency_results = LatencyResults("set", set_latencies);
 
-        var result = new Dictionary<string, object>
+        Dictionary<string, object> result = new()
         {
             {"client", client_name},
             {"num_of_tasks", num_of_concurrent_tasks},
@@ -244,43 +218,40 @@ public static class MainClass
             .Concat(get_non_existing_latency_results)
             .Concat(set_latency_results)
             .ToDictionary(pair => pair.Key, pair => pair.Value);
-        bench_json_results.Add(result);
+        BenchJsonResults.Add(result);
     }
 
     private class ClientWrapper : IDisposable
     {
         internal ClientWrapper(Func<string, Task<string?>> get, Func<string, string, Task> set, Action disposalFunction)
         {
-            this.get = get;
-            this.set = set;
-            this.disposalFunction = disposalFunction;
+            Get = get;
+            Set = set;
+            _disposalFunction = disposalFunction;
         }
 
-        public void Dispose()
-        {
-            this.disposalFunction();
-        }
+        public void Dispose() => _disposalFunction();
 
-        internal Func<string, Task<string?>> get;
-        internal Func<string, string, Task> set;
+        internal Func<string, Task<string?>> Get;
+        internal Func<string, string, Task> Set;
 
-        private readonly Action disposalFunction;
+        private readonly Action _disposalFunction;
     }
 
-    private async static Task<ClientWrapper[]> createClients(int clientCount,
+    private static async Task<ClientWrapper[]> CreateClients(int clientCount,
         Func<Task<(Func<string, Task<string?>>,
                    Func<string, string, Task>,
                    Action)>> clientCreation)
     {
-        var tasks = Enumerable.Range(0, clientCount).Select(async (_) =>
+        IEnumerable<Task<ClientWrapper>> tasks = Enumerable.Range(0, clientCount).Select(async (_) =>
         {
-            var tuple = await clientCreation();
+            (Func<string, Task<string?>>, Func<string, string, Task>, Action) tuple = await clientCreation();
             return new ClientWrapper(tuple.Item1, tuple.Item2, tuple.Item3);
         });
         return await Task.WhenAll(tasks);
     }
 
-    private static async Task run_with_parameters(int total_commands,
+    private static async Task RunWithParameters(int total_commands,
         int data_size,
         int num_of_concurrent_tasks,
         string clientsToRun,
@@ -288,18 +259,18 @@ public static class MainClass
         int clientCount,
         bool useTLS)
     {
-        if (clientsToRun == "all" || clientsToRun == "glide")
+        if (clientsToRun is "all" or "glide")
         {
-            var clients = await createClients(clientCount, () =>
+            ClientWrapper[] clients = await CreateClients(clientCount, () =>
             {
-                var glide_client = new AsyncClient(host, PORT, useTLS);
+                AsyncClient glide_client = new(host, PORT, useTLS);
                 return Task.FromResult<(Func<string, Task<string?>>, Func<string, string, Task>, Action)>(
                     (async (key) => await glide_client.GetAsync(key),
                      async (key, value) => await glide_client.SetAsync(key, value),
                      () => glide_client.Dispose()));
             });
 
-            await run_clients(
+            await RunClients(
                 clients,
                 "glide",
                 total_commands,
@@ -310,16 +281,16 @@ public static class MainClass
 
         if (clientsToRun == "all")
         {
-            var clients = await createClients(clientCount, () =>
+            ClientWrapper[] clients = await CreateClients(clientCount, () =>
                 {
-                    var connection = ConnectionMultiplexer.Connect(getAddressForStackExchangeRedis(host, useTLS));
-                    var db = connection.GetDatabase();
+                    ConnectionMultiplexer connection = ConnectionMultiplexer.Connect(GetAddressForStackExchangeRedis(host, useTLS));
+                    IDatabase db = connection.GetDatabase();
                     return Task.FromResult<(Func<string, Task<string?>>, Func<string, string, Task>, Action)>(
                         (async (key) => await db.StringGetAsync(key),
                          async (key, value) => await db.StringSetAsync(key, value),
                          () => connection.Dispose()));
                 });
-            await run_clients(
+            await RunClients(
                 clients,
                 "StackExchange.Redis",
                 total_commands,
@@ -327,33 +298,30 @@ public static class MainClass
                 num_of_concurrent_tasks
             );
 
-            foreach (var client in clients)
+            foreach (ClientWrapper client in clients)
             {
                 client.Dispose();
             }
         }
     }
 
-    private static int number_of_iterations(int num_of_concurrent_tasks)
-    {
-        return Math.Min(Math.Max(100000, num_of_concurrent_tasks * 10000), 10000000);
-    }
+    private static int NumberOfIterations(int num_of_concurrent_tasks) => Math.Min(Math.Max(100000, num_of_concurrent_tasks * 10000), 10000000);
 
     public static async Task Main(string[] args)
     {
         CommandLineOptions options = new();
-        Parser.Default
-            .ParseArguments<CommandLineOptions>(args).WithParsed<CommandLineOptions>(parsed => { options = parsed; });
+        _ = Parser.Default
+            .ParseArguments<CommandLineOptions>(args).WithParsed(parsed => options = parsed);
 
-        Logger.SetLoggerConfig(Level.Info, Path.GetFileNameWithoutExtension(options.resultsFile));
-        var product = options.concurrentTasks.SelectMany(concurrentTasks =>
-            options.clientCount.Select(clientCount => (concurrentTasks: concurrentTasks, dataSize: options.dataSize, clientCount: clientCount))).Where(tuple => tuple.concurrentTasks >= tuple.clientCount);
-        foreach (var (concurrentTasks, dataSize, clientCount) in product)
+        Logger.SetLoggerConfig(Level.Info, Path.GetFileNameWithoutExtension(options.ResultsFile));
+        IEnumerable<(int concurrentTasks, int dataSize, int clientCount)> product = options.ConcurrentTasks.SelectMany(concurrentTasks =>
+            options.ClientCount.Select(clientCount => (concurrentTasks, options.DataSize, clientCount))).Where(tuple => tuple.concurrentTasks >= tuple.clientCount);
+        foreach ((int concurrentTasks, int dataSize, int clientCount) in product)
         {
-            var iterations = options.minimal ? 1000 : number_of_iterations(concurrentTasks);
-            await run_with_parameters(iterations, dataSize, concurrentTasks, options.clientsToRun, options.host, clientCount, options.tls);
+            int iterations = options.Minimal ? 1000 : NumberOfIterations(concurrentTasks);
+            await RunWithParameters(iterations, dataSize, concurrentTasks, options.ClientsToRun, options.Host, clientCount, options.Tls);
         }
 
-        print_results(options.resultsFile);
+        PrintResults(options.ResultsFile);
     }
 }

--- a/benchmarks/csharp/csharp_benchmark.csproj
+++ b/benchmarks/csharp/csharp_benchmark.csproj
@@ -15,7 +15,14 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1587</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/csharp/.editorconfig
+++ b/csharp/.editorconfig
@@ -349,3 +349,5 @@ dotnet_naming_style.s_camelcase.required_prefix = s_
 dotnet_naming_style.s_camelcase.required_suffix =
 dotnet_naming_style.s_camelcase.word_separator =
 dotnet_naming_style.s_camelcase.capitalization = camel_case
+
+dotnet_analyzer_diagnostic.category-Style.severity = error

--- a/csharp/lib/AsyncClient.cs
+++ b/csharp/lib/AsyncClient.cs
@@ -1,6 +1,4 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 using System.Buffers;
 using System.Runtime.InteropServices;
@@ -10,59 +8,59 @@ namespace Glide;
 public class AsyncClient : IDisposable
 {
     #region public methods
-    public AsyncClient(string host, UInt32 port, bool useTLS)
+    public AsyncClient(string host, uint port, bool useTLS)
     {
-        successCallbackDelegate = SuccessCallback;
-        var successCallbackPointer = Marshal.GetFunctionPointerForDelegate(successCallbackDelegate);
-        failureCallbackDelegate = FailureCallback;
-        var failureCallbackPointer = Marshal.GetFunctionPointerForDelegate(failureCallbackDelegate);
-        clientPointer = CreateClientFfi(host, port, useTLS, successCallbackPointer, failureCallbackPointer);
-        if (clientPointer == IntPtr.Zero)
+        _successCallbackDelegate = SuccessCallback;
+        nint successCallbackPointer = Marshal.GetFunctionPointerForDelegate(_successCallbackDelegate);
+        _failureCallbackDelegate = FailureCallback;
+        nint failureCallbackPointer = Marshal.GetFunctionPointerForDelegate(_failureCallbackDelegate);
+        _clientPointer = CreateClientFfi(host, port, useTLS, successCallbackPointer, failureCallbackPointer);
+        if (_clientPointer == IntPtr.Zero)
         {
             throw new Exception("Failed creating a client");
         }
     }
 
-    private async Task<string?> command(IntPtr[] args, int argsCount, RequestType requestType)
+    private async Task<string?> Command(IntPtr[] args, int argsCount, RequestType requestType)
     {
         // We need to pin the array in place, in order to ensure that the GC doesn't move it while the operation is running.
         GCHandle pinnedArray = GCHandle.Alloc(args, GCHandleType.Pinned);
         IntPtr pointer = pinnedArray.AddrOfPinnedObject();
-        var message = messageContainer.GetMessageForCall(args, argsCount);
-        CommandFfi(clientPointer, (ulong)message.Index, (int)requestType, pointer, (uint)argsCount);
-        var result = await message;
+        Message<string> message = _messageContainer.GetMessageForCall(args, argsCount);
+        CommandFfi(_clientPointer, (ulong)message.Index, (int)requestType, pointer, (uint)argsCount);
+        string? result = await message;
         pinnedArray.Free();
         return result;
     }
 
     public async Task<string?> SetAsync(string key, string value)
     {
-        var args = this.arrayPool.Rent(2);
+        IntPtr[] args = _arrayPool.Rent(2);
         args[0] = Marshal.StringToHGlobalAnsi(key);
         args[1] = Marshal.StringToHGlobalAnsi(value);
-        var result = await command(args, 2, RequestType.SetString);
-        this.arrayPool.Return(args);
+        string? result = await Command(args, 2, RequestType.SetString);
+        _arrayPool.Return(args);
         return result;
     }
 
     public async Task<string?> GetAsync(string key)
     {
-        var args = this.arrayPool.Rent(1);
+        IntPtr[] args = _arrayPool.Rent(1);
         args[0] = Marshal.StringToHGlobalAnsi(key);
-        var result = await command(args, 1, RequestType.GetString);
-        this.arrayPool.Return(args);
+        string? result = await Command(args, 1, RequestType.GetString);
+        _arrayPool.Return(args);
         return result;
     }
 
     public void Dispose()
     {
-        if (clientPointer == IntPtr.Zero)
+        if (_clientPointer == IntPtr.Zero)
         {
             return;
         }
-        messageContainer.DisposeWithError(null);
-        CloseClientFfi(clientPointer);
-        clientPointer = IntPtr.Zero;
+        _messageContainer.DisposeWithError(null);
+        CloseClientFfi(_clientPointer);
+        _clientPointer = IntPtr.Zero;
     }
 
     #endregion public methods
@@ -71,24 +69,22 @@ public class AsyncClient : IDisposable
 
     private void SuccessCallback(ulong index, IntPtr str)
     {
-        var result = str == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(str);
+        string? result = str == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(str);
         // Work needs to be offloaded from the calling thread, because otherwise we might starve the client's thread pool.
-        Task.Run(() =>
+        _ = Task.Run(() =>
         {
-            var message = messageContainer.GetMessage((int)index);
+            Message<string> message = _messageContainer.GetMessage((int)index);
             message.SetResult(result);
         });
     }
 
-    private void FailureCallback(ulong index)
-    {
+    private void FailureCallback(ulong index) =>
         // Work needs to be offloaded from the calling thread, because otherwise we might starve the client's thread pool.
         Task.Run(() =>
         {
-            var message = messageContainer.GetMessage((int)index);
+            Message<string> message = _messageContainer.GetMessage((int)index);
             message.SetException(new Exception("Operation failed"));
         });
-    }
 
     ~AsyncClient() => Dispose();
     #endregion private methods
@@ -97,17 +93,16 @@ public class AsyncClient : IDisposable
 
     /// Held as a measure to prevent the delegate being garbage collected. These are delegated once
     /// and held in order to prevent the cost of marshalling on each function call.
-    private readonly FailureAction failureCallbackDelegate;
+    private readonly FailureAction _failureCallbackDelegate;
 
     /// Held as a measure to prevent the delegate being garbage collected. These are delegated once
     /// and held in order to prevent the cost of marshalling on each function call.
-    private readonly StringAction successCallbackDelegate;
+    private readonly StringAction _successCallbackDelegate;
 
     /// Raw pointer to the underlying native client.
-    private IntPtr clientPointer;
-
-    private readonly MessageContainer<string> messageContainer = new();
-    private readonly ArrayPool<IntPtr> arrayPool = ArrayPool<IntPtr>.Shared;
+    private IntPtr _clientPointer;
+    private readonly MessageContainer<string> _messageContainer = new();
+    private readonly ArrayPool<IntPtr> _arrayPool = ArrayPool<IntPtr>.Shared;
 
     #endregion private fields
 
@@ -116,11 +111,11 @@ public class AsyncClient : IDisposable
     private delegate void StringAction(ulong index, IntPtr str);
     private delegate void FailureAction(ulong index);
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "command")]
-    private static extern void CommandFfi(IntPtr client, ulong index, Int32 requestType, IntPtr args, UInt32 argCount);
+    private static extern void CommandFfi(IntPtr client, ulong index, int requestType, IntPtr args, uint argCount);
 
     private delegate void IntAction(IntPtr arg);
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "create_client")]
-    private static extern IntPtr CreateClientFfi(String host, UInt32 port, bool useTLS, IntPtr successCallback, IntPtr failureCallback);
+    private static extern IntPtr CreateClientFfi(string host, uint port, bool useTLS, IntPtr successCallback, IntPtr failureCallback);
 
     [DllImport("libglide_rs", CallingConvention = CallingConvention.Cdecl, EntryPoint = "close_client")]
     private static extern void CloseClientFfi(IntPtr client);

--- a/csharp/lib/Message.cs
+++ b/csharp/lib/Message.cs
@@ -1,6 +1,4 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -11,38 +9,29 @@ using Glide;
 /// Reusable source of ValueTask. This object can be allocated once and then reused
 /// to create multiple asynchronous operations, as long as each call to CreateTask
 /// is awaited to completion before the next call begins.
-internal class Message<T> : INotifyCompletion
+internal class Message<T>(int index, MessageContainer<T> container) : INotifyCompletion
 {
     /// This is the index of the message in an external array, that allows the user to
     /// know how to find the message and set its result.
-    public int Index { get; }
-
+    public int Index { get; } = index;
     /// The array holding the pointers  to the unmanaged memory that contains the operation's arguments.
-    public IntPtr[]? args { get; private set; }
+    public IntPtr[]? Args { get; private set; }
     // We need to save the args count, because sometimes we get arrays that are larger than they need to be. We can't rely on `this.args.Length`, due to it coming from an array pool.
-    private int argsCount;
-    private readonly MessageContainer<T> container;
-
-    public Message(int index, MessageContainer<T> container)
-    {
-        Index = index;
-        continuation = () => { };
-        this.container = container;
-    }
-
-    private Action? continuation;
-    const int COMPLETION_STAGE_STARTED = 0;
-    const int COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION = 1;
-    const int COMPLETION_STAGE_CONTINUATION_EXECUTED = 2;
-    private int completionState;
-    private T? result;
-    private Exception? exception;
+    private int _argsCount;
+    private MessageContainer<T> Container { get; } = container;
+    private Action? _continuation = () => { };
+    private const int COMPLETION_STAGE_STARTED = 0;
+    private const int COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION = 1;
+    private const int COMPLETION_STAGE_CONTINUATION_EXECUTED = 2;
+    private int _completionState;
+    private T? _result;
+    private Exception? _exception;
 
     /// Triggers a succesful completion of the task returned from the latest call
     /// to CreateTask.
     public void SetResult(T? result)
     {
-        this.result = result;
+        _result = result;
         FinishSet();
     }
 
@@ -50,7 +39,7 @@ internal class Message<T> : INotifyCompletion
     /// CreateTask.
     public void SetException(Exception exc)
     {
-        this.exception = exc;
+        _exception = exc;
         FinishSet();
     }
 
@@ -63,17 +52,17 @@ internal class Message<T> : INotifyCompletion
 
     private void CheckRaceAndCallContinuation()
     {
-        if (Interlocked.CompareExchange(ref this.completionState, COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION, COMPLETION_STAGE_STARTED) == COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION)
+        if (Interlocked.CompareExchange(ref _completionState, COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION, COMPLETION_STAGE_STARTED) == COMPLETION_STAGE_NEXT_SHOULD_EXECUTE_CONTINUATION)
         {
-            Debug.Assert(this.continuation != null);
-            this.completionState = COMPLETION_STAGE_CONTINUATION_EXECUTED;
+            Debug.Assert(_continuation != null);
+            _completionState = COMPLETION_STAGE_CONTINUATION_EXECUTED;
             try
             {
-                continuation();
+                _continuation();
             }
             finally
             {
-                this.container.ReturnFreeMessage(this);
+                Container.ReturnFreeMessage(this);
             }
         }
     }
@@ -83,44 +72,44 @@ internal class Message<T> : INotifyCompletion
     /// This returns a task that will complete once SetException / SetResult are called,
     /// and ensures that the internal state of the message is set-up before the task is created,
     /// and cleaned once it is complete.
-    public void SetupTask(IntPtr[] args, int argsCount, object client)
+    public void SetupTask(IntPtr[] arguments, int argsCount, object client)
     {
-        continuation = null;
-        this.completionState = COMPLETION_STAGE_STARTED;
-        this.result = default(T);
-        this.exception = null;
-        this.client = client;
-        this.args = args;
-        this.argsCount = argsCount;
+        _continuation = null;
+        _completionState = COMPLETION_STAGE_STARTED;
+        _result = default;
+        _exception = null;
+        _client = client;
+        Args = arguments;
+        _argsCount = argsCount;
     }
 
     // This function isn't thread-safe. Access to it should be from a single thread, and only once per operation.
     // For the sake of performance, this responsibility is on the caller, and the function doesn't contain any safety measures.
     private void FreePointers()
     {
-        if (this.args is not null)
+        if (Args is { })
         {
-            for (var i = 0; i < this.argsCount; i++)
+            for (int i = 0; i < _argsCount; i++)
             {
-                Marshal.FreeHGlobal(this.args[i]);
+                Marshal.FreeHGlobal(Args[i]);
             }
-            this.args = null;
-            this.argsCount = 0;
+            Args = null;
+            _argsCount = 0;
         }
-        client = null;
+        _client = null;
     }
 
     // Holding the client prevents it from being CG'd until all operations complete.
-    private object? client;
+    private object? _client;
 
 
     public void OnCompleted(Action continuation)
     {
-        this.continuation = continuation;
+        _continuation = continuation;
         CheckRaceAndCallContinuation();
     }
 
-    public bool IsCompleted => completionState == COMPLETION_STAGE_CONTINUATION_EXECUTED;
+    public bool IsCompleted => _completionState == COMPLETION_STAGE_CONTINUATION_EXECUTED;
 
-    public T? GetResult() => this.exception is null ? this.result : throw this.exception;
+    public T? GetResult() => _exception is null ? _result : throw _exception;
 }

--- a/csharp/lib/MessageContainer.cs
+++ b/csharp/lib/MessageContainer.cs
@@ -1,6 +1,4 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 using System.Collections.Concurrent;
 
@@ -9,36 +7,36 @@ namespace Glide;
 
 internal class MessageContainer<T>
 {
-    internal Message<T> GetMessage(int index) => messages[index];
+    internal Message<T> GetMessage(int index) => _messages[index];
 
     internal Message<T> GetMessageForCall(IntPtr[] args, int argsCount)
     {
-        var message = GetFreeMessage();
+        Message<T> message = GetFreeMessage();
         message.SetupTask(args, argsCount, this);
         return message;
     }
 
     private Message<T> GetFreeMessage()
     {
-        if (!availableMessages.TryDequeue(out var message))
+        if (!_availableMessages.TryDequeue(out Message<T>? message))
         {
-            lock (messages)
+            lock (_messages)
             {
-                var index = messages.Count;
+                int index = _messages.Count;
                 message = new Message<T>(index, this);
-                messages.Add(message);
+                _messages.Add(message);
             }
         }
         return message;
     }
 
-    public void ReturnFreeMessage(Message<T> message) => availableMessages.Enqueue(message);
+    public void ReturnFreeMessage(Message<T> message) => _availableMessages.Enqueue(message);
 
     internal void DisposeWithError(Exception? error)
     {
-        lock (messages)
+        lock (_messages)
         {
-            foreach (var message in messages.Where(message => !message.IsCompleted))
+            foreach (Message<T>? message in _messages.Where(message => !message.IsCompleted))
             {
                 try
                 {
@@ -46,17 +44,17 @@ internal class MessageContainer<T>
                 }
                 catch (Exception) { }
             }
-            messages.Clear();
+            _messages.Clear();
         }
-        availableMessages.Clear();
+        _availableMessages.Clear();
     }
 
     /// This list allows us random-access to the message in each index,
     /// which means that once we receive a callback with an index, we can
     /// find the message to resolve in constant time.
-    private readonly List<Message<T>> messages = new();
+    private readonly List<Message<T>> _messages = [];
 
     /// This queue contains the messages that were created and are currently unused by any task,
     /// so they can be reused y new tasks instead of allocating new messages.
-    private readonly ConcurrentQueue<Message<T>> availableMessages = new();
+    private readonly ConcurrentQueue<Message<T>> _availableMessages = new();
 }

--- a/csharp/lib/Properties/AssemblyInfo.cs
+++ b/csharp/lib/Properties/AssemblyInfo.cs
@@ -1,6 +1,5 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
+
 
 using System.Runtime.CompilerServices;
 

--- a/csharp/lib/glide.csproj
+++ b/csharp/lib/glide.csproj
@@ -5,7 +5,14 @@
     <RootNamespace>Glide</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1587</NoWarn>
   </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/csharp/tests/Usings.cs
+++ b/csharp/tests/Usings.cs
@@ -1,5 +1,3 @@
-/**
- * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
- */
+// Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 global using NUnit.Framework;

--- a/csharp/tests/tests.csproj
+++ b/csharp/tests/tests.csproj
@@ -4,8 +4,15 @@
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1573;CS1587</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*

- Enabling strict rules check by adding `dotnet_analyzer_diagnostic.category-Style.severity = error` in .editorconfig and 

`<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild> ` to project files. 
- Added lang section to enable modern syntax
- Added workaround to handle unused imports
- Applied rules in all C# codebase
- disable HandleVeryLargeInput according to https://github.com/aws/glide-for-redis/pull/1085/files
- timer for workflow set to 25 min (better caching strategy pending)