### PR TITLE
Python: add HRANDFIELD command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Python: Added GEOPOS command ([#1301](https://github.com/aws/glide-for-redis/pull/1301))
 * Node: Added PFADD command ([#1317](https://github.com/aws/glide-for-redis/pull/1317))
 * Python: Added PFADD command ([#1315](https://github.com/aws/glide-for-redis/pull/1315))
+* Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -270,7 +270,7 @@ pub(crate) fn convert_to_expected_type(
             }
         }
         ExpectedReturnType::ArrayOfKeyValuePairs => match value {
-            Value::Nil => Ok(value.clone()),
+            Value::Nil => Ok(value),
             Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Array(_)) => {
                 Ok(value)
             }

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -363,7 +363,7 @@ fn convert_flat_array_to_key_value_pairs(array: Vec<Value>) -> RedisResult<Value
             .into());
     }
 
-    let mut result = Vec::new();
+    let mut result = Vec::with_capacity(array.len() / 2);
     for i in (0..array.len()).step_by(2) {
         let pair = vec![array[i].clone(), array[i + 1].clone()];
         result.push(Value::Array(pair));

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -19,6 +19,7 @@ pub(crate) enum ExpectedReturnType {
     ArrayOfBools,
     Lolwut,
     ArrayOfArraysOfDoubleOrNull,
+    ArrayOfKeyValuePairs,
 }
 
 pub(crate) fn convert_to_expected_type(
@@ -268,6 +269,23 @@ pub(crate) fn convert_to_expected_type(
                     .into()),
             }
         }
+        ExpectedReturnType::ArrayOfKeyValuePairs => match value {
+            Value::Nil => Ok(value.clone()),
+            Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Array(_)) => {
+                Ok(value)
+            }
+            Value::Array(array)
+                if matches!(array[0], Value::BulkString(_) | Value::SimpleString(_)) =>
+            {
+                convert_flat_array_to_key_value_pairs(array)
+            }
+            _ => Err((
+                ErrorKind::TypeError,
+                "Response couldn't be converted to an array of key-value pairs",
+                format!("(response was {:?})", value),
+            )
+                .into()),
+        },
     }
 }
 
@@ -333,6 +351,26 @@ fn convert_array_to_map(
     Ok(Value::Map(map))
 }
 
+/// Converts a flat array of values to a two-dimensional array, where the inner arrays are two-length arrays representing key-value pairs. Normally a map would be more suitable for these responses, but some commands (eg HRANDFIELD) may return duplicate key-value pairs depending on the command arguments. These duplicated pairs cannot be represented by a map.
+///
+/// `array` is a flat array containing keys at even-positioned elements and their associated values at odd-positioned elements.
+fn convert_flat_array_to_key_value_pairs(array: Vec<Value>) -> RedisResult<Value> {
+    if array.len() % 2 != 0 {
+        return Err((
+            ErrorKind::TypeError,
+            "Response has odd number of items, and cannot be converted to an array of key-value pairs"
+        )
+            .into());
+    }
+
+    let mut result = Vec::new();
+    for i in (0..array.len()).step_by(2) {
+        let pair = vec![array[i].clone(), array[i + 1].clone()];
+        result.push(Value::Array(pair));
+    }
+    Ok(Value::Array(result))
+}
+
 pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
     let command = cmd.command()?;
 
@@ -350,6 +388,9 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
         b"ZPOPMIN" | b"ZPOPMAX" => Some(ExpectedReturnType::MapOfStringToDouble),
         b"JSON.TOGGLE" => Some(ExpectedReturnType::JsonToggleReturnType),
         b"GEOPOS" => Some(ExpectedReturnType::ArrayOfArraysOfDoubleOrNull),
+        b"HRANDFIELD" => cmd
+            .position(b"WITHVALUES")
+            .map(|_| ExpectedReturnType::ArrayOfKeyValuePairs),
         b"ZADD" => cmd
             .position(b"INCR")
             .map(|_| ExpectedReturnType::DoubleOrNull),
