### PR TITLE
Clean up all warnings in Java client test

### DIFF
--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -133,8 +133,8 @@ public class RedisClientTest {
         Object value = "testValue";
         String cmd = "GETSTRING";
         String[] arguments = new String[] {cmd, key};
-        CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Object> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.submitNewCommand(eq(CustomCommand), eq(arguments), any()))
@@ -175,8 +175,8 @@ public class RedisClientTest {
     @Test
     public void ping_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn("PONG");
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete("PONG");
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(Ping), eq(new String[0]), any()))
@@ -217,9 +217,9 @@ public class RedisClientTest {
     @Test
     public void select_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        Long index = 5L;
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        long index = 5L;
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(
@@ -241,8 +241,8 @@ public class RedisClientTest {
         // setup
         String[] keys = new String[] {"testKey1", "testKey2"};
         Long numberDeleted = 1L;
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(numberDeleted);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(numberDeleted);
         when(commandManager.<Long>submitNewCommand(eq(Del), eq(keys), any())).thenReturn(testResponse);
 
         // exercise
@@ -260,8 +260,8 @@ public class RedisClientTest {
         // setup
         String[] keys = new String[] {"testKey1", "testKey2"};
         Long numberUnlinked = 1L;
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(numberUnlinked);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(numberUnlinked);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Unlink), eq(keys), any()))
@@ -282,8 +282,8 @@ public class RedisClientTest {
         // setup
         String key = "testKey";
         String value = "testValue";
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
         when(commandManager.<String>submitNewCommand(eq(GetString), eq(new String[] {key}), any()))
                 .thenReturn(testResponse);
 
@@ -302,9 +302,10 @@ public class RedisClientTest {
         // setup
         String key = "testKey";
         String value = "testValue";
-        CompletableFuture<Void> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(null);
-        when(commandManager.<Void>submitNewCommand(eq(SetString), eq(new String[] {key, value}), any()))
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(null);
+        when(commandManager.<String>submitNewCommand(
+                        eq(SetString), eq(new String[] {key, value}), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -330,8 +331,8 @@ public class RedisClientTest {
                         .build();
         String[] arguments = new String[] {key, value, ONLY_IF_EXISTS.getRedisApi(), "KEEPTTL"};
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(null);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(null);
         when(commandManager.<String>submitNewCommand(eq(SetString), eq(arguments), any()))
                 .thenReturn(testResponse);
 
@@ -359,8 +360,8 @@ public class RedisClientTest {
                 new String[] {
                     key, value, ONLY_IF_DOES_NOT_EXIST.getRedisApi(), RETURN_OLD_VALUE, "EXAT", "60"
                 };
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
         when(commandManager.<String>submitNewCommand(eq(SetString), eq(arguments), any()))
                 .thenReturn(testResponse);
 
@@ -378,8 +379,8 @@ public class RedisClientTest {
         // setup
         String[] keys = new String[] {"testKey1", "testKey2"};
         Long numberExisting = 1L;
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(numberExisting);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(numberExisting);
         when(commandManager.<Long>submitNewCommand(eq(Exists), eq(keys), any()))
                 .thenReturn(testResponse);
 
@@ -400,8 +401,8 @@ public class RedisClientTest {
         long seconds = 10L;
         String[] arguments = new String[] {key, Long.toString(seconds)};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(true);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(Expire), eq(arguments), any()))
@@ -423,8 +424,8 @@ public class RedisClientTest {
         long seconds = 10L;
         String[] arguments = new String[] {key, Long.toString(seconds), "NX"};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(false);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(Expire), eq(arguments), any()))
@@ -446,8 +447,8 @@ public class RedisClientTest {
         long unixSeconds = 100000L;
         String[] arguments = new String[] {key, Long.toString(unixSeconds)};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(true);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(ExpireAt), eq(arguments), any()))
@@ -469,8 +470,8 @@ public class RedisClientTest {
         long unixSeconds = 100000L;
         String[] arguments = new String[] {key, Long.toString(unixSeconds), "XX"};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(false);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(ExpireAt), eq(arguments), any()))
@@ -493,8 +494,8 @@ public class RedisClientTest {
         long milliseconds = 50000L;
         String[] arguments = new String[] {key, Long.toString(milliseconds)};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(true);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(PExpire), eq(arguments), any()))
@@ -516,8 +517,8 @@ public class RedisClientTest {
         long milliseconds = 50000L;
         String[] arguments = new String[] {key, Long.toString(milliseconds), "LT"};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(false);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(PExpire), eq(arguments), any()))
@@ -540,8 +541,8 @@ public class RedisClientTest {
         long unixMilliseconds = 999999L;
         String[] arguments = new String[] {key, Long.toString(unixMilliseconds)};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(true);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(PExpireAt), eq(arguments), any()))
@@ -563,8 +564,8 @@ public class RedisClientTest {
         long unixMilliseconds = 999999L;
         String[] arguments = new String[] {key, Long.toString(unixMilliseconds), "GT"};
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(false);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(PExpireAt), eq(arguments), any()))
@@ -585,9 +586,8 @@ public class RedisClientTest {
         // setup
         String key = "testKey";
         long ttl = 999L;
-
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(ttl);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(ttl);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(TTL), eq(new String[] {key}), any()))
@@ -701,9 +701,9 @@ public class RedisClientTest {
     @Test
     public void info_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
         String testPayload = "Key: Value";
-        when(testResponse.get()).thenReturn(testPayload);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(testPayload);
         when(commandManager.<String>submitNewCommand(eq(Info), eq(new String[0]), any()))
                 .thenReturn(testResponse);
 
@@ -722,9 +722,9 @@ public class RedisClientTest {
         // setup
         String[] arguments =
                 new String[] {InfoOptions.Section.ALL.toString(), InfoOptions.Section.DEFAULT.toString()};
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
         String testPayload = "Key: Value";
-        when(testResponse.get()).thenReturn(testPayload);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(testPayload);
         when(commandManager.<String>submitNewCommand(eq(Info), eq(arguments), any()))
                 .thenReturn(testResponse);
 
@@ -746,9 +746,9 @@ public class RedisClientTest {
     @Test
     public void info_with_empty_InfoOptions_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
         String testPayload = "Key: Value";
-        when(testResponse.get()).thenReturn(testPayload);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(testPayload);
         when(commandManager.<String>submitNewCommand(eq(Info), eq(new String[0]), any()))
                 .thenReturn(testResponse);
 
@@ -768,11 +768,11 @@ public class RedisClientTest {
         String[] keys = {"key1", null, "key2"};
         String[] values = {"value1", null, "value2"};
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(values);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(values);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(MGet), eq(keys), any()))
+        when(commandManager.<String[]>submitNewCommand(eq(MGet), eq(keys), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -793,8 +793,8 @@ public class RedisClientTest {
         keyValueMap.put("key2", "value2");
         String[] args = {"key1", "value1", "key2", "value2"};
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(MSet), eq(args), any()))
@@ -816,11 +816,11 @@ public class RedisClientTest {
         String key = "testKey";
         Long value = 10L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(eq(Incr), eq(new String[] {key}), any()))
+        when(commandManager.<Long>submitNewCommand(eq(Incr), eq(new String[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -840,11 +840,11 @@ public class RedisClientTest {
         long amount = 1L;
         Long value = 10L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(
+        when(commandManager.<Long>submitNewCommand(
                         eq(IncrBy), eq(new String[] {key, Long.toString(amount)}), any()))
                 .thenReturn(testResponse);
 
@@ -865,11 +865,11 @@ public class RedisClientTest {
         double amount = 1.1;
         Double value = 10.1;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Double> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
-        when(commandManager.<String>submitNewCommand(
+        when(commandManager.<Double>submitNewCommand(
                         eq(IncrByFloat), eq(new String[] {key, Double.toString(amount)}), any()))
                 .thenReturn(testResponse);
 
@@ -889,8 +889,8 @@ public class RedisClientTest {
         String key = "testKey";
         Long value = 10L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Decr), eq(new String[] {key}), any()))
@@ -913,8 +913,8 @@ public class RedisClientTest {
         long amount = 1L;
         Long value = 10L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(
@@ -962,8 +962,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, field};
         String value = "value";
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
         when(commandManager.<String>submitNewCommand(eq(HashGet), eq(args), any()))
                 .thenReturn(testResponse);
 
@@ -987,8 +987,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, "field1", "value1", "field2", "value2"};
         Long value = 2L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
         when(commandManager.<Long>submitNewCommand(eq(HashSet), eq(args), any()))
                 .thenReturn(testResponse);
 
@@ -1035,8 +1035,8 @@ public class RedisClientTest {
         String[] args = {key, "testField1", "testField2"};
         Long value = 2L;
 
-        CompletableFuture testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(HashDel), eq(args), any()))
@@ -1084,8 +1084,8 @@ public class RedisClientTest {
         String[] args = {"testKey", "testField1", "testField2"};
         String[] value = {"testValue1", "testValue2"};
 
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(HashMGet), eq(args), any()))
@@ -1109,8 +1109,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, field};
         Boolean value = true;
 
-        CompletableFuture<Boolean> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Boolean>submitNewCommand(eq(HashExists), eq(args), any()))
@@ -1135,8 +1135,8 @@ public class RedisClientTest {
         value.put("key1", "field1");
         value.put("key2", "field2");
 
-        CompletableFuture<Map<String, String>> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Map<String, String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Map<String, String>>submitNewCommand(eq(HashGetAll), eq(args), any()))
@@ -1160,8 +1160,8 @@ public class RedisClientTest {
         long amount = 1L;
         Long value = 10L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(
@@ -1186,8 +1186,8 @@ public class RedisClientTest {
         double amount = 1.0;
         Double value = 10.0;
 
-        CompletableFuture<Double> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Double> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Double>submitNewCommand(
@@ -1212,8 +1212,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, "value1", "value2"};
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(LPush), eq(args), any()))
@@ -1236,8 +1236,8 @@ public class RedisClientTest {
         String[] args = new String[] {key};
         String value = "value";
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(LPop), eq(args), any()))
@@ -1261,8 +1261,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, Long.toString(count)};
         String[] value = new String[] {"value1", "value2"};
 
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(LPop), eq(args), any()))
@@ -1287,8 +1287,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, Long.toString(start), Long.toString(end)};
         String[] value = new String[] {"value1", "value2"};
 
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(LRange), eq(args), any()))
@@ -1312,8 +1312,8 @@ public class RedisClientTest {
         long end = 2L;
         String[] args = new String[] {key, Long.toString(end), Long.toString(start)};
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(LTrim), eq(args), any()))
@@ -1336,8 +1336,8 @@ public class RedisClientTest {
         String[] args = new String[] {key};
         long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(LLen), eq(args), any())).thenReturn(testResponse);
