### PR TITLE
Node - Fix semgrep detected vulnerability in hybrid tests

### DIFF
--- a/node/hybrid-node-tests/commonjs-test/commonjs-test.cjs
+++ b/node/hybrid-node-tests/commonjs-test/commonjs-test.cjs
@@ -2,16 +2,15 @@
 const { AsyncClient } = require("glide-rs");
 const RedisServer = require("redis-server");
 const FreePort = require("find-free-port");
-const PORT_NUMBER = 4001;
+const { execFile } = require("child_process");
 
+const PORT_NUMBER = 4001;
 let server;
 let port;
 
-const { exec } = require("child_process");
-
 function flushallOnPort(port) {
     return new Promise((resolve, reject) => {
-        exec(`redis-cli -p ${port} FLUSHALL`, (error, _, stderr) => {
+        execFile("redis-cli", ["-p", port, "FLUSHALL"], (error, _, stderr) => {
             if (error) {
                 console.error(stderr);
                 reject(error);

--- a/node/hybrid-node-tests/ecmascript-test/ecmascript-test.mjs
+++ b/node/hybrid-node-tests/ecmascript-test/ecmascript-test.mjs
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import findFreePorts from "find-free-ports";
 import { AsyncClient } from "glide-rs";
 import RedisServer from "redis-server";
@@ -7,9 +7,9 @@ const PORT_NUMBER = 4001;
 let server;
 let port;
 
-export function flushallOnPort(port) {
+function flushallOnPort(port) {
     return new Promise((resolve, reject) => {
-        exec(`redis-cli -p ${port} FLUSHALL`, (error, _, stderr) => {
+        execFile("redis-cli", ["-p", port, "FLUSHALL"], (error, _, stderr) => {
             if (error) {
                 console.error(stderr);
                 reject(error);


### PR DESCRIPTION
Fix semgrep detected vulnerability in hybrid tests by using array which does not allow shell parameter expansion


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
