### PR TITLE
Compile `musl` lib,   support for `alpine` image

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -9,6 +9,7 @@ inputs:
             - amazon-linux
             - macos-latest
             - ubuntu-latest
+            - ubuntu-latest-musl
     named_os:
         description: "The name of the current operating system"
         required: false
@@ -16,6 +17,7 @@ inputs:
         type: string
         options:
             - linux
+            - linux-musl
             - darwin
     arch:
         description: "The current architecture"

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -17,6 +17,7 @@ inputs:
         options:
             - x86_64-unknown-linux-gnu
             - aarch64-unknown-linux-gnu
+            - aarch64-unknown-linux-musl
             - x86_64-apple-darwin
             - aarch64-apple-darwin
     github-token:
@@ -35,7 +36,7 @@ runs:
               brew upgrade || true
               brew install git gcc pkgconfig openssl redis coreutils
 
-        - name: Install software dependencies for Ubuntu
+        - name: Install software dependencies for Ubuntu GNU
           shell: bash
           if: "${{ inputs.os == 'ubuntu-latest' }}"
           run: |
@@ -48,12 +49,24 @@ runs:
           run: |
               yum install -y gcc pkgconfig openssl openssl-devel which curl redis6 gettext --allowerasing
 
+        - name: Install software dependencies for Ubuntu MUSL
+          shell: sh
+          if: "${{ inputs.os == 'ubuntu-latest-musl' }}"
+          run: |
+              apk update
+              wget -O - https://sh.rustup.rs | sh -s -- -y
+              source "$HOME/.cargo/env"
+              apk add protobuf-dev musl-dev make gcc
+
+
         - name: Install Rust toolchain
+          if: "${{ inputs.os != 'ubuntu-latest-musl' }}"
           uses: dtolnay/rust-toolchain@stable
           with:
               targets: ${{ inputs.target }}
 
         - name: Install protoc (protobuf)
+          if: "${{ inputs.os != 'ubuntu-latest-musl' }}"
           uses: arduino/setup-protoc@v3
           with:
               version: "25.1"

--- a/.github/workflows/node-create-package-file/action.yml
+++ b/.github/workflows/node-create-package-file/action.yml
@@ -13,6 +13,7 @@ inputs:
             - amazon-linux
             - macos-latest
             - ubuntu-latest
+            - ubuntu-latest-musl
     named_os:
         description: "The name of the current operating system"
         required: false
@@ -20,6 +21,7 @@ inputs:
         type: string
         options:
             - linux
+            - linux-musl
             - darwin
     arch:
         description: "The current architecture"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -64,7 +64,7 @@ jobs:
             - name: Install Redis Modules
               uses: ./.github/workflows/install-redis-modules
               with:
-                  redis-version: ${{ matrix.redis }} 
+                  redis-version: ${{ matrix.redis }}
 
             - name: test
               run: npm test
@@ -73,17 +73,17 @@ jobs:
             - name: test hybrid node modules - commonjs
               run: |
                 npm install --package-lock-only
-                npm ci 
+                npm ci
                 npm run build-and-test
               working-directory: ./node/hybrid-node-tests/commonjs-test
-            
+
             - name: test hybrid node modules - ecma
               run: |
                 npm install --package-lock-only
                 npm ci
                 npm run build-and-test
               working-directory: ./node/hybrid-node-tests/ecmascript-test
-            
+
             - name: test redis modules
               run: npm run test-modules -- --load-module=$GITHUB_WORKSPACE/redisjson.so
               working-directory: ./node
@@ -147,7 +147,7 @@ jobs:
                   yum -y remove git
                   yum -y remove git-*
                   yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
-                  yum install -y git 
+                  yum install -y git
                   git --version
 
             - uses: actions/checkout@v4