@@ -1361,8 +1361,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, Long.toString(count), element};
         long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(LRem), eq(args), any())).thenReturn(testResponse);
@@ -1385,8 +1385,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, "value1", "value2"};
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(RPush), eq(args), any()))
@@ -1409,8 +1409,8 @@ public class RedisClientTest {
         String value = "value";
         String[] args = new String[] {key};
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(RPop), eq(args), any()))
@@ -1434,8 +1434,8 @@ public class RedisClientTest {
         String[] args = new String[] {key, Long.toString(count)};
         String[] value = new String[] {"value1", "value2"};
 
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(RPop), eq(args), any()))
@@ -1459,8 +1459,8 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(SAdd), eq(arguments), any()))
@@ -1484,8 +1484,8 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(SRem), eq(arguments), any()))
@@ -1507,8 +1507,8 @@ public class RedisClientTest {
         String key = "testKey";
         Set<String> value = Set.of("testMember");
 
-        CompletableFuture<Set<String>> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Set<String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Set<String>>submitNewCommand(eq(SMembers), eq(new String[] {key}), any()))
@@ -1530,8 +1530,8 @@ public class RedisClientTest {
         String key = "testKey";
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(SCard), eq(new String[] {key}), any()))
@@ -1558,8 +1558,8 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(membersScoresArgs, key);
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Zadd), eq(arguments), any()))
@@ -1593,8 +1593,8 @@ public class RedisClientTest {
         arguments = ArrayUtils.addAll(arguments, membersScoresArgs);
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Zadd), eq(arguments), any()))
@@ -1637,8 +1637,8 @@ public class RedisClientTest {
         String[] arguments = new String[] {key, "INCR", Double.toString(increment), member};
         Double value = 3.0;
 
-        CompletableFuture<Double> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Double> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Double>submitNewCommand(eq(Zadd), eq(arguments), any()))
@@ -1672,8 +1672,8 @@ public class RedisClientTest {
                         new String[] {"INCR", Double.toString(increment), member});
         Double value = 3.0;
 
