### PR TITLE
Node - Minor - changed tsconfig-base to tsconfig and added default outdir

### DIFF
--- a/node/DEVELOPER.md
+++ b/node/DEVELOPER.md
@@ -177,7 +177,7 @@ In this project we are using hybrid method for building the package for NodeJS, 
 Hybrid method -
 In order to build the package for usage in either module system, we use three different tsconfig files:
 
--   `tsconfig-base` is the general tsconfig file, which the others will extend.
+-   `tsconfig` is the general tsconfig file, which the others will extend.
 -   `tsconfig-cjs` for `commonJS` build with `CommonJS` as the target of translation.
 -   `tsconfig` for `ECMA` build with `ECMA` as the target of translation.
 

--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -14,9 +14,4 @@ module.exports = {
         "mjs",
     ],
     testTimeout: 20000,
-    globals: {
-        "ts-jest": {
-            tsconfig: "tsconfig-mjs.json",
-        },
-    },
 };

--- a/node/tsconfig-cjs.json
+++ b/node/tsconfig-cjs.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig-base.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig to read more about this file */
         "module": "commonjs" /* Specify what module code is generated. */,

--- a/node/tsconfig-mjs.json
+++ b/node/tsconfig-mjs.json
@@ -1,5 +1,5 @@
 {
-    "extends": "./tsconfig-base.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
         /* Visit https://aka.ms/tsconfig to read more about this file */
         "module": "ES2022" /* Specify what module code is generated. */,

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -21,7 +21,8 @@
         "traceResolution": false /* true to have TypeScript print information about its resolution process for each processed file */,
         "lib": [
             "esnext"
-        ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
+        "outDir": "./build-ts/mjs" /* Specify an output folder for all emitted files. */
     },
     "compileOnSave": false,
     "include": ["./*.ts", "src/*.ts", "src/*.js"],

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -22,7 +22,7 @@
         "lib": [
             "esnext"
         ] /* Specify a set of bundled library declaration files that describe the target runtime environment. */,
-        "outDir": "./build-ts/mjs" /* Specify an output folder for all emitted files. */
+        "outDir": "./build-ts/mjs" /* Specify an output folder for all emitted files. Ovrride in tsconfig-cjs */
     },
     "compileOnSave": false,
     "include": ["./*.ts", "src/*.ts", "src/*.js"],


### PR DESCRIPTION
If you are using some TS extensions you noticed some new errors showing in some of the TS files.
The reason is that the different TS extensions are looking for tsconfig file for their rules. And since we dont have one anymore some errors pops in the IDE.
Those errors are not real errors, since when build run and test we did config to which config file tsc and jest should go for rules, but while working it can be annoying to see red marks all over your file,
So instead of calling the general config file `tsconfig-base`, we call it simply `tsconfig` and then whatever look for tsconfig as default will find the base rule we use. 

We adding default outDir value, since otherwise the default is /src and it cause more red marks (since we don't have our `d.ts` files in /src).

Since now extensions and frameworks apps thats looks for default `tsconfig` has it, we can remove it from `jest.config`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
