### PR TITLE
Downgrade cargo deny and rustc to fix failing CI builds

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
     run-tests:
-        timeout-minutes: 15
+        timeout-minutes: 25
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -28,6 +28,10 @@ runs:
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash
 
+        - run: rustup component add clippy
+          working-directory: ${{ inputs.cargo-toml-folder }}
+          shell: bash
+
         - run: cargo fmt --all -- --check
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -14,23 +14,15 @@ runs:
           with:
               submodules: recursive
 
-        - uses: dtolnay/rust-toolchain@master
+        - uses: dtolnay/rust-toolchain@1.76.0
           with:
-              toolchain: "1.76.0"
+              components: "rustfmt, clippy"
         - uses: Swatinem/rust-cache@v2
 
         - name: Install protoc (protobuf)
           uses: arduino/setup-protoc@v3
           with:
             version: "25.1"
-
-        - run: rustup component add rustfmt
-          working-directory: ${{ inputs.cargo-toml-folder }}
-          shell: bash
-
-        - run: rustup component add clippy
-          working-directory: ${{ inputs.cargo-toml-folder }}
-          shell: bash
 
         - run: cargo fmt --all -- --check
           working-directory: ${{ inputs.cargo-toml-folder }}

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -37,7 +37,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install --version 0.14.14 cargo-deny
+              cargo install --version 0.14.3 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -24,6 +24,8 @@ runs:
           with:
             version: "25.1"
 
+        - run: rustup component add rustfmt
+
         - run: cargo fmt --all -- --check
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -37,7 +37,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install cargo-deny
+              cargo install --version 0.14.18 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -37,7 +37,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install --version 0.14.18 cargo-deny
+              cargo install --version 0.14.14 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -14,7 +14,7 @@ runs:
           with:
               submodules: recursive
 
-        - uses: dtolnay/rust-toolchain@stable
+        - uses: dtolnay/rust-toolchain@1.76.0
         - uses: Swatinem/rust-cache@v2
 
         - name: Install protoc (protobuf)
@@ -37,7 +37,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install --version 0.14.0 cargo-deny
+              cargo install --version 0.14.3 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -37,7 +37,7 @@ runs:
 
         - run: |
               cargo update
-              cargo install --version 0.14.3 cargo-deny
+              cargo install --version 0.14.0 cargo-deny
               cargo deny check --config ${GITHUB_WORKSPACE}/deny.toml
           working-directory: ${{ inputs.cargo-toml-folder }}
           shell: bash

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -14,7 +14,9 @@ runs:
           with:
               submodules: recursive
 
-        - uses: dtolnay/rust-toolchain@1.76.0
+        - uses: dtolnay/rust-toolchain@master
+          with:
+              toolchain: "1.76.0"
         - uses: Swatinem/rust-cache@v2
 
         - name: Install protoc (protobuf)

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -25,6 +25,8 @@ runs:
             version: "25.1"
 
         - run: rustup component add rustfmt
+          working-directory: ${{ inputs.cargo-toml-folder }}
+          shell: bash
 
         - run: cargo fmt --all -- --check
           working-directory: ${{ inputs.cargo-toml-folder }}


### PR DESCRIPTION
This is a workaround to fix CI builds. A better fix should be implemented when a proper solution is found.

The `cargo-deny` plugin has been having issues checking for advisories recently: https://github.com/EmbarkStudios/cargo-deny/issues/641

I tried the other versions of `cargo-deny` mentioned by users in that issue (0.14.18, 0.14.17, 0.14.16, 0.14.10, 0.14.4), but none worked. Version 0.14.3 only works because I downgraded the Rust compiler as well to 1.76.0. The `rustc` version 1.77.0 only released a few days ago, so I suspect that may be related to the new failures in `cargo-deny` but this is just speculation. Regardless, the combination of `cargo-deny` 0.14.3 and `rustc` 1.76.0 seem to at least allow the lint-rust action to pass.