### PR TITLE
Java: Fix protoc version check.

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -58,6 +58,7 @@ tasks.register('protobuf', Exec) {
             if (e.getMessage().startsWith("A problem occurred starting process")) {
                 throw new GradleException("No Protobuf compiler (protoc) found. Protobuf compiler version 26.1 or newer is required.");
             }
+            throw e
         }
 
         project.mkdir(Paths.get(project.projectDir.path, 'src/main/java/glide/models/protobuf').toString())


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Hotfix for #1237. While addressing [this comment](https://github.com/aws/glide-for-redis/pull/1237#discussion_r1558888000) we broke the version check.

Before:
```
$ ./gradlew protobuf

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 852ms
1 actionable task: 1 executed
```
After:
```
$ ./gradlew protobuf
> Task :client:protobuf FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/mnt/c/GitHub/babushka_2/java/client/build.gradle' line: 40

* What went wrong:
Execution failed for task ':client:protobuf'.
> Protobuf compiler (protoc) version 26.1 or newer is required. Current version: libprotoc 25.1

...
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
