### PR TITLE
Removed signals hook in socket.

### DIFF
--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -11,8 +11,6 @@ authors = ["Amazon Web Services"]
 bytes = { version = "^1.3", optional = true }
 futures = "^0.3"
 redis = { path = "../submodules/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp", "connection-manager","cluster", "cluster-async"] }
-signal-hook = { version = "^0.3", optional = true }
-signal-hook-tokio = {version = "^0.3", features = ["futures-v0_3"], optional = true }
 tokio = { version = "1", features = ["macros", "time"] }
 logger_core = {path = "../logger_core"}
 dispose = "0.5.0"
@@ -30,7 +28,7 @@ arcstr = "1.1.5"
 sha1_smol = "1.0.0"
 
 [features]
-socket-layer = ["directories", "integer-encoding", "num_cpus", "signal-hook", "signal-hook-tokio", "protobuf", "tokio-util", "bytes", "rand"]
+socket-layer = ["directories", "integer-encoding", "num_cpus", "protobuf", "tokio-util", "bytes", "rand"]
 
 [dev-dependencies]
 rsevents = "0.3.1"


### PR DESCRIPTION
The signals hook caused Node to not respond to ^C and similar signals, since Node yields to existing signals hooks. Tested Python, Node, C#, & Java benchmarks - all closed with ^C after this change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
