### PR TITLE
Node: convert Set commands return type to Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@
 * Python: Added PFADD command ([#1315](https://github.com/aws/glide-for-redis/pull/1315))
 * Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 * Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
-* Node: When receiving SPOP with count, SMEMBERS convert result to Set ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
+
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))
 * Core: Fixed blocking commands to use the specified timeout from the command argument ([#1283](https://github.com/aws/glide-for-redis/pull/1283))
+
+### Breaking Change
+* Node: When receiving SPOP with count, SMEMBERS convert result to Set ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
 
 ## 0.3.3 (2024-03-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Python: Added PFADD command ([#1315](https://github.com/aws/glide-for-redis/pull/1315))
 * Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 * Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
+* Node: When receiving SPOP with count, SMEMBERS convert result to Set ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))
 * Core: Fixed blocking commands to use the specified timeout from the command argument ([#1283](https://github.com/aws/glide-for-redis/pull/1283))
 
-### Breaking Change
-* Node: When receiving SPOP with count, SMEMBERS convert result to Set ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
+### Breaking Changes
+* Node: Changed SMEMBERS and SPOP with count functions to return Set instead of string [] ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
 
 ## 0.3.3 (2024-03-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Core: Fixed blocking commands to use the specified timeout from the command argument ([#1283](https://github.com/aws/glide-for-redis/pull/1283))
 
 ### Breaking Changes
-* Node: Changed SMEMBERS and SPOP with count functions to return Set instead of string [] ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
+* Node: Changed `smembers` and `spopCount` functions to return Set instead of string[] ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
 
 ## 0.3.3 (2024-03-28)
 

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1196,11 +1196,15 @@ export class BaseClient {
      * console.log(result); // Output: Set {'member1', 'member2', 'member3'}
      * ```
      */
-    public async smembers(key: string): Promise<Set<string>> {
-        const result = (await this.createWritePromise(
-            createSMembers(key),
-        )) as string[];
-        return new Set(result);
+    public smembers(key: string): Promise<Set<string>> {
+        return this.createWritePromise(createSMembers(key)).then(
+            (result: unknown) => {
+                const resultSet: Set<string> = new Set<string>(
+                    result as string[],
+                );
+                return resultSet;
+            },
+        );
     }
 
     /** Returns the set cardinality (number of elements) of the set stored at `key`.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1186,18 +1186,21 @@ export class BaseClient {
      * See https://redis.io/commands/smembers/ for details.
      *
      * @param key - The key to return its members.
-     * @returns All members of the set.
-     * If `key` does not exist, it is treated as an empty set and this command returns empty list.
+     * @returns A set containing all members of the set.
+     * If `key` does not exist, it is treated as an empty set and this command returns an empty set.
      *
      * @example
      * ```typescript
      * // Example usage of the smembers method
      * const result = await client.smembers("my_set");
-     * console.log(result); // Output: ["member1", "member2", "member3"]
+     * console.log(result); // Output: Set {'member1', 'member2', 'member3'}
      * ```
      */
-    public smembers(key: string): Promise<string[]> {
-        return this.createWritePromise(createSMembers(key));
+    public async smembers(key: string): Promise<Set<string>> {
+        const result = (await this.createWritePromise(
+            createSMembers(key),
+        )) as string[];
+        return new Set(result);
     }
 
     /** Returns the set cardinality (number of elements) of the set stored at `key`.
@@ -1274,25 +1277,28 @@ export class BaseClient {
      *
      * @param key - The key of the set.
      * @param count - The count of the elements to pop from the set.
-     * @returns A list of popped elements will be returned depending on the set's length.
-     * If `key` does not exist, empty list will be returned.
+     * @returns A set containing the popped elements, depending on the set's length.
+     * If `key` does not exist, an empty set will be returned.
      *
      * @example
      * ```typescript
      * // Example usage of spopCount method to remove and return multiple random members from a set
      * const result = await client.spopCount("my_set", 2);
-     * console.log(result); // Output: ['member2', 'member3'] - Removes and returns 2 random members from the set "my_set".
+     * console.log(result); // Output: Set {'member2', 'member3'} - Removes and returns 2 random members from the set "my_set".
      * ```
      *
      * @example
      * ```typescript
      * // Example usage of spopCount method with non-existing key
      * const result = await client.spopCount("non_existing_key");
-     * console.log(result); // Output: []
+     * console.log(result); // Output: Set {} - An empty set is returned since the key does not exist.
      * ```
      */
-    public spopCount(key: string, count: number): Promise<string[]> {
-        return this.createWritePromise(createSPop(key, count));
+    public async spopCount(key: string, count: number): Promise<Set<string>> {
+        const result = (await this.createWritePromise(
+            createSPop(key, count),
+        )) as string[];
+        return new Set(result);
     }
 
     /** Returns the number of keys in `keys` that exist in the database.

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -425,22 +425,19 @@ export class BaseClient {
     /**
      * @internal
      */
-    protected processResultWithSetCommands<ReturnType>(
+    protected processResultWithSetCommands(
         result: ReturnType[] | null,
         setCommandsIndexes: number[],
-    ): (ReturnType | Set<string>)[] | null {
+    ): ReturnType[] | null {
         if (result === null) {
             return null;
         }
 
-        const modifiedResult: (ReturnType | Set<string>)[] =
-            result as ReturnType[];
-
         for (const index of setCommandsIndexes) {
-            modifiedResult[index] = new Set(modifiedResult[index] as string[]);
+            result[index] = new Set<ReturnType>(result[index] as ReturnType[]);
         }
 
-        return modifiedResult;
+        return result;
     }
 
     /** Get the value associated with the given key, or null if no such value exists.
@@ -1220,10 +1217,7 @@ export class BaseClient {
      */
     public smembers(key: string): Promise<Set<string>> {
         return this.createWritePromise<string[]>(createSMembers(key)).then(
-            (result: string[]) => {
-                const resultSet: Set<string> = new Set<string>(result);
-                return resultSet;
-            },
+            (smembes) => new Set<string>(smembes),
         );
     }
 
@@ -1320,10 +1314,7 @@ export class BaseClient {
      */
     public async spopCount(key: string, count: number): Promise<Set<string>> {
         return this.createWritePromise<string[]>(createSPop(key, count)).then(
-            (result: string[]) => {
-                const resultSet: Set<string> = new Set<string>(result);
-                return resultSet;
-            },
+            (spop) => new Set<string>(spop),
         );
     }
 

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -101,8 +101,16 @@ export class RedisClient extends BaseClient {
      *      the list entry will be null.
      *      If the transaction failed due to a WATCH command, `exec` will return `null`.
      */
-    public exec(transaction: Transaction): Promise<ReturnType[] | null> {
-        return this.createWritePromise(transaction.commands);
+    public async exec(transaction: Transaction): Promise<ReturnType[] | null> {
+        const result = (await this.createWritePromise(
+            transaction.commands,
+        )) as ReturnType[];
+
+        for (const index of transaction.set_commands_indexes) {
+            result[index] = new Set(result[index] as string[]);
+        }
+
+        return result;
     }
 
     /** Executes a single command, without checking inputs. Every part of the command, including subcommands,

--- a/node/src/RedisClient.ts
+++ b/node/src/RedisClient.ts
@@ -107,7 +107,7 @@ export class RedisClient extends BaseClient {
         ).then((result: ReturnType[] | null) => {
             return this.processResultWithSetCommands(
                 result,
-                transaction.set_commands_indexes,
+                transaction.setCommandsIndexes,
             );
         });
     }

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -290,23 +290,14 @@ export class RedisClusterClient extends BaseClient {
         transaction: ClusterTransaction,
         route?: SingleNodeRoute,
     ): Promise<ReturnType[] | null> {
-        return this.createWritePromise(
+        return this.createWritePromise<ReturnType[] | null>(
             transaction.commands,
             toProtobufRoute(route),
-        ).then((result: unknown) => {
-            if (result === null) {
-                return null;
-            }
-
-            const modifiedResult: ReturnType[] = result as ReturnType[];
-
-            for (const index of transaction.set_commands_indexes) {
-                modifiedResult[index] = new Set(
-                    modifiedResult[index] as string[],
-                );
-            }
-
-            return modifiedResult;
+        ).then((result: ReturnType[] | null) => {
+            return this.processResultWithSetCommands(
+                result,
+                transaction.set_commands_indexes,
+            );
         });
     }
 

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -296,7 +296,7 @@ export class RedisClusterClient extends BaseClient {
         ).then((result: ReturnType[] | null) => {
             return this.processResultWithSetCommands(
                 result,
-                transaction.set_commands_indexes,
+                transaction.setCommandsIndexes,
             );
         });
     }

--- a/node/src/RedisClusterClient.ts
+++ b/node/src/RedisClusterClient.ts
@@ -286,14 +286,20 @@ export class RedisClusterClient extends BaseClient {
      *      the list entry will be null.
      *      If the transaction failed due to a WATCH command, `exec` will return `null`.
      */
-    public exec(
+    public async exec(
         transaction: ClusterTransaction,
         route?: SingleNodeRoute,
     ): Promise<ReturnType[] | null> {
-        return this.createWritePromise(
+        const result = (await this.createWritePromise(
             transaction.commands,
             toProtobufRoute(route),
-        );
+        )) as ReturnType[];
+
+        for (const index of transaction.set_commands_indexes) {
+            result[index] = new Set(result[index] as string[]);
+        }
+
+        return result;
     }
 
     /** Ping the Redis server.

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -119,15 +119,23 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     readonly commands: redis_request.Command[] = [];
     /**
+     * Array of command indexes indicating commands that need to be converted into a `Set` within the transaction.
      * @internal
      */
     readonly set_commands_indexes: number[] = [];
 
+    /**
+     * Adds a command to the transaction and returns the transaction instance.
+     * @param command - The command to add.
+     * @param is_set - Indicates if the command should be converted to a `Set`.
+     * @returns The updated transaction instance.
+     */
     protected addAndReturn(
         command: redis_request.Command,
         is_set: boolean = false,
     ): T {
         if (is_set) {
+            // If the command is marked as a Set command, its index within the transaction is recorded for conversion.
             this.set_commands_indexes.push(this.commands.length);
         }
 

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -122,21 +122,21 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * Array of command indexes indicating commands that need to be converted into a `Set` within the transaction.
      * @internal
      */
-    readonly set_commands_indexes: number[] = [];
+    readonly setCommandsIndexes: number[] = [];
 
     /**
      * Adds a command to the transaction and returns the transaction instance.
      * @param command - The command to add.
-     * @param is_set - Indicates if the command should be converted to a `Set`.
+     * @param shouldConvertToSet - Indicates if the command should be converted to a `Set`.
      * @returns The updated transaction instance.
      */
     protected addAndReturn(
         command: redis_request.Command,
-        is_set: boolean = false,
+        shouldConvertToSet: boolean = false,
     ): T {
-        if (is_set) {
-            // If the command is marked as a Set command, its index within the transaction is recorded for conversion.
-            this.set_commands_indexes.push(this.commands.length);
+        if (shouldConvertToSet) {
+            // The command's index within the transaction is saved for later conversion of its response to a Set type.
+            this.setCommandsIndexes.push(this.commands.length);
         }
 
         this.commands.push(command);

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -118,6 +118,9 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @internal
      */
     readonly commands: redis_request.Command[] = [];
+    /**
+     * @internal
+     */
     readonly set_commands_indexes: number[] = [];
 
     protected addAndReturn(

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -118,8 +118,16 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * @internal
      */
     readonly commands: redis_request.Command[] = [];
+    readonly set_commands_indexes: number[] = [];
 
-    protected addAndReturn(command: redis_request.Command): T {
+    protected addAndReturn(
+        command: redis_request.Command,
+        is_set: boolean = false,
+    ): T {
+        if (is_set) {
+            this.set_commands_indexes.push(this.commands.length);
+        }
+
         this.commands.push(command);
         return this as unknown as T;
     }
@@ -655,7 +663,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` does not exist, it is treated as an empty set and this command returns empty list.
      */
     public smembers(key: string): T {
-        return this.addAndReturn(createSMembers(key));
+        return this.addAndReturn(createSMembers(key), true);
     }
 
     /** Returns the set cardinality (number of elements) of the set stored at `key`.
@@ -705,7 +713,7 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      * If `key` does not exist, empty list will be returned.
      */
     public spopCount(key: string, count: number): T {
-        return this.addAndReturn(createSPop(key, count));
+        return this.addAndReturn(createSPop(key, count), true);
     }
 
     /** Returns the number of keys in `keys` that exist in the database.

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -144,7 +144,7 @@ export async function transactionTest(
     baseTransaction.sismember(key7, "bar");
     args.push(true);
     baseTransaction.smembers(key7);
-    args.push(["bar"]);
+    args.push(new Set(["bar"]));
     baseTransaction.spop(key7);
     args.push("bar");
     baseTransaction.scard(key7);

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -147,6 +147,8 @@ export async function transactionTest(
     args.push(new Set(["bar"]));
     baseTransaction.spop(key7);
     args.push("bar");
+    baseTransaction.spopCount(key7, 2);
+    args.push(new Set());
     baseTransaction.scard(key7);
     args.push(0);
     baseTransaction.zadd(key8, {

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -1245,7 +1245,7 @@ class CoreCommands(Protocol):
 
         Returns:
             Set[str]: A set of all members of the set.
-                If `key` does not exist an empty list will be returned.
+                If `key` does not exist an empty set will be returned.
 
         Examples:
             >>> await client.smembers("my_set")
@@ -1305,7 +1305,7 @@ class CoreCommands(Protocol):
 
         Returns:
             Set[str]: A set of popped elements will be returned depending on the set's length.
-                  If `key` does not exist, an empty set will be returned.
+                If `key` does not exist, an empty set will be returned.
 
         Examples:
             >>> await client.spop_count("my_set", 2)


### PR DESCRIPTION
*Issue #, if available:*

***Description of changes:***
Currently, the way we convert the rust value returning from core to a js value, is by using napi.
Since napi doesn't support sets, commmands with a return type of set, returns an array in node.
This is breaking the GLIDE API, since similar commands in different wrappers return a completely different type.
Until napi will add support for sets, we will convert each of the command to a Set, in the wrapper. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
