### PR TITLE
Java: Fix transaction handling for cluster client.

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -26,7 +26,6 @@ import glide.api.models.configuration.RedisClusterClientConfiguration;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -88,15 +87,11 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
-    public CompletableFuture<ClusterValue<Object>[]> exec(
-            @NonNull ClusterTransaction transaction, Route route) {
-        return commandManager
-                .submitNewCommand(transaction, Optional.ofNullable(route), this::handleArrayOrNullResponse)
-                .thenApply(
-                        objects ->
-                                Arrays.stream(objects)
-                                        .map(ClusterValue::of)
-                                        .<ClusterValue<Object>>toArray(ClusterValue[]::new));
+    public CompletableFuture<Object[]> exec(
+            @NonNull ClusterTransaction transaction, @NonNull Route route) {
+        assert route.isSingleNodeRoute() : "Multi-node routes are not supported for exec()";
+        return commandManager.submitNewCommand(
+                transaction, Optional.of(route), this::handleArrayOrNullResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericClusterCommands.java
@@ -93,8 +93,8 @@ public interface GenericClusterCommands {
      * @see <a href="https://redis.io/topics/Transactions/">redis.io</a> for details on Redis
      *     Transactions.
      * @param transaction A {@link Transaction} object containing a list of commands to be executed.
-     * @param route Specifies the routing configuration for the transaction. The client will route the
-     *     transaction to the nodes defined by <code>route</code>.
+     * @param route A single-node routing configuration for the transaction. The client will route the
+     *     transaction to the node defined by <code>route</code>.
      * @return A list of results corresponding to the execution of each command in the transaction.
      * @remarks
      *     <ul>
@@ -107,10 +107,10 @@ public interface GenericClusterCommands {
      * @example
      *     <pre>{@code
      * ClusterTransaction transaction = new ClusterTransaction().ping().info();
-     * ClusterValue<Object>[] result = clusterClient.exec(transaction, RANDOM).get();
-     * assert ((String) result[0].getSingleValue()).equals("PONG");
-     * assert ((String) result[1].getSingleValue()).contains("# Stats");
+     * Object[] result = clusterClient.exec(transaction, RANDOM).get();
+     * assert ((String) result[0]).equals("PONG");
+     * assert ((String) result[1]).contains("# Stats");
      * }</pre>
      */
-    CompletableFuture<ClusterValue<Object>[]> exec(ClusterTransaction transaction, Route route);
+    CompletableFuture<Object[]> exec(ClusterTransaction transaction, Route route);
 }

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -13,10 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import glide.TestConfiguration;
 import glide.api.RedisClusterClient;
 import glide.api.models.ClusterTransaction;
-import glide.api.models.ClusterValue;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
@@ -68,15 +66,10 @@ public class ClusterTransactionTests {
     @SneakyThrows
     public void info_simple_route_test() {
         ClusterTransaction transaction = new ClusterTransaction().info().info();
-        ClusterValue<Object>[] result =
-                clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
+        Object[] result = clusterClient.exec(transaction, RANDOM).get();
 
-        // check single-value result
-        assertTrue(result[0].hasSingleData());
-        assertTrue(((String) result[0].getSingleValue()).contains("# Stats"));
-
-        assertTrue(result[1].hasSingleData());
-        assertTrue(((String) result[1].getSingleValue()).contains("# Stats"));
+        assertTrue(((String) result[0]).contains("# Stats"));
+        assertTrue(((String) result[1]).contains("# Stats"));
     }
 
     @SneakyThrows
@@ -85,12 +78,7 @@ public class ClusterTransactionTests {
         ClusterTransaction transaction = (ClusterTransaction) transactionTest(new ClusterTransaction());
         Object[] expectedResult = transactionTestResult();
 
-        ClusterValue<Object>[] clusterValues =
-                clusterClient.exec(transaction, RANDOM).get(10, TimeUnit.SECONDS);
-        Object[] results =
-                Arrays.stream(clusterValues)
-                        .map(v -> v.hasSingleData() ? v.getSingleValue() : v.getMultiValue())
-                        .toArray(Object[]::new);
+        Object[] results = clusterClient.exec(transaction, RANDOM).get();
         assertArrayEquals(expectedResult, results);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The `exec()` command (with a transaction as input argument) for cluster clients must be routed to a single node. Multi-node routes are not supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
