### PR TITLE
Fix CI workflows.

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     named_os:
         description: "The name of the current operating system"
         required: false

--- a/.github/workflows/build-python-wrapper/action.yml
+++ b/.github/workflows/build-python-wrapper/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     target:
         description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
         type: string

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -44,7 +44,7 @@ jobs:
                     - '8.0'
                 os:
                     - ubuntu-latest
-                    - macos-latest
+                    - macos-12
         runs-on: ${{ matrix.os }}
 
         steps:
@@ -62,7 +62,7 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: ${{ matrix.os }}
+                  os: ${{ (contains(matrix.os, 'macos') && 'macos') || 'ubuntu' }}
                   target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -93,6 +93,8 @@ jobs:
                       csharp/TestReport.html
                       benchmarks/results/*
                       utils/clusters/**
+
+# TODO amazonlinux
 
     lint-rust:
         timeout-minutes: 10

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,7 +35,7 @@ jobs:
                     - 7.2.3
                 os:
                     - ubuntu-latest
-                    - macos-latest
+                    - macos-12
 
         runs-on: ${{ matrix.os }}
 
@@ -53,7 +53,7 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: ${{ matrix.os }}
+                  os: ${{ (contains(matrix.os, 'macos') && 'macos') || 'ubuntu' }}
                   target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     target:
         description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
         type: string
@@ -29,7 +29,7 @@ runs:
     steps:
         - name: Install software dependencies for macOS
           shell: bash
-          if: "${{ inputs.os == 'macos-latest' }}"
+          if: "${{ contains(inputs.os, 'macos') }}"
           run: |
               brew update
               brew upgrade || true
@@ -37,7 +37,7 @@ runs:
 
         - name: Install software dependencies for Ubuntu
           shell: bash
-          if: "${{ inputs.os == 'ubuntu-latest' }}"
+          if: "${{ contains(inputs.os, 'ubuntu') }}"
           run: |
               sudo apt update -y
               sudo apt install -y git gcc pkg-config openssl libssl-dev

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -42,7 +42,7 @@ jobs:
                     - 7.2.3
                 os:
                     - ubuntu-latest
-                    - macos-latest
+                    - macos-12
 
         runs-on: ${{ matrix.os }}
 
@@ -60,7 +60,7 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: ${{ matrix.os }}
+                  os: ${{ (contains(matrix.os, 'macos') && 'macos') || 'ubuntu' }}
                   target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/node-create-package-file/action.yml
+++ b/.github/workflows/node-create-package-file/action.yml
@@ -11,8 +11,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     named_os:
         description: "The name of the current operating system"
         required: false

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -106,7 +106,7 @@ jobs:
               name: lint node rust
 
     build-macos-latest:
-        runs-on: macos-latest
+        runs-on: macos-12
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: "macos-latest"
+                  os: "macos"
                   named_os: "darwin"
                   target: "x86_64-apple-darwin"
                   github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -18,17 +18,18 @@ concurrency:
 
 jobs:
     start-self-hosted-runner:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-        - name: Start self hosted EC2 runner
-          uses: ./.github/workflows/start-self-hosted-runner
-          with:
-              aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
-              aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
-              aws-region: ${{ secrets.AWS_REGION }}
-              ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
+        if: github.repository_owner == 'aws'
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+          - name: Start self hosted EC2 runner
+            uses: ./.github/workflows/start-self-hosted-runner
+            with:
+                aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.AWS_REGION }}
+                ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
 
     publish-binaries:
         needs: start-self-hosted-runner
@@ -40,14 +41,14 @@ jobs:
             matrix:
                 build:
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: ubuntu-latest,
                           ARCH: x64,
                           TARGET: x86_64-unknown-linux-gnu,
                       }
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: [self-hosted, Linux, ARM64],
                           ARCH: arm64,
@@ -55,14 +56,14 @@ jobs:
                           CONTAINER: "2_28",
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
-                          RUNNER: macos-latest,
+                          RUNNER: macos-12,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-13-xlarge,
                           arch: arm64,
@@ -152,6 +153,7 @@ jobs:
                   if-no-files-found: error
 
     publish-base-to-npm:
+        if: github.event_name != 'pull_request'
         name: Publish the base NPM package
         needs: publish-binaries
         runs-on: ubuntu-latest
@@ -188,7 +190,7 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: ubuntu-latest
+                  os: ubuntu
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
     start-self-hosted-runner:
+        if: github.repository_owner == 'aws'
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
@@ -41,14 +42,14 @@ jobs:
             matrix:
                 build:
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: ubuntu-latest,
                           ARCH: x64,
                           TARGET: x86_64-unknown-linux-gnu,
                       }
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: [self-hosted, Linux, ARM64],
                           ARCH: arm64,
@@ -56,14 +57,14 @@ jobs:
                           CONTAINER: "2_28",
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
-                          RUNNER: macos-latest,
+                          RUNNER: macos-12,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-13-xlarge,
                           arch: arm64,

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -84,7 +84,7 @@ jobs:
             - name: Build Python wrapper
               uses: ./.github/workflows/build-python-wrapper
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -129,7 +129,7 @@ jobs:
               name: lint python-rust
 
     build-macos-latest:
-        runs-on: macos-latest
+        runs-on: macos-12
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
             - name: Build Python wrapper
               uses: ./.github/workflows/build-python-wrapper
               with:
-                  os: "macos-latest"
+                  os: "macos"
                   target: "x86_64-apple-darwin"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
 
             - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
1. use `macos-12` instead of `macos-latest`
2. prepare to switch from `ubuntu-latest` to `ubunty-$ver`
4. disable CD workflows on forks
5. Fixes CI rediness for C#, node and python

Meanwhile `AWS_REGION` secret is missing, CD workflows are still red.