@@ -167,6 +167,42 @@ jobs:
                   os: "amazon-linux"
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Create a symbolic Link for redis6 binaries
+              working-directory: ./node
+              run: |
+                  ln -s /usr/bin/redis6-server /usr/bin/redis-server
+                  ln -s /usr/bin/redis6-cli /usr/bin/redis-cli
+
+            - name: Test compatibility
+              run: npm test -- -t "set and get flow works"
+              working-directory: ./node
+
+
+    build-linux-musl-latest:
+        runs-on: ubuntu-latest
+        container:
+            image: node:18.19.0-alpine
+        timeout-minutes: 15
+        steps:
+            - name: Install git
+              run: apk add git
+
+            - uses: actions/checkout@v4
+
+            - name: Checkout submodules
+              run: |
+                  git config --global --add safe.directory "$GITHUB_WORKSPACE"
+                  git submodule update --init --recursive
+
+            - name: Build Node wrapper
+              uses: ./.github/workflows/build-node-wrapper
+              with:
+                  os: "ubuntu-latest-musl"
+                  target: "aarch64-unknown-linux-musl"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  arch: "arm64"
+                  named_os: "linux-musl"
 
             - name: Create a symbolic Link for redis6 binaries
               working-directory: ./node

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -35,6 +35,8 @@ jobs:
         if: github.repository_owner == 'aws'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
+        container:
+            image: ${{ matrix.build.IMAGE }}
         strategy:
             fail-fast: false
             matrix:
@@ -54,6 +56,14 @@ jobs:
                           TARGET: aarch64-unknown-linux-gnu,
                           CONTAINER: "2_28",
                       }
+                    - {
+                        OS: ubuntu-latest-musl,
+                        NAMED_OS: linux-musl,
+                        RUNNER: ubuntu-latest,
+                        ARCH: arm64,
+                        TARGET: aarch64-unknown-linux-musl,
+                        IMAGE: "node:18.19.0-alpine",
+                    }
                     - {
                           OS: macos-latest,
                           NAMED_OS: darwin,
@@ -85,6 +95,7 @@ jobs:
                   echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
 
             - name: Setup node
+              if: "${{ matrix.build.OS != 'ubuntu-latest-musl' }}"
               uses: actions/setup-node@v3
               with:
                   node-version: "16"
@@ -93,13 +104,13 @@ jobs:
                   scope: "${{ vars.NPM_SCOPE }}"
                   always-auth: true
                   token: ${{ secrets.NPM_AUTH_TOKEN }}
-            
+
             - name: Update package version in config.toml
               uses: ./.github/workflows/update-glide-version
               with:
                   folder_path: "${{ github.workspace }}/node/rust-client/.cargo"
                   named_os: ${{ matrix.build.NAMED_OS }}
-                
+
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:

--- a/.github/workflows/update-glide-version/action.yml
+++ b/.github/workflows/update-glide-version/action.yml
@@ -12,6 +12,7 @@ inputs:
         type: string
         options:
             - linux
+            - linux-musl
             - darwin
 runs:
     using: "composite"

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { arch, platform } from "process";
+import { existsSync } from "fs";
 
 let globalObject = global as unknown;
 
@@ -17,7 +18,9 @@ function loadNativeBinding() {
                     nativeBinding = require("@scope/glide-for-redis-linux-x64");
                     break;
                 case "arm64":
-                    nativeBinding = require("@scope/glide-for-redis-linux-arm64");
+                    nativeBinding = existsSync("./node_modules/@scope/glide-for-redis-linux-musl-arm64")
+                        ? require("@scope/glide-for-redis-linux-musl-arm64")
+                        : require("@scope/glide-for-redis-linux-arm64")
                     break;
                 default:
                     throw new Error(

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -43,7 +43,8 @@
         "${scope}glide-for-redis-darwin-arm64": "${package_version}",
         "${scope}glide-for-redis-darwin-x64": "${package_version}",
         "${scope}glide-for-redis-linux-arm64": "${package_version}",
-        "${scope}glide-for-redis-linux-x64": "${package_version}"
+        "${scope}glide-for-redis-linux-x64": "${package_version}",
+        "${scope}glide-for-redis-linux-musl-arm64": "${package_version}"
     },
     "eslintConfig": {
         "extends": [


### PR DESCRIPTION
*Issue #, if available:*
fixes  #1205 

*Description of changes:*
Re issue above,  this PR adds compiling action for `musl` environment.
Demo of the compiled binary - https://github.com/ofirsnb/node-glide-demo

This PR was tested in a sterile environment,   but I need your help testing it under your repo using your workflows.
I expect it to create a new sub-dependency,   called `glide-for-redis-linux-musl-arm64`,  which will be pushed to the registry,  and of course once done - `npm`+`napi` should successfully download and use it under `musl` env.

Let me know how can I help forward.
Thanks


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
