### PR TITLE
Java: Add `Time()` command

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -1,6 +1,7 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
+import static glide.utils.ArrayTransformUtils.castArray;
 import static glide.utils.ArrayTransformUtils.convertMapToKeyValueStringArray;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
@@ -13,6 +14,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 
 import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericCommands;
@@ -123,5 +125,11 @@ public class RedisClient extends BaseClient
     public CompletableFuture<String> echo(@NonNull String message) {
         return commandManager.submitNewCommand(
                 Echo, new String[] {message}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String[]> time() {
+        return commandManager.submitNewCommand(
+                Time, new String[0], response -> castArray(handleArrayResponse(response), String.class));
     }
 }

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1,6 +1,8 @@
 /** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
+import static glide.utils.ArrayTransformUtils.castArray;
+import static glide.utils.ArrayTransformUtils.castMapOfArrays;
 import static glide.utils.ArrayTransformUtils.convertMapToKeyValueStringArray;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
@@ -12,6 +14,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.CustomCommand;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 
 import glide.api.commands.ConnectionManagementClusterCommands;
 import glide.api.commands.GenericClusterCommands;
@@ -261,5 +264,24 @@ public class RedisClusterClient extends BaseClient
                         route.isSingleNodeRoute()
                                 ? ClusterValue.ofSingleValue(handleStringResponse(response))
                                 : ClusterValue.ofMultiValue(handleMapResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<String[]> time() {
+        return commandManager.submitNewCommand(
+                Time, new String[0], response -> castArray(handleArrayResponse(response), String.class));
+    }
+
+    @Override
+    public CompletableFuture<ClusterValue<String[]>> time(@NonNull Route route) {
+        return commandManager.submitNewCommand(
+                Time,
+                new String[0],
+                route,
+                response ->
+                        route.isSingleNodeRoute()
+                                ? ClusterValue.ofSingleValue(castArray(handleArrayResponse(response), String.class))
+                                : ClusterValue.ofMultiValue(
+                                        castMapOfArrays(handleMapResponse(response), String.class)));
     }
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -242,7 +242,7 @@ public interface ServerManagementClusterCommands {
     CompletableFuture<String> configSet(Map<String, String> parameters, Route route);
 
     /**
-     * Returns the server time. <br>
+     * Returns the server time.<br>
      * The command will be routed to a random node.
      *
      * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -248,7 +248,7 @@ public interface ServerManagementClusterCommands {
      * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
      * @return The current server time as a <code>String</code> array with two elements: A Unix
      *     timestamp and the amount of microseconds already elapsed in the current second. The
-     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     *     returned array is in a <code>[Unix timestamp, Microseconds already elapsed]</code> format.
      * @example
      *     <pre>{@code
      * String[] serverTime = client.time().get();
@@ -265,7 +265,7 @@ public interface ServerManagementClusterCommands {
      *     command to the nodes defined by <code>route</code>.
      * @return The current server time as a <code>String</code> array with two elements: A Unix
      *     timestamp and the amount of microseconds already elapsed in the current second. The
-     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     *     returned array is in a <code>[Unix timestamp, Microseconds already elapsed]</code> format.
      * @example
      *     <pre>{@code
      * // Command sent to a single random node via RANDOM route, expecting a SingleValue result.

--- a/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementClusterCommands.java
@@ -240,4 +240,46 @@ public interface ServerManagementClusterCommands {
      * }</pre>
      */
     CompletableFuture<String> configSet(Map<String, String> parameters, Route route);
+
+    /**
+     * Returns the server time. <br>
+     * The command will be routed to a random node.
+     *
+     * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
+     * @return The current server time as a <code>String</code> array with two elements: A Unix
+     *     timestamp and the amount of microseconds already elapsed in the current second. The
+     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     * @example
+     *     <pre>{@code
+     * String[] serverTime = client.time().get();
+     * System.out.println("Server time is: " + serverTime[0] + "." + serverTime[1]);
+     * }</pre>
+     */
+    CompletableFuture<String[]> time();
+
+    /**
+     * Returns the server time.
+     *
+     * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
+     * @param route Specifies the routing configuration for the command. The client will route the
+     *     command to the nodes defined by <code>route</code>.
+     * @return The current server time as a <code>String</code> array with two elements: A Unix
+     *     timestamp and the amount of microseconds already elapsed in the current second. The
+     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     * @example
+     *     <pre>{@code
+     * // Command sent to a single random node via RANDOM route, expecting a SingleValue result.
+     * String[] serverTime = client.time().get(RANDOM).getSingleValue();
+     * System.out.println("Server time is: " + serverTime[0] + "." + serverTime[1]);
+     *
+     * // Command sent to all nodes via ALL_NODES route, expecting a MultiValue result.
+     * Map<String, String[]> serverTimeForAllNodes = client.time(ALL_NODES).get().getMultiValue();
+     * for(var serverTimePerNode : serverTimeForAllNodes.getMultiValue().entrySet()) {
+     *     String node = serverTimePerNode.getKey();
+     *     String serverTimePerNodeStr = serverTimePerNode.getValue()[0] + "." + serverTimePerNode.getValue()[1];
+     *     System.out.println("Server time for node [" + node + "]: " + serverTimePerNodeStr);
+     * }
+     * }</pre>
+     */
+    CompletableFuture<ClusterValue<String[]>> time(Route route);
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
@@ -117,4 +117,19 @@ public interface ServerManagementCommands {
      * }</pre>
      */
     CompletableFuture<String> configSet(Map<String, String> parameters);
+
+    /**
+     * Returns the server time.
+     *
+     * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
+     * @return The current server time as a <code>String</code> array with two elements: A Unix
+     *     timestamp and the amount of microseconds already elapsed in the current second. The
+     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     * @example
+     *     <pre>{@code
+     * String[] serverTime = client.time().get();
+     * System.out.println("Server time is: " + serverTime[0] + "." + serverTime[1]);
+     * }</pre>
+     */
+    CompletableFuture<String[]> time();
 }