-        CompletableFuture<Double> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Double> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Double>submitNewCommand(eq(Zadd), eq(arguments), any()))
@@ -1692,8 +1692,8 @@ public class RedisClientTest {
     @Test
     public void clientId_returns_success() {
         // setup
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(42L);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(42L);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(ClientId), eq(new String[0]), any()))
@@ -1711,8 +1711,8 @@ public class RedisClientTest {
     @Test
     public void clientGetName_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn("TEST");
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete("TEST");
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ClientGetName), eq(new String[0]), any()))
@@ -1730,8 +1730,8 @@ public class RedisClientTest {
     @Test
     public void configRewrite_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ConfigRewrite), eq(new String[0]), any()))
@@ -1750,8 +1750,8 @@ public class RedisClientTest {
     @Test
     public void configResetStat_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ConfigResetStat), eq(new String[0]), any()))
@@ -1770,9 +1770,9 @@ public class RedisClientTest {
     @Test
     public void configGet_returns_success() {
         // setup
-        CompletableFuture<Map<String, String>> testResponse = mock(CompletableFuture.class);
         Map<String, String> testPayload = Map.of("timeout", "1000");
-        when(testResponse.get()).thenReturn(testPayload);
+        CompletableFuture<Map<String, String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(testPayload);
 
         // match on protobuf request
         when(commandManager.<Map<String, String>>submitNewCommand(
@@ -1792,8 +1792,8 @@ public class RedisClientTest {
     @Test
     public void configSet_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(
@@ -1817,8 +1817,8 @@ public class RedisClientTest {
         String[] arguments = ArrayUtils.addFirst(members, key);
         Long value = 2L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Zrem), eq(arguments), any()))
@@ -1841,8 +1841,8 @@ public class RedisClientTest {
         String[] arguments = new String[] {key};
         Long value = 3L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Zcard), eq(arguments), any()))

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -614,7 +614,7 @@ public class RedisClientTest {
         testResponse.complete(payload);
 
         // match on protobuf request
-        when(commandManager.<Object>submitScript(eq(script), eq(List.of()), eq(List.of()), any()))
+        when(commandManager.submitScript(eq(script), eq(List.of()), eq(List.of()), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -641,7 +641,7 @@ public class RedisClientTest {
         testResponse.complete(payload);
 
         // match on protobuf request
-        when(commandManager.<Object>submitScript(
+        when(commandManager.submitScript(
                         eq(script), eq(List.of("key1", "key2")), eq(List.of("arg1", "arg2")), any()))
                 .thenReturn(testResponse);
 
@@ -660,8 +660,8 @@ public class RedisClientTest {
         String key = "testKey";
         long pttl = 999000L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(pttl);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(pttl);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(PTTL), eq(new String[] {key}), any()))
@@ -937,8 +937,8 @@ public class RedisClientTest {
         String key = "testKey";
         Long value = 10L;
 
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(Strlen), eq(new String[] {key}), any()))
@@ -2012,7 +2012,6 @@ public class RedisClientTest {
         String key = "testKey";
         RangeByScore rangeByScore =
                 new RangeByScore(new ScoreBoundary(3, false), InfScoreBound.NEGATIVE_INFINITY);
-        boolean reversed = true;
         String[] arguments =
                 new String[] {key, rangeByScore.getStart(), rangeByScore.getEnd(), "BYSCORE", "REV"};
         String[] value = new String[] {"two", "one"};
@@ -2183,8 +2182,8 @@ public class RedisClientTest {
         String[] arguments = new String[] {key};
         String value = "none";
 
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(value);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(Type), eq(arguments), any()))
@@ -2203,9 +2202,9 @@ public class RedisClientTest {
     @Test
     public void time_returns_success() {
         // setup
-        CompletableFuture<String[]> testResponse = mock(CompletableFuture.class);
+        CompletableFuture<String[]> testResponse = new CompletableFuture<>();
         String[] payload = new String[] {"UnixTime", "ms"};
-        when(testResponse.get()).thenReturn(payload);
+        testResponse.complete(payload);
 
         // match on protobuf request
         when(commandManager.<String[]>submitNewCommand(eq(Time), eq(new String[0]), any()))

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -61,10 +61,10 @@ public class RedisClusterClientTest {
     public void custom_command_returns_single_value() {
         var commandManager = new TestCommandManager(null);
 
-        var client = new TestClient(commandManager, "TEST");
-
-        var value = client.customCommand(TEST_ARGS).get();
-        assertEquals("TEST", value.getSingleValue());
+        try(var client = new TestClient(commandManager, "TEST")) {
+            var value = client.customCommand(TEST_ARGS).get();
+            assertEquals("TEST", value.getSingleValue());
+        }
     }
 
     @Test
@@ -73,10 +73,10 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("key1", "value1", "key2", "value2");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.customCommand(TEST_ARGS).get();
-        assertEquals(data, value.getMultiValue());
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.customCommand(TEST_ARGS).get();
+            assertEquals(data, value.getMultiValue());
+        }
     }
 
     @Test
@@ -86,10 +86,10 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("key1", "value1", "key2", "value2");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.customCommand(TEST_ARGS, RANDOM).get();
-        assertEquals(data, value.getSingleValue());
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.customCommand(TEST_ARGS, RANDOM).get();
+            assertEquals(data, value.getSingleValue());
+        }
     }
 
     @Test
@@ -98,10 +98,10 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("key1", "value1", "key2", "value2");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.customCommand(TEST_ARGS, ALL_NODES).get();
-        assertEquals(data, value.getMultiValue());
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.customCommand(TEST_ARGS, ALL_NODES).get();
+            assertEquals(data, value.getMultiValue());
+        }
     }
 
     @Test
@@ -111,10 +111,10 @@ public class RedisClusterClientTest {
                 new TestCommandManager(
                         Response.newBuilder().setConstantResponse(ConstantResponse.OK).build());
 
-        var client = new TestClient(commandManager, "OK");
-
-        var value = client.customCommand(TEST_ARGS, ALL_NODES).get();
-        assertEquals("OK", value.getSingleValue());
+        try (var client = new TestClient(commandManager, "OK")) {
+            var value = client.customCommand(TEST_ARGS, ALL_NODES).get();
+            assertEquals("OK", value.getSingleValue());
+        }
     }
 
     private static class TestClient extends RedisClusterClient {
@@ -366,11 +366,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = "info string";
-        var client = new TestClient(commandManager, data);
-
-        var value = client.info(RANDOM).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.info(RANDOM).get();
+            assertAll(
                 () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+        }
     }
 
     @Test
@@ -379,11 +379,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("key1", "value1", "key2", "value2");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.info(ALL_NODES).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.info(ALL_NODES).get();
+            assertAll(
                 () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+        }
     }
 
     @Test
@@ -392,11 +392,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = "info string";
-        var client = new TestClient(commandManager, data);
-
-        var value = client.info(InfoOptions.builder().build(), RANDOM).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.info(InfoOptions.builder().build(), RANDOM).get();
+            assertAll(
                 () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+        }
     }
 
     @Test
@@ -405,11 +405,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("key1", "value1", "key2", "value2");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.info(InfoOptions.builder().build(), ALL_NODES).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.info(InfoOptions.builder().build(), ALL_NODES).get();
+            assertAll(
                 () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+        }
     }
 
     @SneakyThrows
