### PR TITLE
Set the versions of external clients to be fixed on the current latest releases.

### DIFF
--- a/benchmarks/node/package.json
+++ b/benchmarks/node/package.json
@@ -15,9 +15,9 @@
         "@types/stats-lite": "^2.2.0",
         "command-line-args": "^5.2.1",
         "glide-for-redis": "file:../../node",
-        "ioredis": "^5.3.2",
+        "ioredis": "5.3.2",
         "percentile": "^1.6.0",
-        "redis": "^4.6.2",
+        "redis": "4.6.13",
         "stats-lite": "^2.2.0"
     },
     "devDependencies": {

--- a/benchmarks/python/requirements.txt
+++ b/benchmarks/python/requirements.txt
@@ -2,4 +2,4 @@ hiredis
 numpy
 
 # redis-py
-redis>=5.0.1
+redis==5.0.3


### PR DESCRIPTION
To avoid issues with changes in the clients' licenses 