### PR TITLE
Add WATCH returns null standalone test

### DIFF
--- a/java/integTest/src/test/java/glide/standalone/TransactionTests.java
+++ b/java/integTest/src/test/java/glide/standalone/TransactionTests.java
@@ -8,6 +8,7 @@ import static glide.api.BaseClient.OK;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -184,5 +185,15 @@ public class TransactionTests {
         assertEquals(3L, result[0]);
         assertArrayEquals(new Object[] {0L, 1.0}, (Object[]) result[1]);
         assertArrayEquals(new Object[] {2L, 1.0}, (Object[]) result[2]);
+    }
+
+    @Test
+    @SneakyThrows
+    public void WATCH_transaction_failure_returns_null() {
+        Transaction transaction = new Transaction();
+        transaction.get("key");
+        assertEquals(OK, client.customCommand(new String[] {"WATCH", "key"}).get());
+        assertEquals(OK, client.set("key", "foo").get());
+        assertNull(client.exec(transaction).get());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding shared test for WATCH on a transaction.  Should be updated when we implement the WATCH command. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