@@ -453,6 +494,70 @@ mod tests {
                 .unwrap();
         let expected_response = Value::Array(vec![Value::Boolean(false), Value::Boolean(true)]);
         assert_eq!(expected_response, converted_response);
+    }
+
+    #[test]
+    fn convert_hrandfield() {
+        assert!(matches!(
+            expected_type_for_cmd(
+                redis::cmd("HRANDFIELD")
+                    .arg("key")
+                    .arg("1")
+                    .arg("withvalues")
+            ),
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs)
+        ));
+
+        assert!(expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key").arg("1")).is_none());
+        assert!(expected_type_for_cmd(redis::cmd("HRANDFIELD").arg("key")).is_none());
+
+        let flat_array = Value::Array(vec![
+            Value::BulkString(b"key1".to_vec()),
+            Value::BulkString(b"value1".to_vec()),
+            Value::BulkString(b"key2".to_vec()),
+            Value::BulkString(b"value2".to_vec()),
+        ]);
+        let two_dimensional_array = Value::Array(vec![
+            Value::Array(vec![
+                Value::BulkString(b"key1".to_vec()),
+                Value::BulkString(b"value1".to_vec()),
+            ]),
+            Value::Array(vec![
+                Value::BulkString(b"key2".to_vec()),
+                Value::BulkString(b"value2".to_vec()),
+            ]),
+        ]);
+        let converted_flat_array =
+            convert_to_expected_type(flat_array, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
+                .unwrap();
+        assert_eq!(two_dimensional_array, converted_flat_array);
+
+        let converted_two_dimensional_array = convert_to_expected_type(
+            two_dimensional_array.clone(),
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs),
+        )
+        .unwrap();
+        assert_eq!(two_dimensional_array, converted_two_dimensional_array);
+
+        let empty_array = Value::Array(vec![]);
+        let converted_empty_array = convert_to_expected_type(
+            empty_array.clone(),
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs),
+        )
+        .unwrap();
+        assert_eq!(empty_array, converted_empty_array);
+
+        let converted_nil_value =
+            convert_to_expected_type(Value::Nil, Some(ExpectedReturnType::ArrayOfKeyValuePairs))
+                .unwrap();
+        assert_eq!(Value::Nil, converted_nil_value);
+
+        let array_of_doubles = Value::Array(vec![Value::Double(5.5)]);
+        assert!(convert_to_expected_type(
+            array_of_doubles,
+            Some(ExpectedReturnType::ArrayOfKeyValuePairs)
+        )
+        .is_err());
     }
 
     #[test]

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -175,6 +175,7 @@ enum RequestType {
     Touch = 132;
     ZRevRank = 133;
     ZInterStore = 134;
+    HRandField = 135;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -143,6 +143,7 @@ pub enum RequestType {
     Touch = 132,
     ZRevRank = 133,
     ZInterStore = 134,
+    HRandField = 135,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -289,6 +290,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::Touch => RequestType::Touch,
             ProtobufRequestType::ZRevRank => RequestType::ZRevRank,
             ProtobufRequestType::ZInterStore => RequestType::ZInterStore,
+            ProtobufRequestType::HRandField => RequestType::HRandField,
         }
     }
 }
@@ -431,6 +433,7 @@ impl RequestType {
             RequestType::Touch => Some(cmd("TOUCH")),
             RequestType::ZRevRank => Some(cmd("ZREVRANK")),
             RequestType::ZInterStore => Some(cmd("ZINTERSTORE")),
+            RequestType::HRandField => Some(cmd("HRANDFIELD")),
         }
     }
 }

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -879,8 +879,6 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.HRandField, [key, str(count)]),
         )
 
-    WITH_VALUES: str = "WITHVALUES"
-
     async def hrandfield_withvalues(self, key: str, count: int) -> List[List[str]]:
         """
         Retrieves up to `count` random field names along with their values from the hash value stored at `key`.
@@ -905,7 +903,7 @@ class CoreCommands(Protocol):
         return cast(
             List[List[str]],
             await self._execute_command(
-                RequestType.HRandField, [key, str(count), self.WITH_VALUES]
+                RequestType.HRandField, [key, str(count), "WITHVALUES"]
             ),
         )
 

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -835,7 +835,7 @@ class CoreCommands(Protocol):
         """
         Returns a random field name from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.
@@ -854,9 +854,9 @@ class CoreCommands(Protocol):
 
     async def hrandfield_count(self, key: str, count: int) -> List[str]:
         """
-        Retrieves random field names from the hash value stored at `key`.
+        Retrieves up to `count` random field names from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.
@@ -881,13 +881,11 @@ class CoreCommands(Protocol):
 
     WITH_VALUES: str = "WITHVALUES"
 
-    async def hrandfield_count_withvalues(
-        self, key: str, count: int
-    ) -> List[List[str]]:
+    async def hrandfield_withvalues(self, key: str, count: int) -> List[List[str]]:
         """
