### PR TITLE
cluster_manager: Increased timeout for creating a cluster

### DIFF
--- a/utils/cluster_manager.py
+++ b/utils/cluster_manager.py
@@ -426,7 +426,7 @@ def create_cluster(
         stderr=subprocess.PIPE,
         text=True,
     )
-    output, err = p.communicate(timeout=20)
+    output, err = p.communicate(timeout=40)
     if err or "[OK] All 16384 slots covered." not in output:
         raise Exception(f"Failed to create cluster: {err if err else output}")
 
@@ -963,7 +963,9 @@ def main():
         tic = time.perf_counter()
         cluster_prefix = f"tls-{args.prefix}" if args.tls else args.prefix
         cluster_folder = create_cluster_folder(args.folder_path, cluster_prefix)
-        logging.info(f"{datetime.now(timezone.utc)} Starting script for cluster {cluster_folder}")
+        logging.info(
+            f"{datetime.now(timezone.utc)} Starting script for cluster {cluster_folder}"
+        )
         logfile = (
             f"{cluster_folder}/cluster_manager.log"
             if not args.logfile


### PR DESCRIPTION
Fixing flakeyness that is being caused by:
```
subprocess.TimeoutExpired: Command '['redis-cli', '--cluster', 'create', '127.0.0.1:25528', '127.0.0.1:12261', '127.0.0.1:8734', '127.0.0.1:36600', '127.0.0.1:18288', '127.0.0.1:36402', '--cluster-replicas', '1', '--cluster-yes']' timed out after 20 seconds
```
https://github.com/aws/glide-for-redis/actions/runs/8343816789/job/22834784827?pr=1089

This command is responsible for meeting all nodes, set all slots, and make nodes replicas, which can be longer