### PR TITLE
Java: Add OBJECT ENCODING command

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -152,6 +152,7 @@ enum RequestType {
     ZLexCount = 109;
     Append = 110;
     SInterStore = 114;
+    ObjectEncoding = 115;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -120,6 +120,7 @@ pub enum RequestType {
     ZLexCount = 109,
     Append = 110,
     SInterStore = 114,
+    ObjectEncoding = 115,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -243,6 +244,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ZLexCount => RequestType::ZLexCount,
             ProtobufRequestType::Append => RequestType::Append,
             ProtobufRequestType::SInterStore => RequestType::SInterStore,
+            ProtobufRequestType::ObjectEncoding => RequestType::ObjectEncoding,
         }
     }
 }
@@ -362,6 +364,7 @@ impl RequestType {
             RequestType::ZLexCount => Some(cmd("ZLEXCOUNT")),
             RequestType::Append => Some(cmd("APPEND")),
             RequestType::SInterStore => Some(cmd("SINTERSTORE")),
+            RequestType::ObjectEncoding => Some(get_two_word_command("OBJECT", "ENCODING")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -40,6 +40,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -325,6 +326,12 @@ public abstract class BaseClient
     public CompletableFuture<String> mset(@NonNull Map<String, String> keyValueMap) {
         String[] args = convertMapToKeyValueStringArray(keyValueMap);
         return commandManager.submitNewCommand(MSet, args, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> objectEncoding(@NonNull String key) {
+        return commandManager.submitNewCommand(
+                ObjectEncoding, new String[] {key}, this::handleStringOrNullResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -371,4 +371,22 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> type(String key);
+
+    /**
+     * Returns the internal encoding for the Redis object stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/object-encoding/">redis.io</a> for details.
+     * @param key The <code>key</code> of the object to get the internal encoding of.
+     * @return If <code>key</code> exists, returns the internal encoding of the object stored at
+     *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
+     * @example
+     *     <pre>{@code
+     * String encoding = client.objectEncoding("key").get();
+     * assert encoding.equals("encoding");
+     *
+     * String encoding = client.objectEncoding("non_existing_key").get();
+     * assert encoding.equals(null);
+     * }</pre>
+     */
+    CompletableFuture<String> objectEncoding(String key);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -50,6 +50,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -2052,6 +2053,21 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T pfmerge(@NonNull String destination, @NonNull String[] sourceKeys) {
         ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(sourceKeys, destination));
         protobufTransaction.addCommands(buildCommand(PfMerge, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Returns the internal encoding for the Redis object stored at <code>key</code>.
+     *
+     * @see <a href="https://redis.io/commands/object-encoding/">redis.io</a> for details.
+     * @param key The <code>key</code> of the object to get the internal encoding of.
+     * @return Command response - If <code>key</code> exists, returns the internal encoding of the
+     *     object stored at <code>key</code> as a <code>String</code>. Otherwise, return <code>null
+     *     </code>.
+     */
+    public T objectEncoding(@NonNull String key) {
+        ArgsArray commandArgs = buildArgs(key);
+        protobufTransaction.addCommands(buildCommand(ObjectEncoding, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -70,6 +70,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -2995,5 +2996,25 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(OK, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void objectEncoding_returns_success() {
+        // setup
+        String key = "testKey";
+        String encoding = "testEncoding";
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(encoding);
+        when(commandManager.<String>submitNewCommand(eq(ObjectEncoding), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.objectEncoding(key);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(encoding, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -55,6 +55,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.LTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.Lindex;
 import static redis_request.RedisRequestOuterClass.RequestType.MGet;
 import static redis_request.RedisRequestOuterClass.RequestType.MSet;
+import static redis_request.RedisRequestOuterClass.RequestType.ObjectEncoding;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpire;
 import static redis_request.RedisRequestOuterClass.RequestType.PExpireAt;
 import static redis_request.RedisRequestOuterClass.RequestType.PTTL;
@@ -456,6 +457,9 @@ public class TransactionTests {
                 Pair.of(
                         PfMerge,
                         ArgsArray.newBuilder().addArgs("hll").addArgs("hll1").addArgs("hll2").build()));
+
+        transaction.objectEncoding("key");
+        results.add(Pair.of(ObjectEncoding, buildArgs("key")));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -45,6 +45,7 @@ public class TransactionTestUtilities {
         baseTransaction.set(key1, value1);
         baseTransaction.get(key1);
         baseTransaction.type(key1);
+        baseTransaction.objectEncoding(key1);
 
         baseTransaction.set(key2, value2, SetOptions.builder().returnOldValue(true).build());
         baseTransaction.strlen(key2);
@@ -164,6 +165,7 @@ public class TransactionTestUtilities {
             OK,
             value1,
             "string", // type(key1)
+            "embstr", // objectEncoding(key1)
             null,
             (long) value1.length(), // strlen(key2)
             new String[] {value1, value2},


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/commands/object-encoding/

The encodings that are no longer supported are not tested. The `quicklist` encoding is not tested because the default value for `list-max-listpack-size` is 8Kb and changing this value to something more practical to test requires updating the `redis.conf`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