--- a/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ServerManagementCommands.java
@@ -124,7 +124,7 @@ public interface ServerManagementCommands {
      * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
      * @return The current server time as a <code>String</code> array with two elements: A Unix
      *     timestamp and the amount of microseconds already elapsed in the current second. The
-     *     returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     *     returned array is in a <code>[Unix timestamp, Microseconds already elapsed]</code> format.
      * @example
      *     <pre>{@code
      * String[] serverTime = client.time().get();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -1295,7 +1295,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
      * @return Command Response - The current server time as a <code>String</code> array with two
      *     elements: A Unix timestamp and the amount of microseconds already elapsed in the current
-     *     second. The returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     *     second. The returned array is in a <code>[Unix timestamp, Microseconds already elapsed]
+     *     </code> format.
      */
     public T time() {
         protobufTransaction.addCommands(buildCommand(Time));

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -52,6 +52,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Strlen;
 import static redis_request.RedisRequestOuterClass.RequestType.TTL;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
@@ -1285,6 +1286,19 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs = buildArgs(key);
 
         protobufTransaction.addCommands(buildCommand(PTTL, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the server time.
+     *
+     * @see <a href="https://redis.io/commands/time/">redis.io</a> for details.
+     * @return Command Response - The current server time as a <code>String</code> array with two
+     *     elements: A Unix timestamp and the amount of microseconds already elapsed in the current
+     *     second. The returned array is in a [Unix timestamp, Microseconds already elapsed] format.
+     */
+    public T time() {
+        protobufTransaction.addCommands(buildCommand(Time));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -4,6 +4,7 @@ package glide.utils;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** Utility methods for data conversion. */
@@ -49,6 +50,22 @@ public class ArrayTransformUtils {
         return Arrays.stream(objectArr)
                 .map(clazz::cast)
                 .toArray(size -> (U[]) Array.newInstance(clazz, size));
+    }
+
+    /**
+     * Maps a Map of Arrays with value type T[] to value of U[].
+     *
+     * @param mapOfArrays Map of Array values to cast.
+     * @param clazz The class of the array values to cast to.
+     * @return A Map of arrays of type U[], containing the key/values from the input Map.
+     * @param <T> The base type from which the elements are being cast.
+     * @param <U> The subtype of T to which the elements are cast.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T, U extends T> Map<String, U[]> castMapOfArrays(
+            Map<String, T[]> mapOfArrays, Class<U> clazz) {
+        return mapOfArrays.entrySet().stream()
+                .collect(Collectors.toMap(k -> k.getKey(), e -> castArray(e.getValue(), clazz)));
     }
 
     /**

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -64,6 +64,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Strlen;
 import static redis_request.RedisRequestOuterClass.RequestType.TTL;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
@@ -1730,5 +1731,25 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void time_returns_success() {
+        // setup
+        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
+        String[] payload = new String[] {"UnixTime", "ms"};
+        when(testResponse.get()).thenReturn(payload);
+
+        // match on protobuf request
+        when(commandManager.<String[]>submitNewCommand(eq(Time), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String[]> response = service.time();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(payload, response.get());
     }
 }

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -674,9 +674,10 @@ public class RedisClusterClientTest {
     @Test
     public void time_returns_success() {
         // setup
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
+
         String[] payload = new String[] {"UnixTime", "ms"};
-        when(testResponse.get()).thenReturn(payload);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(payload);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(Time), eq(new String[0]), any()))
@@ -694,9 +695,9 @@ public class RedisClusterClientTest {
     @Test
     public void time_returns_with_route_success() {
         // setup
-        CompletableFuture<ClusterValue<String[]>> testResponse = mock(CompletableFuture.class);
         String[] payload = new String[] {"UnixTime", "ms"};
-        when(testResponse.get()).thenReturn(ClusterValue.ofSingleValue(payload));
+        CompletableFuture<ClusterValue<String[]>> testResponse = new CompletableFuture<>();
+        testResponse.complete(ClusterValue.ofSingleValue(payload));
 
         // match on protobuf request
         when(commandManager.<ClusterValue<String[]>>submitNewCommand(

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -21,6 +21,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.ConfigSet;
 import static redis_request.RedisRequestOuterClass.RequestType.Echo;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 
 import glide.api.models.ClusterValue;
 import glide.api.models.commands.InfoOptions;
@@ -667,5 +668,46 @@ public class RedisClusterClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void time_returns_success() {
+        // setup
+        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
+        String[] payload = new String[] {"UnixTime", "ms"};
+        when(testResponse.get()).thenReturn(payload);
+
+        // match on protobuf request
+        when(commandManager.<String[]>submitNewCommand(eq(Time), eq(new String[0]), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String[]> response = service.time();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(payload, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void time_returns_with_route_success() {
+        // setup
+        CompletableFuture<ClusterValue<String[]>> testResponse = mock(CompletableFuture.class);
+        String[] payload = new String[] {"UnixTime", "ms"};
+        when(testResponse.get()).thenReturn(ClusterValue.ofSingleValue(payload));
+
+        // match on protobuf request
+        when(commandManager.<ClusterValue<String[]>>submitNewCommand(
+                        eq(Time), eq(new String[0]), eq(RANDOM), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<ClusterValue<String[]>> response = service.time(RANDOM);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(payload, response.get().getSingleValue());
     }
 }

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -50,6 +50,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.SRem;
 import static redis_request.RedisRequestOuterClass.RequestType.SetString;
 import static redis_request.RedisRequestOuterClass.RequestType.Strlen;
 import static redis_request.RedisRequestOuterClass.RequestType.TTL;
+import static redis_request.RedisRequestOuterClass.RequestType.Time;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.Zadd;
@@ -384,6 +385,9 @@ public class TransactionTests {
 
         transaction.zcard("key");
         results.add(Pair.of(Zcard, ArgsArray.newBuilder().addArgs("key").build()));
+
+        transaction.time();
+        results.add(Pair.of(Time, ArgsArray.newBuilder().build()));
 
         transaction.type("key");
         results.add(Pair.of(Type, ArgsArray.newBuilder().addArgs("key").build()));

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -35,6 +35,7 @@ import glide.api.models.configuration.RedisClusterClientConfiguration;
 import glide.api.models.configuration.RequestRoutingConfiguration.SlotKeyRoute;
 import glide.api.models.exceptions.RedisException;
 import glide.api.models.exceptions.RequestException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -522,5 +523,39 @@ public class CommandTests {
 
         Map<String, String> multiPayload = clusterClient.echo(message, ALL_NODES).get().getMultiValue();
         multiPayload.forEach((key, value) -> assertEquals(message, value));
+    }
+
+    @Test
+    @SneakyThrows
+    public void time() {
+        // Take the time now, convert to 10 digits and subtract 1 second
+        long now = Instant.now().getEpochSecond() - 1L;
+        String[] result = clusterClient.time().get();
+        assertEquals(2, result.length);
+        assertTrue(
+                Long.parseLong(result[0]) > now,
+                "Time() result (" + result[0] + ") should be greater than now (" + now + ")");
+        assertTrue(Long.parseLong(result[1]) < 1000000);
+    }
+
+    @Test
+    @SneakyThrows
+    public void time_with_route() {
+        // Take the time now, convert to 10 digits and subtract 1 second
+        long now = Instant.now().getEpochSecond() - 1L;
+
+        ClusterValue<String[]> result = clusterClient.time(ALL_PRIMARIES).get();
+        assertTrue(result.hasMultiData());
+        assertTrue(result.getMultiValue().size() > 1);
+
+        // check the first node's server time
+        Object[] serverTime =
+                result.getMultiValue().get(result.getMultiValue().keySet().toArray(String[]::new)[0]);
+
+        assertEquals(2, serverTime.length);
+        assertTrue(
+                Long.parseLong((String) serverTime[0]) > now,
+                "Time() result (" + serverTime[0] + ") should be greater than now (" + now + ")");
+        assertTrue(Long.parseLong((String) serverTime[1]) < 1000000);
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -24,6 +24,7 @@ import glide.api.models.commands.InfoOptions;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClientConfiguration;
 import glide.api.models.exceptions.RequestException;
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -249,5 +250,20 @@ public class CommandTests {
         String message = "GLIDE";
         String response = regularClient.echo(message).get();
         assertEquals(message, response);
+    }
+
+    @Test
+    @SneakyThrows
+    public void time() {
+        // Take the time now, convert to 10 digits and subtract 1 second
+        long now = Instant.now().getEpochSecond() - 1L;
+        String[] result = regularClient.time().get();
+
+        assertEquals(2, result.length);
+
+        assertTrue(
+                Long.parseLong(result[0]) > now,
+                "Time() result (" + result[0] + ") should be greater than now (" + now + ")");
+        assertTrue(Long.parseLong(result[1]) < 1000000);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add [Time()](https://redis.io/commands/time/) command to the java wrapper for both standalone and cluster modes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