@@ -437,10 +437,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("n1", 42L);
-        var client = new TestClient(commandManager, data);
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.clientId(ALL_NODES).get();
 
-        var value = client.clientId(ALL_NODES).get();
-        assertEquals(data, value.getMultiValue());
+            assertEquals(data, value.getMultiValue());
+        }
     }
 
     @Test
@@ -448,10 +449,10 @@ public class RedisClusterClientTest {
     public void clientId_with_single_node_route_returns_success() {
         var commandManager = new TestCommandManager(null);
 
-        var client = new TestClient(commandManager, 42L);
-
-        var value = client.clientId(RANDOM).get();
-        assertEquals(42, value.getSingleValue());
+        try (var client = new TestClient(commandManager, 42L)) {
+            var value = client.clientId(RANDOM).get();
+            assertEquals(42, value.getSingleValue());
+        }
     }
 
     @SneakyThrows
@@ -478,10 +479,10 @@ public class RedisClusterClientTest {
     public void clientGetName_with_single_node_route_returns_success() {
         var commandManager = new TestCommandManager(null);
 
-        var client = new TestClient(commandManager, "TEST");
-
-        var value = client.clientGetName(RANDOM).get();
-        assertEquals("TEST", value.getSingleValue());
+        try (var client = new TestClient(commandManager, "TEST")) {
+            var value = client.clientGetName(RANDOM).get();
+            assertEquals("TEST", value.getSingleValue());
+        }
     }
 
     @Test
@@ -490,10 +491,10 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("n1", "TEST");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.clientGetName(ALL_NODES).get();
-        assertEquals(data, value.getMultiValue());
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.clientGetName(ALL_NODES).get();
+            assertEquals(data, value.getMultiValue());
+        }
     }
 
     @SneakyThrows
@@ -612,11 +613,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("timeout", "1000", "maxmemory", "1GB");
-        var client = new TestClient(commandManager, data);
-
-        var value = client.configGet(TEST_ARGS, RANDOM).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.configGet(TEST_ARGS, RANDOM).get();
+            assertAll(
                 () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+        }
     }
 
     @Test
