### PR TITLE
Fix CI workflows

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     named_os:
         description: "The name of the current operating system"
         required: false

--- a/.github/workflows/build-python-wrapper/action.yml
+++ b/.github/workflows/build-python-wrapper/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     target:
         description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
         type: string
@@ -38,9 +38,10 @@ runs:
         - name: Install Python software dependencies
           shell: bash
           run: |
+              INSTALL_FLAGS=`if [[ "${{ inputs.os }}" =~ .*"macos".*  ]]; then echo "--break-system-packages"; else echo ""; fi`
               python3 -m ensurepip --upgrade || true
-              python3 -m pip install --upgrade pip
-              python3 -m pip install virtualenv mypy-protobuf
+              python3 -m pip install --upgrade pip $INSTALL_FLAGS
+              python3 -m pip install virtualenv mypy-protobuf $INSTALL_FLAGS
 
         - name: Generate protobuf files
           shell: bash
@@ -58,6 +59,5 @@ runs:
               source "$HOME/.cargo/env"
               python3 -m venv .env
               source .env/bin/activate
-              python3 -m pip install --upgrade pip
               python3 -m pip install --no-cache-dir -r requirements.txt
               maturin develop

--- a/.github/workflows/build-python-wrapper/action.yml
+++ b/.github/workflows/build-python-wrapper/action.yml
@@ -38,6 +38,7 @@ runs:
         - name: Install Python software dependencies
           shell: bash
           run: |
+              # Disregarding PEP 668 as it addresses package managers conflicts, which is not applicable in the CI scope.
               INSTALL_FLAGS=`if [[ "${{ inputs.os }}" =~ .*"macos".*  ]]; then echo "--break-system-packages"; else echo ""; fi`
               python3 -m ensurepip --upgrade || true
               python3 -m pip install --upgrade pip $INSTALL_FLAGS

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -81,7 +81,7 @@ jobs:
 
             - uses: ./.github/workflows/test-benchmark
               with:
-                  language-flag: -csharp
+                  language-flag: -csharp -dotnet-framework net${{ matrix.dotnet }}
 
             - name: Upload test reports
               if: always()

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -42,10 +42,19 @@ jobs:
                 dotnet:
                     - '6.0'
                     - '8.0'
-                os:
-                    - ubuntu-latest
-                    - macos-latest
-        runs-on: ${{ matrix.os }}
+                host:
+                    - {
+                        OS: ubuntu,
+                        RUNNER: ubuntu-latest,
+                        TARGET: x86_64-unknown-linux-gnu
+                    }
+                    - {
+                        OS: macos,
+                        RUNNER: macos-latest,
+                        TARGET: aarch64-apple-darwin
+                    }
+    
+        runs-on: ${{ matrix.host.RUNNER }}
 
         steps:
             - uses: actions/checkout@v4
@@ -54,22 +63,22 @@ jobs:
 
             - name: Install redis
               # TODO: make this step macos compatible: https://github.com/aws/glide-for-redis/issues/781
-              if: ${{ matrix.os == 'ubuntu-latest' }}
+              if: ${{ matrix.host.OS == 'ubuntu' }}
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
-
-            - name: Install shared software dependencies
-              uses: ./.github/workflows/install-shared-dependencies
-              with:
-                  os: ${{ matrix.os }}
-                  target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Set up dotnet ${{ matrix.dotnet }}
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: ${{ matrix.dotnet }}
+    
+            - name: Install shared software dependencies
+              uses: ./.github/workflows/install-shared-dependencies
+              with:
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Format
               working-directory: ./csharp
