### PR TITLE
Core test utilities: moved client creation to a separate function

### DIFF
--- a/glide-core/tests/utilities/mod.rs
+++ b/glide-core/tests/utilities/mod.rs
@@ -609,7 +609,7 @@ pub async fn setup_acl(addr: &ConnectionAddr, connection_info: &RedisConnectionI
     connection.send_packed_command(&cmd).await.unwrap();
 }
 
-#[derive(Eq, PartialEq, Default)]
+#[derive(Eq, PartialEq, Default, Clone)]
 pub enum ClusterMode {
     #[default]
     Disabled,
@@ -652,7 +652,7 @@ pub fn create_connection_request(
     connection_request
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TestConfiguration {
     pub use_tls: bool,
     pub connection_retry_strategy: Option<connection_request::ConnectionRetryStrategy>,


### PR DESCRIPTION
Core test utilities: moved client creation to a separate function to allow creating additional clients from tests