-        Retrieves random field names along with their values from the hash value stored at `key`.
+        Retrieves up to `count` random field names along with their values from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.
@@ -901,7 +899,7 @@ class CoreCommands(Protocol):
             If the hash does not exist or is empty, the response will be an empty list.
 
         Examples:
-            >>> await client.hrandfield_count_withvalues("my_hash", -3)
+            >>> await client.hrandfield_withvalues("my_hash", -3)
                 [["field1", "value1"], ["field1", "value1"], ["field2", "value2"]]
         """
         return cast(

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -831,6 +831,86 @@ class CoreCommands(Protocol):
         """
         return cast(List[str], await self._execute_command(RequestType.Hkeys, [key]))
 
+    async def hrandfield(self, key: str) -> Optional[str]:
+        """
+        Returns a random field name from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+
+        Returns:
+            Optional[str]: A random field name from the hash stored at `key`.
+            If the hash does not exist or is empty, None will be returned.
+
+        Examples:
+            >>> await client.hrandfield("my_hash")
+                "field1"  # A random field name stored in the hash "my_hash".
+        """
+        return cast(
+            Optional[str], await self._execute_command(RequestType.HRandField, [key])
+        )
+
+    async def hrandfield_count(self, key: str, count: int) -> List[str]:
+        """
+        Retrieves random field names from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Returns:
+            List[str]: A list of random field names from the hash.
+            If the hash does not exist or is empty, the response will be an empty list.
+
+        Examples:
+            >>> await client.hrandfield_count("my_hash", -3)
+                ["field1", "field1", "field2"]  # Non-distinct, random field names stored in the hash "my_hash".
+            >>> await client.hrandfield_count("non_existing_hash", 3)
+                []  # Empty list
+        """
+        return cast(
+            List[str],
+            await self._execute_command(RequestType.HRandField, [key, str(count)]),
+        )
+
+    WITH_VALUES: str = "WITHVALUES"
+
+    async def hrandfield_count_withvalues(
+        self, key: str, count: int
+    ) -> List[List[str]]:
+        """
+        Retrieves random field names along with their values from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Returns:
+            List[List[str]]: A list of `[field_name, value]` lists, where `field_name` is a random field name from the
+            hash and `value` is the associated value of the field name.
+            If the hash does not exist or is empty, the response will be an empty list.
+
+        Examples:
+            >>> await client.hrandfield_count_withvalues("my_hash", -3)
+                [["field1", "value1"], ["field1", "value1"], ["field2", "value2"]]
+        """
+        return cast(
+            List[List[str]],
+            await self._execute_command(
+                RequestType.HRandField, [key, str(count), self.WITH_VALUES]
+            ),
+        )
+
     async def lpush(self, key: str, elements: List[str]) -> int:
         """
         Insert all the specified values at the head of the list stored at `key`.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -613,7 +613,7 @@ class BaseTransaction:
         """
         Returns a random field name from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.
@@ -626,9 +626,9 @@ class BaseTransaction:
 
     def hrandfield_count(self: TTransaction, key: str, count: int) -> TTransaction:
         """
-        Retrieves random field names from the hash value stored at `key`.
+        Retrieves up to `count` random field names from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.
@@ -642,13 +642,11 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.HRandField, [key, str(count)])
 
-    def hrandfield_count_withvalues(
-        self: TTransaction, key: str, count: int
-    ) -> TTransaction:
+    def hrandfield_withvalues(self: TTransaction, key: str, count: int) -> TTransaction:
         """
-        Retrieves random field names along with their values from the hash value stored at `key`.
+        Retrieves up to `count` random field names along with their values from the hash value stored at `key`.
 
-        See https://redis.io/commands/hrandfield/ for more details.
+        See https://valkey.io/commands/hrandfield for more details.
 
         Args:
             key (str): The key of the hash.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -608,6 +608,62 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.Hkeys, [key])
 