@@ -88,11 +97,13 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-dotnet-${{ matrix.dotnet }}-redis-${{ matrix.redis }}-${{ matrix.os }}
+                  name: test-reports-dotnet-${{ matrix.dotnet }}-redis-${{ matrix.redis }}-${{ matrix.host.RUNNER }}
                   path: |
                       csharp/TestReport.html
                       benchmarks/results/*
                       utils/clusters/**
+
+# TODO Add amazonlinux
 
     lint-rust:
         timeout-minutes: 10

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,11 +33,19 @@ jobs:
                 redis:
                     - 6.2.14
                     - 7.2.3
-                os:
-                    - ubuntu-latest
-                    - macos-latest
+                host:
+                  - {
+                    OS: ubuntu,
+                    RUNNER: ubuntu-latest,
+                    TARGET: x86_64-unknown-linux-gnu
+                  }
+                  - {
+                    OS: macos,
+                    RUNNER: macos-latest,
+                    TARGET: aarch64-apple-darwin
+                  }
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.host.RUNNER }}
 
         steps:
             - uses: actions/checkout@v4
@@ -53,8 +61,8 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: ${{ matrix.os }}
-                  target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install redis

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -7,8 +7,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     target:
         description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
         type: string
@@ -29,7 +29,7 @@ runs:
     steps:
         - name: Install software dependencies for macOS
           shell: bash
-          if: "${{ inputs.os == 'macos-latest' }}"
+          if: "${{ inputs.os == 'macos' }}"
           run: |
               brew update
               brew upgrade || true
@@ -37,7 +37,7 @@ runs:
 
         - name: Install software dependencies for Ubuntu
           shell: bash
-          if: "${{ inputs.os == 'ubuntu-latest' }}"
+          if: "${{ inputs.os == 'ubuntu' }}"
           run: |
               sudo apt update -y
               sudo apt install -y git gcc pkg-config openssl libssl-dev

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -40,11 +40,19 @@ jobs:
                 redis:
                     - 6.2.14
                     - 7.2.3
-                os:
-                    - ubuntu-latest
-                    - macos-latest
+                host:
+                  - {
+                    OS: ubuntu,
+                    RUNNER: ubuntu-latest,
+                    TARGET: x86_64-unknown-linux-gnu
+                  }
+                  - {
+                    OS: macos,
+                    RUNNER: macos-latest,
+                    TARGET: aarch64-apple-darwin
+                  }
 
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.host.RUNNER }}
 
         steps:
             - uses: actions/checkout@v4
@@ -60,8 +68,8 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: ${{ matrix.os }}
-                  target: ${{ matrix.os == 'ubuntu-latest' && 'x86_64-unknown-linux-gnu' || 'x86_64-apple-darwin' }}
+                  os: ${{ matrix.host.OS }}
+                  target: ${{ matrix.host.TARGET }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install protoc (protobuf)
@@ -72,7 +80,7 @@ jobs:
 
             - name: Install redis
               # TODO: make this step macos compatible: https://github.com/aws/glide-for-redis/issues/781
-              if: ${{ matrix.os == 'ubuntu-latest' }}
+              if: ${{ matrix.host.OS == 'ubuntu' }}
               uses: ./.github/workflows/install-redis
               with:
                   redis-version: ${{ matrix.redis }}
@@ -94,7 +102,7 @@ jobs:
               continue-on-error: true
               uses: actions/upload-artifact@v4
               with:
-                  name: test-reports-java-${{ matrix.java }}-redis-${{ matrix.redis }}-${{ matrix.os }}
+                  name: test-reports-java-${{ matrix.java }}-redis-${{ matrix.redis }}-${{ matrix.host.RUNNER }}
                   path: |
                       java/client/build/reports/**
                       java/integTest/build/reports/**

--- a/.github/workflows/node-create-package-file/action.yml
+++ b/.github/workflows/node-create-package-file/action.yml
@@ -11,8 +11,8 @@ inputs:
         type: string
         options:
             - amazon-linux
-            - macos-latest
-            - ubuntu-latest
+            - macos
+            - ubuntu
     named_os:
         description: "The name of the current operating system"
         required: false

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -128,9 +128,10 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: "macos-latest"
+                  os: "macos"
                   named_os: "darwin"
-                  target: "x86_64-apple-darwin"
+                  arch: "arm64"
+                  target: "aarch64-apple-darwin"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test compatibility

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -58,7 +58,7 @@ jobs:
                     - {
                           OS: macos,
                           NAMED_OS: darwin,
-                          RUNNER: macos-latest,
+                          RUNNER: macos-12,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -18,17 +18,18 @@ concurrency:
 
 jobs:
     start-self-hosted-runner:
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-        - name: Start self hosted EC2 runner
-          uses: ./.github/workflows/start-self-hosted-runner
-          with:
-              aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
-              aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
-              aws-region: ${{ secrets.AWS_REGION }}
-              ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
+        if: github.repository_owner == 'aws'
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+          - name: Start self hosted EC2 runner
+            uses: ./.github/workflows/start-self-hosted-runner
+            with:
+                aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.AWS_REGION }}
+                ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
 
     publish-binaries:
         needs: start-self-hosted-runner
@@ -40,14 +41,14 @@ jobs:
             matrix:
                 build:
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: ubuntu-latest,
                           ARCH: x64,
                           TARGET: x86_64-unknown-linux-gnu,
                       }
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: [self-hosted, Linux, ARM64],
                           ARCH: arm64,
@@ -55,14 +56,14 @@ jobs:
                           CONTAINER: "2_28",
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-latest,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-13-xlarge,
                           arch: arm64,
@@ -152,6 +153,7 @@ jobs:
                   if-no-files-found: error
 
     publish-base-to-npm:
+        if: github.event_name != 'pull_request'
         name: Publish the base NPM package
         needs: publish-binaries
         runs-on: ubuntu-latest
@@ -188,7 +190,7 @@ jobs:
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
-                  os: ubuntu-latest
+                  os: ubuntu
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -59,7 +59,7 @@ jobs:
                     - {
                           OS: macos,
                           NAMED_OS: darwin,
-                          RUNNER: macos-latest,
+                          RUNNER: macos-12,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }

--- a/.github/workflows/pypi-cd.yml
+++ b/.github/workflows/pypi-cd.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
     start-self-hosted-runner:
+        if: github.repository_owner == 'aws'
         runs-on: ubuntu-latest
         steps:
           - name: Checkout
@@ -41,14 +42,14 @@ jobs:
             matrix:
                 build:
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: ubuntu-latest,
                           ARCH: x64,
                           TARGET: x86_64-unknown-linux-gnu,
                       }
                     - {
-                          OS: ubuntu-latest,
+                          OS: ubuntu,
                           NAMED_OS: linux,
                           RUNNER: [self-hosted, Linux, ARM64],
                           ARCH: arm64,
@@ -56,14 +57,14 @@ jobs:
                           CONTAINER: "2_28",
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-latest,
                           ARCH: x64,
                           TARGET: x86_64-apple-darwin,
                       }
                     - {
-                          OS: macos-latest,
+                          OS: macos,
                           NAMED_OS: darwin,
                           RUNNER: macos-13-xlarge,
                           arch: arm64,

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -84,7 +84,7 @@ jobs:
             - name: Build Python wrapper
               uses: ./.github/workflows/build-python-wrapper
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -141,8 +141,8 @@ jobs:
             - name: Build Python wrapper
               uses: ./.github/workflows/build-python-wrapper
               with:
-                  os: "macos-latest"
-                  target: "x86_64-apple-darwin"
+                  os: "macos"
+                  target: "aarch64-apple-darwin"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test compatibility with pytest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
             - name: Install shared software dependencies
               uses: ./.github/workflows/install-shared-dependencies
               with:
-                  os: "ubuntu-latest"
+                  os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
 
             - uses: dtolnay/rust-toolchain@stable

--- a/benchmarks/install_and_test.sh
+++ b/benchmarks/install_and_test.sh
@@ -33,6 +33,7 @@ chosenClients="all"
 host="localhost"
 port=6379
 tlsFlag="--tls"
+dotnetFramework="net6.0"
 
 function runPythonBenchmark(){
   # generate protobuf files
@@ -67,7 +68,7 @@ function runCSharpBenchmark(){
   cd ${BENCH_FOLDER}/csharp
   dotnet clean
   dotnet build --configuration Release /warnaserror
-  dotnet run --framework net6.0 --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
+  dotnet run --framework $dotnetFramework --configuration Release --resultsFile=../$1 --dataSize $2 --concurrentTasks $concurrentTasks --clients $chosenClients --host $host --clientCount $clientCount $tlsFlag $portFlag $minimalFlag
 }
 
 function runJavaBenchmark(){
@@ -139,6 +140,7 @@ function Help() {
     echo The benchmark will connect to the server using transport level security \(TLS\) by default. Pass -no-tls to connect to server without TLS.
     echo By default, the benchmark runs against localhost. Pass -host and then the address of the requested Redis server in order to connect to a different server.
     echo By default, the benchmark runs against port 6379. Pass -port and then the port number in order to connect to a different port.
+    echo By default, the C# benchmark runs with 'net6.0' framework. Pass -dotnet-framework and then the framework version in order to use a different framework.
 }
 
 while test $# -gt 0
@@ -226,6 +228,9 @@ do
             ;;
         -minimal)
             minimalFlag="--minimal"
+            ;;
+        -dotnet-framework)
+            dotnetFramework=$2
             ;;
     esac
     shift


### PR DESCRIPTION
Based on https://github.com/aws/glide-for-redis/pull/1358.
This PR:
- Disables CD workflows on forks (checks fort he repo owner)
- Differentiate between OS and RUNNER ('ubuntu' vs 'ubuntu-latest') argument, to allow fine-grained dependency installation later on
- The github runner for macos-latest was updated, and now it requires some modifications in the CI to support the newer macOS version:
   1. The latest MacOS runs on ARM64 vs the former which runs on Intel
   2.The latest  MacOS requires installation flag for python installation

Rebased over #1366 