@@ -625,11 +626,11 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = Map.of("node1", Map.of("timeout", "1000", "maxmemory", "1GB"));
-        var client = new TestClient(commandManager, data);
-
-        var value = client.configGet(TEST_ARGS, ALL_NODES).get();
-        assertAll(
+        try (var client = new TestClient(commandManager, data)) {
+            var value = client.configGet(TEST_ARGS, ALL_NODES).get();
+            assertAll(
                 () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+        }
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -175,7 +175,7 @@ public class RedisClusterClientTest {
         // setup
         String message = "RETURN OF THE PONG";
         String[] arguments = new String[] {message};
-        CompletableFuture<String> testResponse = new CompletableFuture();
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
         testResponse.complete(message);
 
         // match on protobuf request
@@ -287,7 +287,7 @@ public class RedisClusterClientTest {
     public void info_returns_string() {
         // setup
         CompletableFuture<ClusterValue<String>> testResponse = mock(CompletableFuture.class);
-        Map<String, String> testPayload = new HashMap<String, String>();
+        Map<String, String> testPayload = new HashMap<>();
         testPayload.put("addr1", "value1");
         testPayload.put("addr2", "value2");
         testPayload.put("addr3", "value3");

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -39,7 +39,6 @@ import redis_request.RedisRequestOuterClass.RedisRequest;
 import response.ResponseOuterClass.ConstantResponse;
 import response.ResponseOuterClass.Response;
 
-@SuppressWarnings("unchecked,resource")
 public class RedisClusterClientTest {
 
     RedisClusterClient service;
@@ -129,7 +128,9 @@ public class RedisClusterClientTest {
 
         @Override
         protected <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response) {
-            return (T) object;
+            @SuppressWarnings("unchecked")
+            T returnValue = (T) object;
+            return returnValue;
         }
     }
 
@@ -153,8 +154,8 @@ public class RedisClusterClientTest {
     @Test
     public void ping_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn("PONG");
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete("PONG");
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(Ping), eq(new String[0]), any()))
@@ -195,8 +196,8 @@ public class RedisClusterClientTest {
     @Test
     public void ping_with_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn("PONG");
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete("PONG");
 
         Route route = ALL_NODES;
 
@@ -286,12 +287,12 @@ public class RedisClusterClientTest {
     @Test
     public void info_returns_string() {
         // setup
-        CompletableFuture<ClusterValue<String>> testResponse = mock(CompletableFuture.class);
         Map<String, String> testPayload = new HashMap<>();
         testPayload.put("addr1", "value1");
         testPayload.put("addr2", "value2");
         testPayload.put("addr3", "value3");
-        when(testResponse.get()).thenReturn(ClusterValue.of(testPayload));
+        CompletableFuture<ClusterValue<String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(ClusterValue.of(testPayload));
         when(commandManager.<ClusterValue<String>>submitNewCommand(eq(Info), eq(new String[0]), any()))
                 .thenReturn(testResponse);
 
@@ -309,10 +310,10 @@ public class RedisClusterClientTest {
     @Test
     public void info_with_route_returns_string() {
         // setup
-        CompletableFuture<ClusterValue<String>> testResponse = mock(CompletableFuture.class);
         Map<String, String> testClusterValue = Map.of("addr1", "addr1 result", "addr2", "addr2 result");
         Route route = ALL_NODES;
-        when(testResponse.get()).thenReturn(ClusterValue.of(testClusterValue));
+        CompletableFuture<ClusterValue<String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(ClusterValue.of(testClusterValue));
         when(commandManager.<ClusterValue<String>>submitNewCommand(
                         eq(Info), eq(new String[0]), eq(route), any()))
                 .thenReturn(testResponse);
@@ -333,9 +334,10 @@ public class RedisClusterClientTest {
     public void info_with_route_with_infoOptions_returns_string() {
         // setup
         String[] infoArguments = new String[] {"ALL", "DEFAULT"};
-        CompletableFuture<ClusterValue<String>> testResponse = mock(CompletableFuture.class);
         Map<String, String> testClusterValue = Map.of("addr1", "addr1 result", "addr2", "addr2 result");
-        when(testResponse.get()).thenReturn(ClusterValue.of(testClusterValue));
+        CompletableFuture<ClusterValue<String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(ClusterValue.of(testClusterValue));
+
         Route route = ALL_PRIMARIES;
         when(commandManager.<ClusterValue<String>>submitNewCommand(
                         eq(Info), eq(infoArguments), eq(route), any()))
@@ -414,8 +416,8 @@ public class RedisClusterClientTest {
     @Test
     public void clientId_returns_success() {
         // setup
-        CompletableFuture<Long> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(42L);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(42L);
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(ClientId), eq(new String[0]), any()))
@@ -456,8 +458,8 @@ public class RedisClusterClientTest {
     @Test
     public void clientGetName_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn("TEST");
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete("TEST");
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ClientGetName), eq(new String[0]), any()))
@@ -498,8 +500,8 @@ public class RedisClusterClientTest {
     @Test
     public void configRewrite_without_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ConfigRewrite), eq(new String[0]), any()))
@@ -518,8 +520,8 @@ public class RedisClusterClientTest {
     @Test
     public void configRewrite_with_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         Route route = ALL_NODES;
 
@@ -541,8 +543,8 @@ public class RedisClusterClientTest {
     @Test
     public void configResetStat_without_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(eq(ConfigResetStat), eq(new String[0]), any()))
@@ -561,8 +563,8 @@ public class RedisClusterClientTest {
     @Test
     public void configResetStat_with_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         Route route = ALL_NODES;
 
@@ -585,9 +587,9 @@ public class RedisClusterClientTest {
     @Test
     public void configGet_returns_success() {
         // setup
-        CompletableFuture<Map<String, String>> testResponse = mock(CompletableFuture.class);
         var testPayload = Map.of("timeout", "1000");
-        when(testResponse.get()).thenReturn(testPayload);
+        CompletableFuture<Map<String, String>> testResponse = new CompletableFuture<>();
+        testResponse.complete(testPayload);
 
         // match on protobuf request
         when(commandManager.<Map<String, String>>submitNewCommand(
@@ -634,8 +636,8 @@ public class RedisClusterClientTest {
     @Test
     public void configSet_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(
@@ -654,8 +656,8 @@ public class RedisClusterClientTest {
     @Test
     public void configSet_with_route_returns_success() {
         // setup
-        CompletableFuture<String> testResponse = mock(CompletableFuture.class);
-        when(testResponse.get()).thenReturn(OK);
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
 
         // match on protobuf request
         when(commandManager.<String>submitNewCommand(

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -61,7 +61,7 @@ public class RedisClusterClientTest {
     public void custom_command_returns_single_value() {
         var commandManager = new TestCommandManager(null);
 
-        try(var client = new TestClient(commandManager, "TEST")) {
+        try (var client = new TestClient(commandManager, "TEST")) {
             var value = client.customCommand(TEST_ARGS).get();
             assertEquals("TEST", value.getSingleValue());
         }
@@ -369,7 +369,8 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.info(RANDOM).get();
             assertAll(
-                () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+                    () -> assertTrue(value.hasSingleData()),
+                    () -> assertEquals(data, value.getSingleValue()));
         }
     }
 
@@ -382,7 +383,7 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.info(ALL_NODES).get();
             assertAll(
-                () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+                    () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
         }
     }
 
@@ -395,7 +396,8 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.info(InfoOptions.builder().build(), RANDOM).get();
             assertAll(
-                () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+                    () -> assertTrue(value.hasSingleData()),
+                    () -> assertEquals(data, value.getSingleValue()));
         }
     }
 
@@ -408,7 +410,7 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.info(InfoOptions.builder().build(), ALL_NODES).get();
             assertAll(
-                () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+                    () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
         }
     }
 
@@ -616,7 +618,8 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.configGet(TEST_ARGS, RANDOM).get();
             assertAll(
-                () -> assertTrue(value.hasSingleData()), () -> assertEquals(data, value.getSingleValue()));
+                    () -> assertTrue(value.hasSingleData()),
+                    () -> assertEquals(data, value.getSingleValue()));
         }
     }
 
@@ -629,7 +632,7 @@ public class RedisClusterClientTest {
         try (var client = new TestClient(commandManager, data)) {
             var value = client.configGet(TEST_ARGS, ALL_NODES).get();
             assertAll(
-                () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
+                    () -> assertTrue(value.hasMultiData()), () -> assertEquals(data, value.getMultiValue()));
         }
     }
 

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -132,6 +132,9 @@ public class RedisClusterClientTest {
             T returnValue = (T) object;
             return returnValue;
         }
+
+        @Override
+        public void close() {}
     }
 
     private static class TestCommandManager extends CommandManager {

--- a/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
+++ b/java/client/src/test/java/glide/connection/ConnectionWithGlideMockTests.java
@@ -169,15 +169,16 @@ public class ConnectionWithGlideMockTests extends RustCoreLibMockTestBase {
     @Test
     @SneakyThrows
     public void rethrow_error_if_UDS_channel_closed() {
-        var client = new TestClient(channelHandler);
-        stopRustCoreLibMock();
-        try {
-            var exception =
-                    assertThrows(ExecutionException.class, () -> client.customCommand(new String[0]).get());
-            assertTrue(exception.getCause() instanceof ClosingException);
-        } finally {
-            // restart mock to let other tests pass if this one failed
-            startRustCoreLibMock(null);
+        try (var client = new TestClient(channelHandler)) {
+            stopRustCoreLibMock();
+            try {
+                var exception =
+                        assertThrows(ExecutionException.class, () -> client.customCommand(new String[0]).get());
+                assertTrue(exception.getCause() instanceof ClosingException);
+            } finally {
+                // restart mock to let other tests pass if this one failed
+                startRustCoreLibMock(null);
+            }
         }
     }
 

--- a/java/client/src/test/java/glide/connectors/resources/ThreadPoolResourceAllocatorTest.java
+++ b/java/client/src/test/java/glide/connectors/resources/ThreadPoolResourceAllocatorTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 
 public class ThreadPoolResourceAllocatorTest {
 
-    ThreadPoolResourceAllocator service;
-
     @BeforeEach
     public void init() {
         var threadPoolResource = ThreadPoolResourceAllocator.getOrCreate(() -> null);
@@ -30,17 +28,19 @@ public class ThreadPoolResourceAllocatorTest {
     public void getOrCreate_returns_default_after_repeated_calls() {
         ThreadPoolResource mockedThreadPoolResource = mock(ThreadPoolResource.class);
         EventLoopGroup mockedEventLoopGroup = mock(EventLoop.class);
+        @SuppressWarnings("unchecked")
         Supplier<ThreadPoolResource> threadPoolSupplier = mock(Supplier.class);
 
         when(mockedThreadPoolResource.getEventLoopGroup()).thenReturn(mockedEventLoopGroup);
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(false);
         when(threadPoolSupplier.get()).thenReturn(mockedThreadPoolResource);
 
-        ThreadPoolResource theResource = service.getOrCreate(threadPoolSupplier);
+        ThreadPoolResource theResource = ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theResource);
 
         // Ensure that supplier only is invoked once to set up the shared resource
-        ThreadPoolResource theSameResource = service.getOrCreate(threadPoolSupplier);
+        ThreadPoolResource theSameResource =
+                ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theSameResource);
         verify(threadPoolSupplier, times(1)).get();
 
@@ -52,17 +52,20 @@ public class ThreadPoolResourceAllocatorTest {
     public void getOrCreate_returns_new_thread_pool_after_shutdown() {
         ThreadPoolResource mockedThreadPoolResource = mock(ThreadPoolResource.class);
         EventLoopGroup mockedEventLoopGroup = mock(EventLoop.class);
+
+        @SuppressWarnings("unchecked")
         Supplier<ThreadPoolResource> threadPoolSupplier = mock(Supplier.class);
 
         when(mockedThreadPoolResource.getEventLoopGroup()).thenReturn(mockedEventLoopGroup);
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(true);
         when(threadPoolSupplier.get()).thenReturn(mockedThreadPoolResource);
 
-        ThreadPoolResource theResource = service.getOrCreate(threadPoolSupplier);
+        ThreadPoolResource theResource = ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theResource);
 
         // Ensure that supplier only is invoked once to set up the shared resource
-        ThreadPoolResource theSameResource = service.getOrCreate(threadPoolSupplier);
+        ThreadPoolResource theSameResource =
+                ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theSameResource);
         verify(threadPoolSupplier, times(2)).get();
 

--- a/java/client/src/test/java/glide/connectors/resources/ThreadPoolResourceAllocatorTest.java
+++ b/java/client/src/test/java/glide/connectors/resources/ThreadPoolResourceAllocatorTest.java
@@ -3,9 +3,7 @@ package glide.connectors.resources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
@@ -28,12 +26,11 @@ public class ThreadPoolResourceAllocatorTest {
     public void getOrCreate_returns_default_after_repeated_calls() {
         ThreadPoolResource mockedThreadPoolResource = mock(ThreadPoolResource.class);
         EventLoopGroup mockedEventLoopGroup = mock(EventLoop.class);
-        @SuppressWarnings("unchecked")
-        Supplier<ThreadPoolResource> threadPoolSupplier = mock(Supplier.class);
+
+        Supplier<ThreadPoolResource> threadPoolSupplier = () -> mockedThreadPoolResource;
 
         when(mockedThreadPoolResource.getEventLoopGroup()).thenReturn(mockedEventLoopGroup);
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(false);
-        when(threadPoolSupplier.get()).thenReturn(mockedThreadPoolResource);
 
         ThreadPoolResource theResource = ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theResource);
@@ -42,7 +39,6 @@ public class ThreadPoolResourceAllocatorTest {
         ThreadPoolResource theSameResource =
                 ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theSameResource);
-        verify(threadPoolSupplier, times(1)).get();
 
         // teardown
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(true);
@@ -53,12 +49,10 @@ public class ThreadPoolResourceAllocatorTest {
         ThreadPoolResource mockedThreadPoolResource = mock(ThreadPoolResource.class);
         EventLoopGroup mockedEventLoopGroup = mock(EventLoop.class);
 
-        @SuppressWarnings("unchecked")
-        Supplier<ThreadPoolResource> threadPoolSupplier = mock(Supplier.class);
+        Supplier<ThreadPoolResource> threadPoolSupplier = () -> mockedThreadPoolResource;
 
         when(mockedThreadPoolResource.getEventLoopGroup()).thenReturn(mockedEventLoopGroup);
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(true);
-        when(threadPoolSupplier.get()).thenReturn(mockedThreadPoolResource);
 
         ThreadPoolResource theResource = ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theResource);
@@ -67,7 +61,6 @@ public class ThreadPoolResourceAllocatorTest {
         ThreadPoolResource theSameResource =
                 ThreadPoolResourceAllocator.getOrCreate(threadPoolSupplier);
         assertEquals(mockedThreadPoolResource, theSameResource);
-        verify(threadPoolSupplier, times(2)).get();
 
         // teardown
         when(mockedEventLoopGroup.isShuttingDown()).thenReturn(true);

--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -65,7 +65,7 @@ public class FfiTest {
     }
 
     @ParameterizedTest
-    @ValueSource(longs = {0L, 100L, 774L, Integer.MAX_VALUE + 1, Integer.MIN_VALUE - 1})
+    @ValueSource(longs = {0L, 100L, 774L, Integer.MAX_VALUE + 1L, Integer.MIN_VALUE - 1L})
     public void redisValueToJavaValue_Int(Long input) {
         long ptr = FfiTest.createLeakedInt(input);
         Object longValue = RedisValueResolver.valueFromPointer(ptr);

--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -98,8 +98,8 @@ public class FfiTest {
         long[] values = {1L, 2L, 3L};
         long ptr = FfiTest.createLeakedMap(keys, values);
         Object mapValue = RedisValueResolver.valueFromPointer(ptr);
-        assertTrue(mapValue instanceof HashMap);
-        HashMap<Object, Object> result = (HashMap<Object, Object>) mapValue;
+        assertTrue(mapValue instanceof HashMap<?, ?>);
+        HashMap<?, ?> result = (HashMap<?, ?>) mapValue;
         assertAll(
                 () -> assertEquals(1L, result.get(12L)),
                 () -> assertEquals(2L, result.get(14L)),
@@ -134,8 +134,8 @@ public class FfiTest {
         long[] array = {1L, 2L, 2L};
         long ptr = FfiTest.createLeakedLongSet(array);
         Object longSetValue = RedisValueResolver.valueFromPointer(ptr);
-        assertTrue(longSetValue instanceof HashSet);
-        HashSet<Long> result = (HashSet<Long>) longSetValue;
+        assertTrue(longSetValue instanceof HashSet<?>);
+        HashSet<?> result = (HashSet<?>) longSetValue;
         assertAll(
                 () -> assertTrue(result.contains(1L)),
                 () -> assertTrue(result.contains(2L)),

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -40,21 +40,21 @@ public class ConnectionManagerTest {
 
     ChannelHandler channel;
 
-    private static String HOST = "aws.com";
-    private static int PORT = 9999;
+    private static final String HOST = "aws.com";
+    private static final int PORT = 9999;
 
-    private static String USERNAME = "JohnDoe";
-    private static String PASSWORD = "Password1";
+    private static final String USERNAME = "JohnDoe";
+    private static final String PASSWORD = "Password1";
 
-    private static int NUM_OF_RETRIES = 5;
-    private static int FACTOR = 10;
-    private static int EXPONENT_BASE = 50;
+    private static final int NUM_OF_RETRIES = 5;
+    private static final int FACTOR = 10;
+    private static final int EXPONENT_BASE = 50;
 
-    private static int DATABASE_ID = 1;
+    private static final int DATABASE_ID = 1;
 
-    private static int REQUEST_TIMEOUT = 3;
+    private static final int REQUEST_TIMEOUT = 3;
 
-    private static String CLIENT_NAME = "ClientName";
+    private static final String CLIENT_NAME = "ClientName";
 
     @BeforeEach
     public void setUp() {

--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -88,6 +88,7 @@ public class SharedClientTests {
     @MethodSource("clientAndDataSize")
     public void client_can_handle_concurrent_workload(BaseClient client, int valueSize) {
         ExecutorService executorService = Executors.newCachedThreadPool();
+        @SuppressWarnings("rawtypes")
         CompletableFuture[] futures = new CompletableFuture[100];
 
         for (int i = 0; i < 100; i++) {

--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -88,8 +88,8 @@ public class SharedClientTests {
     @MethodSource("clientAndDataSize")
     public void client_can_handle_concurrent_workload(BaseClient client, int valueSize) {
         ExecutorService executorService = Executors.newCachedThreadPool();
-        @SuppressWarnings("rawtypes")
-        CompletableFuture[] futures = new CompletableFuture[100];
+        @SuppressWarnings("unchecked")
+        CompletableFuture<Void>[] futures = new CompletableFuture[100];
 
         for (int i = 0; i < 100; i++) {
             futures[i] =

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -48,6 +48,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -1061,7 +1062,7 @@ public class SharedCommandTests {
 
         assertEquals(0, client.zadd(key, membersScores, onlyIfExistsOptions).get());
         assertEquals(3, client.zadd(key, membersScores, onlyIfDoesNotExistOptions).get());
-        assertEquals(null, client.zaddIncr(key, "one", 5, onlyIfDoesNotExistOptions).get());
+        assertNull(client.zaddIncr(key, "one", 5, onlyIfDoesNotExistOptions).get());
         assertEquals(6, client.zaddIncr(key, "one", 5, onlyIfExistsOptions).get());
     }
 
@@ -1090,25 +1091,24 @@ public class SharedCommandTests {
         assertEquals(1, client.zadd(key, membersScores, scoreGreaterThanOptions, true).get());
         assertEquals(0, client.zadd(key, membersScores, scoreLessThanOptions, true).get());
         assertEquals(7, client.zaddIncr(key, "one", -3, scoreLessThanOptions).get());
-        assertEquals(null, client.zaddIncr(key, "one", -3, scoreGreaterThanOptions).get());
+        assertNull(client.zaddIncr(key, "one", -3, scoreGreaterThanOptions).get());
     }
 
-    @SneakyThrows
-    @ParameterizedTest
-    @MethodSource("getClients")
-    public void zadd_illegal_arguments(BaseClient client) {
+    // TODO move to another class
+    @Test
+    public void zadd_illegal_arguments() {
         ZaddOptions existsGreaterThanOptions =
                 ZaddOptions.builder()
                         .conditionalChange(ZaddOptions.ConditionalChange.ONLY_IF_DOES_NOT_EXIST)
                         .updateOptions(ZaddOptions.UpdateOptions.SCORE_GREATER_THAN_CURRENT)
                         .build();
-        assertThrows(IllegalArgumentException.class, () -> existsGreaterThanOptions.toArgs());
+        assertThrows(IllegalArgumentException.class, existsGreaterThanOptions::toArgs);
         ZaddOptions existsLessThanOptions =
                 ZaddOptions.builder()
                         .conditionalChange(ZaddOptions.ConditionalChange.ONLY_IF_DOES_NOT_EXIST)
                         .updateOptions(ZaddOptions.UpdateOptions.SCORE_LESS_THAN_CURRENT)
                         .build();
-        assertThrows(IllegalArgumentException.class, () -> existsLessThanOptions.toArgs());
+        assertThrows(IllegalArgumentException.class, existsLessThanOptions::toArgs);
         ZaddOptions options =
                 ZaddOptions.builder()
                         .conditionalChange(ZaddOptions.ConditionalChange.ONLY_IF_DOES_NOT_EXIST)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Cleans up all compiler warnings in the Java/Client/src/test folder.  Most of the changes are like this:
```java
        CompletableFuture<Object> testResponse = mock(CompletableFuture.class);
        when(testResponse.get()).thenReturn(value);
```
changed to:
```java
        CompletableFuture<Object> testResponse = new CompletableFuture<>();
        testResponse.complete(value);
```
The above tests clean up the type error when converting from `CompletableFuture` to `CompletableFuture<Object>`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
