### PR TITLE
node - fixed broken path of tsconfig translation

### DIFF
--- a/node/fixup_pj_files_for_build_type
+++ b/node/fixup_pj_files_for_build_type
@@ -2,16 +2,12 @@
 # This script add "type" and "types" entries to the different `package.json` that been created for `ECMAScript` and `CommonJS` with the fitting values.
 cat >build-ts/cjs/package.json <<!EOF
 {
-    "type": "commonjs",
-    "types": "build-ts/cjs/index.d.ts"
-
+    "type": "commonjs"
 }
 !EOF
 
 cat >build-ts/mjs/package.json <<!EOF
 {
-    "type": "module",
-    "types": "build-ts/mjs/index.d.ts"
-
+    "type": "module"
 }
 !EOF

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -4,63 +4,98 @@
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
 
-const { platform, arch } = process;
-let nativeBinding = null;
-switch (platform) {
-    case "linux":
-        switch (arch) {
-            case "x64":
-                nativeBinding = await import(
-                    "@scope/glide-for-redis-linux-x64"
-                );
-                break;
-            case "arm64":
-                nativeBinding = await import(
-                    "@scope/glide-for-redis-linux-arm64"
-                );
-                break;
-            default:
-                throw new Error(
-                    `Unsupported OS: ${platform}, architecture: ${arch}`,
-                );
-        }
-        break;
-    case "darwin":
-        switch (arch) {
-            case "x64":
-                nativeBinding = await import(
-                    "@scope/glide-for-redis-darwin-x64"
-                );
-                break;
-            case "arm64":
-                nativeBinding = await import(
-                    "@scope/glide-for-redis-darwin-arm64"
-                );
-                break;
-            default:
-                throw new Error(
-                    `Unsupported OS: ${platform}, architecture: ${arch}`,
-                );
-        }
-        break;
-    default:
-        throw new Error(`Unsupported OS: ${platform}, architecture: ${arch}`);
+import { arch, platform } from "process";
+
+let globalObject = global as unknown;
+
+async function loadNativeBinding() {
+    let nativeBinding = null;
+    switch (platform) {
+        case "linux":
+            switch (arch) {
+                case "x64":
+                    nativeBinding = await import(
+                        "@scope/glide-for-redis-linux-x64"
+                    );
+                    break;
+                case "arm64":
+                    nativeBinding = await import(
+                        "@scope/glide-for-redis-linux-arm64"
+                    );
+                    break;
+                default:
+                    throw new Error(
+                        `Unsupported OS: ${platform}, architecture: ${arch}`,
+                    );
+            }
+            break;
+        case "darwin":
+            switch (arch) {
+                case "x64":
+                    nativeBinding = await import(
+                        "@scope/glide-for-redis-darwin-x64"
+                    );
+                    break;
+                case "arm64":
+                    nativeBinding = await import(
+                        "@scope/glide-for-redis-darwin-arm64"
+                    );
+                    break;
+                default:
+                    throw new Error(
+                        `Unsupported OS: ${platform}, architecture: ${arch}`,
+                    );
+            }
+            break;
+        default:
+            throw new Error(
+                `Unsupported OS: ${platform}, architecture: ${arch}`,
+            );
+    }
+    if (!nativeBinding) {
+        throw new Error(`Failed to load native binding`);
+    }
+    return nativeBinding;
 }
-if (!nativeBinding) {
-    throw new Error(`Failed to load native binding`);
+
+async function initialize() {
+    const nativeBinding = await loadNativeBinding();
+    const {
+        RedisClient,
+        RedisClusterClient,
+        Logger,
+        ExpireOptions,
+        InfoOptions,
+        ClosingError,
+        ExecAbortError,
+        RedisError,
+        RequestError,
+        TimeoutError,
+        ClusterTransaction,
+        Transaction,
+    } = nativeBinding;
+
+    module.exports = {
+        RedisClient,
+        RedisClusterClient,
+        Logger,
+        ExpireOptions,
+        InfoOptions,
+        ClosingError,
+        ExecAbortError,
+        RedisError,
+        RequestError,
+        TimeoutError,
+        ClusterTransaction,
+        Transaction,
+    };
+
+    globalObject = Object.assign(global, nativeBinding);
 }
-export const {
-    RedisClient,
-    RedisClusterClient,
-    Logger,
-    ExpireOptions,
-    InfoOptions,
-    ClosingError,
-    ExecAbortError,
-    RedisError,
-    RequestError,
-    TimeoutError,
-    ClusterTransaction,
-    Transaction,
-} = nativeBinding;
-export default Object.assign(global, nativeBinding);
+
+initialize().catch((error) => {
+    console.error("Failed to initialize:", error);
+    process.exit(1);
+});
+
+export default globalObject;

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -1,6 +1,6 @@
 {
-    "type": "module",
     "name": "${scope}${pkg_name}",
+    "types": "build-ts/mjs/index.d.ts",
     "version": "${package_version}",
     "description": "An AWS-sponsored, open-source Redis client.",
     "main": "build-ts/cjs/index.js",
@@ -8,7 +8,8 @@
     "exports": {
         ".": {
             "import": "./build-ts/mjs/index.js",
-            "require": "./build-ts/cjs/index.js"
+            "require": "./build-ts/cjs/index.js",
+            "types": "./build-ts/mjs/index.d.ts"
         }
     },
     "scripts": {

--- a/node/npm/glide/tsconfig-cjs.json
+++ b/node/npm/glide/tsconfig-cjs.json
@@ -1,6 +1,9 @@
 {
-    "extends": "../../tsconfig-cjs.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig to read more about this file */
+        "module": "CommonJS" /* Specify what module code is generated. */,
+        /* Emit */
         "outDir": "./build-ts/cjs" /* Specify an output folder for all emitted files. */
     }
 }

--- a/node/npm/glide/tsconfig-mjs.json
+++ b/node/npm/glide/tsconfig-mjs.json
@@ -1,6 +1,9 @@
 {
-    "extends": "../../tsconfig-mjs.json",
+    "extends": "./tsconfig.json",
     "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig to read more about this file */
+        "module": "esnext" /* Specify what module code is generated. */,
+        /* Emit */
         "outDir": "./build-ts/mjs" /* Specify an output folder for all emitted files. */
     }
 }

--- a/node/npm/glide/tsconfig.json
+++ b/node/npm/glide/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "esnext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+        "allowJs": true,
+        "esModuleInterop": true,
+        "baseUrl": "./",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+        "allowSyntheticDefaultImports": true,
+        "declaration": true,
+        "inlineSourceMap": false,
+        "lib": ["esnext"],
+        "listEmittedFiles": false,
+        "listFiles": false,
+        "noFallthroughCasesInSwitch": true,
+        "pretty": true,
+        "resolveJsonModule": true,
+        "traceResolution": false,
+        "types": ["node", "jest"],
+        /* The bellow parts are for developer extention usage and should be overriden in cjs and mjs tscofig's files */
+        "module": "ESNext" /* Specify what module code is generated. Ovrride in tsconfig-cjs/mjs */,
+        "outDir": "./build-ts/mjs" /* Specify an output folder for all emitted files. Ovrride in tsconfig-cjs */
+    },
+    "include": ["./*.ts", "src/*.ts", "src/*.js"],
+    "exclude": [
+        "node_modules",
+        "build-ts"
+    ] /* Prevents TypeScript from compiling files in node_modules and build-ts */
+}

--- a/node/package.json
+++ b/node/package.json
@@ -3,10 +3,12 @@
     "description": "An AWS-sponsored, open-source Redis client.",
     "main": "build-ts/cjs/index.js",
     "module": "build-ts/mjs/index.js",
+    "types": "./build-ts/mjs/index.d.ts",
     "exports": {
         ".": {
             "import": "./build-ts/mjs/index.js",
-            "require": "./build-ts/cjs/index.js"
+            "require": "./build-ts/cjs/index.js",
+            "types": "./build-ts/mjs/index.d.ts"
         }
     },
     "repository": {


### PR DESCRIPTION
Apparently when inheriting tsconfig, everything is happening in the folder of the parent-file, so paths etc. are  base on where the parent file located, which broke the importing of index file for different arch'

Plus - the index file was written in a way that can work just with esm, so translated it to fit both.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
