### PR TITLE
C#: changing utest framework to xunit

### DIFF
--- a/csharp/tests/Integration/GetAndSet.cs
+++ b/csharp/tests/Integration/GetAndSet.cs
@@ -2,19 +2,23 @@
 
 using System.Runtime.InteropServices;
 
+using FluentAssertions;
+
 using Glide;
 
 using static Tests.Integration.IntegrationTestBase;
 
 namespace Tests.Integration;
-public class GetAndSet
+public class GetAndSet : IClassFixture<IntegrationTestBase>
 {
     private async Task GetAndSetValues(AsyncClient client, string key, string value)
     {
-        string? setResult = await client.SetAsync(key, value);
-        Assert.That(setResult, Is.EqualTo("OK"));
-        string? result = await client.GetAsync(key);
-        Assert.That(result, Is.EqualTo(value));
+        _ = (await client.SetAsync(key, value))
+            .Should()
+            .Be("OK");
+        _ = (await client.GetAsync(key))
+            .Should()
+            .Be(value);
     }
 
     private async Task GetAndSetRandomValues(AsyncClient client)
@@ -24,14 +28,14 @@ public class GetAndSet
         await GetAndSetValues(client, key, value);
     }
 
-    [Test]
+    [Fact]
     public async Task GetReturnsLastSet()
     {
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
         await GetAndSetRandomValues(client);
     }
 
-    [Test]
+    [Fact]
     public async Task GetAndSetCanHandleNonASCIIUnicode()
     {
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
@@ -40,15 +44,16 @@ public class GetAndSet
         await GetAndSetValues(client, key, value);
     }
 
-    [Test]
+    [Fact]
     public async Task GetReturnsNull()
     {
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
-        string? result = await client.GetAsync(Guid.NewGuid().ToString());
-        Assert.That(result, Is.EqualTo(null));
+        _ = (await client.GetAsync(Guid.NewGuid().ToString()))
+            .Should()
+            .BeNull();
     }
 
-    [Test]
+    [Fact]
     public async Task GetReturnsEmptyString()
     {
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
@@ -57,13 +62,14 @@ public class GetAndSet
         await GetAndSetValues(client, key, value);
     }
 
-    [Test]
+    [Fact]
     public async Task HandleVeryLargeInput()
     {
         // TODO invesitage and fix
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            Assert.Ignore("Flaky on MacOS");
+            //"Flaky on MacOS"
+            return;
         }
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
 
@@ -80,7 +86,7 @@ public class GetAndSet
 
     // This test is slow and hardly a unit test, but it caught timing and releasing issues in the past,
     // so it's being kept.
-    [Test]
+    [Fact]
     public void ConcurrentOperationsWork()
     {
         using AsyncClient client = new("localhost", TestConfiguration.STANDALONE_PORTS[0], false);
@@ -99,8 +105,9 @@ public class GetAndSet
                     }
                     else
                     {
-                        string? result = await client.GetAsync(Guid.NewGuid().ToString());
-                        Assert.That(result, Is.EqualTo(null));
+                        _ = (await client.GetAsync(Guid.NewGuid().ToString()))
+                            .Should()
+                            .BeNull();
                     }
                 }
             }));

--- a/csharp/tests/Usings.cs
+++ b/csharp/tests/Usings.cs
@@ -1,3 +1,3 @@
 // Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
-global using NUnit.Framework;
+global using Xunit;

--- a/csharp/tests/tests.csproj
+++ b/csharp/tests/tests.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -16,11 +18,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
*Description of changes:*

Changing UTest framework to XUnit, because it will allow to address NUnit constrain (Setting Up will require separate method with attribute, so initialising on shared variables couldn't be done in constractor)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
