### PR TITLE
Python: add ZMSCORE command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Python: Added GEOPOS command ([#1301](https://github.com/aws/glide-for-redis/pull/1301))
 * Node: Added PFADD command ([#1317](https://github.com/aws/glide-for-redis/pull/1317))
 * Python: Added PFADD command ([#1315](https://github.com/aws/glide-for-redis/pull/1315))
+* Python: Added ZMSCORE command (TODO: add PR link)
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Python: Added GEOPOS command ([#1301](https://github.com/aws/glide-for-redis/pull/1301))
 * Node: Added PFADD command ([#1317](https://github.com/aws/glide-for-redis/pull/1317))
 * Python: Added PFADD command ([#1315](https://github.com/aws/glide-for-redis/pull/1315))
-* Python: Added ZMSCORE command (TODO: add PR link)
+* Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 
 #### Fixes
 * Python: Fix typing error "‘type’ object is not subscriptable" ([#1203](https://github.com/aws/glide-for-redis/pull/1203))

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -561,9 +561,11 @@ mod tests {
             Value::Double(1.5),
             Value::BulkString(b"2.5".to_vec()),
         ]);
-        let converted_response =
-            convert_to_expected_type(array_response, Some(ExpectedReturnType::ArrayOfDoubleOrNull))
-                .unwrap();
+        let converted_response = convert_to_expected_type(
+            array_response,
+            Some(ExpectedReturnType::ArrayOfDoubleOrNull),
+        )
+        .unwrap();
         let expected_response =
             Value::Array(vec![Value::Nil, Value::Double(1.5), Value::Double(2.5)]);
         assert_eq!(expected_response, converted_response);

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -164,16 +164,7 @@ pub(crate) fn convert_to_expected_type(
                 .into()),
         },
         ExpectedReturnType::ArrayOfBools => match value {
-            Value::Array(array) => {
-                let array_of_bools = array
-                    .iter()
-                    .map(|v| {
-                        convert_to_expected_type(v.clone(), Some(ExpectedReturnType::Boolean))
-                            .unwrap()
-                    })
-                    .collect();
-                Ok(Value::Array(array_of_bools))
-            }
+            Value::Array(array) => convert_array_elements(array, ExpectedReturnType::Boolean),
             _ => Err((
                 ErrorKind::TypeError,
                 "Response couldn't be converted to an array of boolean",
@@ -182,16 +173,7 @@ pub(crate) fn convert_to_expected_type(
                 .into()),
         },
         ExpectedReturnType::ArrayOfDoubles => match value {
-            Value::Array(array) => {
-                let array_of_doubles = array
-                    .iter()
-                    .map(|v| {
-                        convert_to_expected_type(v.clone(), Some(ExpectedReturnType::DoubleOrNull))
-                            .unwrap()
-                    })
-                    .collect();
-                Ok(Value::Array(array_of_doubles))
-            }
+            Value::Array(array) => convert_array_elements(array, ExpectedReturnType::DoubleOrNull),
             _ => Err((
                 ErrorKind::TypeError,
                 "Response couldn't be converted to an array of doubles",
@@ -302,6 +284,21 @@ fn convert_lolwut_string(data: &str) -> String {
     } else {
         data.to_owned()
     }
+}
+
+/// Converts elements in an array to the specified type.
+///
+/// `array` is an array of values.
+/// `element_type` is the type that the array elements should be converted to.
+fn convert_array_elements(array: Vec<Value>, element_type: ExpectedReturnType) -> RedisResult<Value> {
+    let converted_array = array
+        .iter()
+        .map(|v| {
+            convert_to_expected_type(v.clone(), Some(element_type))
+                .unwrap()
+        })
+        .collect();
+    Ok(Value::Array(converted_array))
 }
 
 fn convert_array_to_map(

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -290,13 +290,13 @@ fn convert_lolwut_string(data: &str) -> String {
 ///
 /// `array` is an array of values.
 /// `element_type` is the type that the array elements should be converted to.
-fn convert_array_elements(array: Vec<Value>, element_type: ExpectedReturnType) -> RedisResult<Value> {
+fn convert_array_elements(
+    array: Vec<Value>,
+    element_type: ExpectedReturnType,
+) -> RedisResult<Value> {
     let converted_array = array
         .iter()
-        .map(|v| {
-            convert_to_expected_type(v.clone(), Some(element_type))
-                .unwrap()
-        })
+        .map(|v| convert_to_expected_type(v.clone(), Some(element_type)).unwrap())
         .collect();
     Ok(Value::Array(converted_array))
 }

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2330,7 +2330,7 @@ class CoreCommands(Protocol):
         self,
         key: str,
         members: List[str],
-    ) -> List[float]:
+    ) -> List[Optional[float]]:
         """
         Returns the scores associated with the specified `members` in the sorted set stored at `key`.
 
@@ -2341,7 +2341,7 @@ class CoreCommands(Protocol):
             members (List[str]): A list of members in the sorted set.
 
         Returns:
-            List[float]: A list of scores of the `members`.
+            List[Optional[float]]: A list of scores of the `members`.
                 If a member does not exist, the corresponding value in the list will be None.
 
         Examples:
@@ -2349,7 +2349,7 @@ class CoreCommands(Protocol):
                 [1.0, None, 3.0]
         """
         return cast(
-            List[float],
+            List[Optional[float]],
             await self._execute_command(RequestType.ZMScore, [key] + members),
         )
 

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2334,7 +2334,7 @@ class CoreCommands(Protocol):
         """
         Returns the scores associated with the specified `members` in the sorted set stored at `key`.
 
-        See https://redis.io/commands/zmscore for more details.
+        See https://valkey.io/commands/zmscore for more details.
 
         Args:
             key (str): The key of the sorted set.
@@ -2342,7 +2342,7 @@ class CoreCommands(Protocol):
 
         Returns:
             List[float]: A list of scores of the `members`.
-                If a `member` does not exist, the corresponding value in the list will be `None`.
+                If a member does not exist, the corresponding value in the list will be None.
 
         Examples:
             >>> await client.zmscore("my_sorted_set", ["one", "non_existent_member", "three"])

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2326,6 +2326,33 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.ZScore, [key, member]),
         )
 
+    async def zmscore(
+        self,
+        key: str,
+        members: List[str],
+    ) -> List[float]:
+        """
+        Returns the scores associated with the specified `members` in the sorted set stored at `key`.
+
+        See https://redis.io/commands/zmscore for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            members (List[str]): A list of members in the sorted set.
+
+        Returns:
+            List[float]: A list of scores of the `members`.
+                If a `member` does not exist, the corresponding value in the list will be `None`.
+
+        Examples:
+            >>> await client.zmscore("my_sorted_set", ["one", "non_existent_member", "three"])
+                [1.0, None, 3.0]
+        """
+        return cast(
+            List[float],
+            await self._execute_command(RequestType.ZMScore, [key] + members),
+        )
+
     async def invoke_script(
         self,
         script: Script,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2341,8 +2341,8 @@ class CoreCommands(Protocol):
             members (List[str]): A list of members in the sorted set.
 
         Returns:
-            List[Optional[float]]: A list of scores of the `members`.
-                If a member does not exist, the corresponding value in the list will be None.
+            List[Optional[float]]: A list of scores corresponding to `members`.
+                If a member does not exist in the sorted set, the corresponding value in the list will be None.
 
         Examples:
             >>> await client.zmscore("my_sorted_set", ["one", "non_existent_member", "three"])

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1751,6 +1751,22 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.ZScore, [key, member])
 
+    def zmscore(self: TTransaction, key: str, members: List[str]) -> TTransaction:
+        """
+        Returns the scores associated with the specified `members` in the sorted set stored at `key`.
+
+        See https://redis.io/commands/zmscore for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            members (List[str]): A list of members in the sorted set.
+
+        Command response:
+            List[float]: A list of scores of the `members`.
+                If a `member` does not exist, the corresponding value in the list will be `None`.
+        """
+        return self.append_command(RequestType.ZMScore, [key] + members)
+
     def dbsize(self: TTransaction) -> TTransaction:
         """
         Returns the number of keys in the currently selected database.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1762,7 +1762,7 @@ class BaseTransaction:
             members (List[str]): A list of members in the sorted set.
 
         Command response:
-            List[float]: A list of scores of the `members`.
+            List[Optional[float]]: A list of scores of the `members`.
                 If a member does not exist, the corresponding value in the list will be None.
         """
         return self.append_command(RequestType.ZMScore, [key] + members)

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1755,7 +1755,7 @@ class BaseTransaction:
         """
         Returns the scores associated with the specified `members` in the sorted set stored at `key`.
 
-        See https://redis.io/commands/zmscore for more details.
+        See https://valkey.io/commands/zmscore for more details.
 
         Args:
             key (str): The key of the sorted set.
@@ -1763,7 +1763,7 @@ class BaseTransaction:
 
         Command response:
             List[float]: A list of scores of the `members`.
-                If a `member` does not exist, the corresponding value in the list will be `None`.
+                If a member does not exist, the corresponding value in the list will be None.
         """
         return self.append_command(RequestType.ZMScore, [key] + members)
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1762,8 +1762,8 @@ class BaseTransaction:
             members (List[str]): A list of members in the sorted set.
 
         Command response:
-            List[Optional[float]]: A list of scores of the `members`.
-                If a member does not exist, the corresponding value in the list will be None.
+            List[Optional[float]]: A list of scores corresponding to `members`.
+                If a member does not exist in the sorted set, the corresponding value in the list will be None.
         """
         return self.append_command(RequestType.ZMScore, [key] + members)
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -1706,6 +1706,28 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_zmscore(self, redis_client: TRedisClient):
+        key1 = get_random_string(10)
+        key2 = get_random_string(10)
+        members_scores = {"one": 1, "two": 2, "three": 3}
+
+        assert await redis_client.zadd(key1, members_scores=members_scores) == 3
+        assert await redis_client.zmscore(key1, ["one", "two", "three"]) == [
+            1.0,
+            2.0,
+            3.0,
+        ]
+        assert await redis_client.zmscore(
+            key1, ["one", "non_existing_member", "non_existing_member", "three"]
+        ) == [1.0, None, None, 3.0]
+        assert await redis_client.zmscore("non_existing_key", ["one"]) == [None]
+
+        assert await redis_client.set(key2, "value") == OK
+        with pytest.raises(RequestError):
+            await redis_client.zmscore(key2, ["one"])
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_zpopmin(self, redis_client: TRedisClient):
         key = get_random_string(10)
         members_scores = {"a": 1.0, "b": 2.0, "c": 3.0}

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -203,6 +203,8 @@ async def transaction_test(
     args.append(["two", "three", "four"])
     transaction.zrange_withscores(key8, RangeByIndex(start=0, stop=-1))
     args.append({"two": 2, "three": 3, "four": 4})
+    transaction.zmscore(key8, ["two", "three"])
+    args.append([2.0, 3.0])
     transaction.zpopmin(key8)
     args.append({"two": 2.0})
     transaction.zpopmax(key8)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- https://redis.io/docs/latest/commands/zmscore/
- Note: includes value conversion
  - RESP2 returns an array of BulkString values, where each string represents a Double. The value conversion added in this PR converts array-of-bulkstring responses to array-of-double responses, which matches the RESP3 format

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
