### PR TITLE
Go: Fix bug with -clients=all setting

### DIFF
--- a/go/benchmarks/benchmarking.go
+++ b/go/benchmarks/benchmarking.go
@@ -72,15 +72,13 @@ func executeBenchmarks(runConfig *runConfiguration, connectionSettings *connecti
 				}
 			}
 		}
+	}
 
-		for _, config := range benchmarkConfigs {
-			err := runSingleBenchmark(&config)
-			if err != nil {
-				return err
-			}
+	for _, config := range benchmarkConfigs {
+		err := runSingleBenchmark(&config)
+		if err != nil {
+			return err
 		}
-
-		fmt.Println()
 	}
 
 	return nil
@@ -107,6 +105,7 @@ func runSingleBenchmark(config *benchmarkConfig) error {
 	}
 
 	printResults(benchmarkResult)
+	fmt.Println()
 	return closeClients(clients)
 }
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- This PR fixes a bug where the benchmarks were ran twice for go-redis when the -clients option was set to "all"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