+    def hrandfield(self: TTransaction, key: str) -> TTransaction:
+        """
+        Returns a random field name from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+
+        Command response:
+            Optional[str]: A random field name from the hash stored at `key`.
+            If the hash does not exist or is empty, None will be returned.
+        """
+        return self.append_command(RequestType.HRandField, [key])
+
+    def hrandfield_count(self: TTransaction, key: str, count: int) -> TTransaction:
+        """
+        Retrieves random field names from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Command response:
+            List[str]: A list of random field names from the hash.
+            If the hash does not exist or is empty, the response will be an empty list.
+        """
+        return self.append_command(RequestType.HRandField, [key, str(count)])
+
+    def hrandfield_count_withvalues(
+        self: TTransaction, key: str, count: int
+    ) -> TTransaction:
+        """
+        Retrieves random field names along with their values from the hash value stored at `key`.
+
+        See https://redis.io/commands/hrandfield/ for more details.
+
+        Args:
+            key (str): The key of the hash.
+            count (int): The number of field names to return.
+                If `count` is positive, returns unique elements.
+                If negative, allows for duplicates.
+
+        Command response:
+            List[List[str]]: A list of `[field_name, value]` lists, where `field_name` is a random field name from the
+            hash and `value` is the associated value of the field name.
+            If the hash does not exist or is empty, the response will be an empty list.
+        """
+        return self.append_command(
+            RequestType.HRandField, [key, str(count), "WITHVALUES"]
+        )
+
     def lpush(self: TTransaction, key: str, elements: List[str]) -> TTransaction:
         """
         Insert all the specified values at the head of the list stored at `key`.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -5,7 +5,6 @@ from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
 from glide.async_commands.core import (
     ConditionalChange,
-    CoreCommands,
     ExpireOptions,
     ExpirySet,
     GeospatialData,
@@ -660,7 +659,7 @@ class BaseTransaction:
             If the hash does not exist or is empty, the response will be an empty list.
         """
         return self.append_command(
-            RequestType.HRandField, [key, str(count), CoreCommands.WITH_VALUES]
+            RequestType.HRandField, [key, str(count), "WITHVALUES"]
         )
 
     def lpush(self: TTransaction, key: str, elements: List[str]) -> TTransaction:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -5,6 +5,7 @@ from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
 from glide.async_commands.core import (
     ConditionalChange,
+    CoreCommands,
     ExpireOptions,
     ExpirySet,
     GeospatialData,
@@ -661,7 +662,7 @@ class BaseTransaction:
             If the hash does not exist or is empty, the response will be an empty list.
         """
         return self.append_command(
-            RequestType.HRandField, [key, str(count), "WITHVALUES"]
+            RequestType.HRandField, [key, str(count), CoreCommands.WITH_VALUES]
         )
 
     def lpush(self: TTransaction, key: str, elements: List[str]) -> TTransaction:

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -846,7 +846,7 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_hrandfield_count_withvalues(self, redis_client: TRedisClient):
+    async def test_hrandfield_withvalues(self, redis_client: TRedisClient):
         key = get_random_string(10)
         key2 = get_random_string(5)
         field = get_random_string(5)
@@ -855,27 +855,23 @@ class TestCommands:
 
         assert await redis_client.hset(key, field_value_map) == 2
         # Unique values are expected as count is positive
-        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(key, 4)
+        rand_fields_with_values = await redis_client.hrandfield_withvalues(key, 4)
         assert len(rand_fields_with_values) == 2
         for field_with_value in rand_fields_with_values:
             assert field_with_value in [[field, "value"], [field2, "value2"]]
 
         # Duplicate values are expected as count is negative
-        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(
-            key, -4
-        )
+        rand_fields_with_values = await redis_client.hrandfield_withvalues(key, -4)
         assert len(rand_fields_with_values) == 4
         for field_with_value in rand_fields_with_values:
             assert field_with_value in [[field, "value"], [field2, "value2"]]
 
-        assert await redis_client.hrandfield_count_withvalues(key, 0) == []
-        assert (
-            await redis_client.hrandfield_count_withvalues("non_existing_key", 4) == []
-        )
+        assert await redis_client.hrandfield_withvalues(key, 0) == []
+        assert await redis_client.hrandfield_withvalues("non_existing_key", 4) == []
 
         assert await redis_client.set(key2, "value") == OK
         with pytest.raises(RequestError):
-            await redis_client.hrandfield_count_withvalues(key2, 5)
+            await redis_client.hrandfield_withvalues(key2, 5)
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -801,6 +801,84 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        assert await redis_client.hrandfield(key) in [field, field2]
+        assert await redis_client.hrandfield("non_existing_key") is None
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield(key2)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield_count(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        # Unique values are expected as count is positive
+        rand_fields = await redis_client.hrandfield_count(key, 4)
+        assert len(rand_fields) == 2
+        assert set(rand_fields) == {field, field2}
+
+        # Duplicate values are expected as count is negative
+        rand_fields = await redis_client.hrandfield_count(key, -4)
+        assert len(rand_fields) == 4
+        for rand_field in rand_fields:
+            assert rand_field in [field, field2]
+
+        assert await redis_client.hrandfield_count(key, 0) == []
+        assert await redis_client.hrandfield_count("non_existing_key", 4) == []
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield_count(key2, 5)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_hrandfield_count_withvalues(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        key2 = get_random_string(5)
+        field = get_random_string(5)
+        field2 = get_random_string(5)
+        field_value_map = {field: "value", field2: "value2"}
+
+        assert await redis_client.hset(key, field_value_map) == 2
+        # Unique values are expected as count is positive
+        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(key, 4)
+        assert len(rand_fields_with_values) == 2
+        for field_with_value in rand_fields_with_values:
+            assert field_with_value in [[field, "value"], [field2, "value2"]]
+
+        # Duplicate values are expected as count is negative
+        rand_fields_with_values = await redis_client.hrandfield_count_withvalues(
+            key, -4
+        )
+        assert len(rand_fields_with_values) == 4
+        for field_with_value in rand_fields_with_values:
+            assert field_with_value in [[field, "value"], [field2, "value2"]]
+
+        assert await redis_client.hrandfield_count_withvalues(key, 0) == []
+        assert (
+            await redis_client.hrandfield_count_withvalues("non_existing_key", 4) == []
+        )
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.hrandfield_count_withvalues(key2, 5)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_lpush_lpop_lrange(self, redis_client: TRedisClient):
         key = get_random_string(10)
         value_list = ["value4", "value3", "value2", "value1"]

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -39,6 +39,7 @@ async def transaction_test(
     key8 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key9 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key10 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # hyper log log
+    key11 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # hash
 
     value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
@@ -128,6 +129,15 @@ async def transaction_test(
     args.append({key: value, key2: value2, key3: "10.5"})
     transaction.hdel(key4, [key, key2])
     args.append(2)
+
+    transaction.hset(key11, {key: value})
+    args.append(1)
+    transaction.hrandfield(key11)
+    args.append(key)
+    transaction.hrandfield_count(key11, 1)
+    args.append([key])
+    transaction.hrandfield_count_withvalues(key11, 1)
+    args.append([[key, value]])
 
     transaction.client_getname()
     args.append(None)

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -39,7 +39,6 @@ async def transaction_test(
     key8 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key9 = "{{{}}}:{}".format(keyslot, get_random_string(3))
     key10 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # hyper log log
-    key11 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # hash
 
     value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
@@ -129,15 +128,12 @@ async def transaction_test(
     args.append({key: value, key2: value2, key3: "10.5"})
     transaction.hdel(key4, [key, key2])
     args.append(2)
-
-    transaction.hset(key11, {key: value})
-    args.append(1)
-    transaction.hrandfield(key11)
-    args.append(key)
-    transaction.hrandfield_count(key11, 1)
-    args.append([key])
-    transaction.hrandfield_count_withvalues(key11, 1)
-    args.append([[key, value]])
+    transaction.hrandfield(key4)
+    args.append(key3)
+    transaction.hrandfield_count(key4, 1)
+    args.append([key3])
+    transaction.hrandfield_withvalues(key4, 1)
+    args.append([[key3, "10.5"]])
 
     transaction.client_getname()
     args.append(None)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- https://redis.io/docs/latest/commands/hrandfield/
- Includes value conversion:
  - RESP2 returns a flat array of BulkString values, where even-positioned elements are keys and odd-positioned elements are values. RESP3 returns an array of array of BulkString values (in other words, a 2D-array where the inner arrays are key-value pairs). The value conversion converts the RESP2 responses to the RESP3 format.
  - Note that the returned type is a List instead of a Dict because the response may contain duplicates if the user passes in a negative count argument

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
