### PR TITLE
Python: Fix typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 #### Changes
 * Python: Added JSON.DEL JSON.FORGET commands  ([#1146](https://github.com/aws/glide-for-redis/pull/1146))
 
+#### Fixes
+* Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))
+
 ## 0.3.1 (2024-03-28)
 
 #### Fixes

--- a/python/python/glide/redis_client.py
+++ b/python/python/glide/redis_client.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import threading
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Type, Union, cast
 
 import async_timeout
 from glide.async_commands.cluster_commands import ClusterCommands
@@ -35,7 +35,7 @@ from .glide import (
 
 def get_request_error_class(
     error_type: Optional[RequestErrorType.ValueType],
-) -> type[RequestError]:
+) -> Type[RequestError]:
     if error_type == RequestErrorType.Disconnect:
         return ConnectionError
     if error_type == RequestErrorType.ExecAbort:


### PR DESCRIPTION
Resolves error on python3.8:
```
Traceback (most recent call last):
  File “client_example.py”, line 6, in <module>
    from glide import (
  File “/Users/daganh/Library/Python/3.8/lib/python/site-packages/glide/__init__.py”, line 11, in <module>
    from glide.async_commands.redis_modules import json
  File “/Users/daganh/Library/Python/3.8/lib/python/site-packages/glide/async_commands/redis_modules/json.py”, line 23, in <module>
    from glide.redis_client import TRedisClient
  File “/Users/daganh/Library/Python/3.8/lib/python/site-packages/glide/redis_client.py”, line 38, in <module>
    ) -> type[RequestError]:
TypeError: ‘type’ object is not subscriptable