### PR TITLE
Allow endpoint specification for Python and Node test

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -43,6 +43,7 @@
         "@babel/preset-env": "^7.20.2",
         "@jest/globals": "^29.5.0",
         "@types/jest": "^29.4.0",
+        "@types/minimist": "^1.2.5",
         "@types/redis-server": "^1.2.0",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.54.1",

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -51,7 +51,20 @@ describe("RedisClient", () => {
     }, 20000);
 
     afterEach(async () => {
-        await flushallOnPort(cluster.ports()[0]);
+        // some tests don't initialize a client
+        if (client == undefined) {
+            return;
+        }
+
+        try {
+            await client.customCommand(["FLUSHALL"]);
+        } catch (e) {
+            expect((e as ClosingError).message).toMatch(
+                "Unable to execute requests; the client is closed. Please create a new client.",
+            );
+        }
+
+        client.close();
     });
 
     afterAll(async () => {

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -11,8 +11,10 @@ import {
     it,
 } from "@jest/globals";
 import { v4 as uuidv4 } from "uuid";
+
 import {
     BaseClientConfiguration,
+    ClosingError,
     ClusterTransaction,
     InfoOptions,
     ProtocolVersion,
@@ -21,8 +23,9 @@ import {
 import { runBaseTests } from "./SharedTests";
 import {
     RedisCluster,
-    flushallOnPort,
     getFirstResult,
+    parseCommandLineArgs,
+    parseEndpoints,
     transactionTest,
 } from "./TestUtilities";
 
@@ -35,8 +38,15 @@ const TIMEOUT = 10000;
 describe("RedisClusterClient", () => {
     let testsFailed = 0;
     let cluster: RedisCluster;
+    let client: RedisClusterClient;
     beforeAll(async () => {
-        cluster = await RedisCluster.createCluster(true, 3, 0);
+        const clusterAddresses = parseCommandLineArgs()["cluster-endpoints"];
+        // Connect to cluster or create a new one based on the parsed addresses
+        cluster = clusterAddresses
+            ? RedisCluster.initFromExistingCluster(
+                  parseEndpoints(clusterAddresses),
+              )
+            : await RedisCluster.createCluster(true, 3, 0);
     }, 20000);
 
     afterEach(async () => {
@@ -50,12 +60,12 @@ describe("RedisClusterClient", () => {
     });
 
     const getOptions = (
-        ports: number[],
+        addresses: [string, number][],
         protocol: ProtocolVersion,
     ): BaseClientConfiguration => {
         return {
-            addresses: ports.map((port) => ({
-                host: "localhost",
+            addresses: addresses.map(([host, port]) => ({
+                host,
                 port,
             })),
             protocol,
@@ -64,11 +74,11 @@ describe("RedisClusterClient", () => {
 
     runBaseTests<Context>({
         init: async (protocol, clientName?) => {
-            const options = getOptions(cluster.ports(), protocol);
+            const options = getOptions(cluster.getAddresses(), protocol);
             options.protocol = protocol;
             options.clientName = clientName;
             testsFailed += 1;
-            const client = await RedisClusterClient.createClient(options);
+            client = await RedisClusterClient.createClient(options);
             return {
                 context: {
                     client,
@@ -80,8 +90,6 @@ describe("RedisClusterClient", () => {
             if (testSucceeded) {
                 testsFailed -= 1;
             }
-
-            context.client.close();
         },
         timeout: TIMEOUT,
     });
@@ -89,8 +97,8 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `info with server and replication_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const info_server = getFirstResult(
                 await client.info([InfoOptions.Server]),
@@ -113,7 +121,6 @@ describe("RedisClusterClient", () => {
                     expect.not.stringContaining("# Errorstats"),
                 );
             });
-            client.close();
         },
         TIMEOUT,
     );
@@ -121,8 +128,8 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `info with server and randomNode route_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const result = await client.info(
                 [InfoOptions.Server],
@@ -131,7 +138,6 @@ describe("RedisClusterClient", () => {
             expect(typeof result).toEqual("string");
             expect(result).toEqual(expect.stringContaining("# Server"));
             expect(result).toEqual(expect.not.stringContaining("# Errorstats"));
-            client.close();
         },
         TIMEOUT,
     );
@@ -149,8 +155,8 @@ describe("RedisClusterClient", () => {
                 );
             };
 
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const result = cleanResult(
                 (await client.customCommand(
@@ -187,8 +193,6 @@ describe("RedisClusterClient", () => {
             );
 
             expect(result).toEqual(thirdResult);
-
-            client.close();
         },
         TIMEOUT,
     );
@@ -196,8 +200,8 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `fail routing by address if no port is provided_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             expect(() =>
                 client.info(undefined, {
@@ -205,7 +209,6 @@ describe("RedisClusterClient", () => {
                     host: "foo",
                 }),
             ).toThrowError();
-            client.close();
         },
         TIMEOUT,
     );
@@ -213,15 +216,14 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `config get and config set transactions test_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const transaction = new ClusterTransaction();
             transaction.configSet({ timeout: "1000" });
             transaction.configGet(["timeout"]);
             const result = await client.exec(transaction);
             expect(result).toEqual(["OK", { timeout: "1000" }]);
-            client.close();
         },
         TIMEOUT,
     );
@@ -229,14 +231,13 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `can send transactions_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const transaction = new ClusterTransaction();
             const expectedRes = await transactionTest(transaction);
             const result = await client.exec(transaction);
             expect(result).toEqual(expectedRes);
-            client.close();
         },
         TIMEOUT,
     );
@@ -245,10 +246,10 @@ describe("RedisClusterClient", () => {
         `can return null on WATCH transaction failures_%p`,
         async (protocol) => {
             const client1 = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+                getOptions(cluster.getAddresses(), protocol),
             );
             const client2 = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+                getOptions(cluster.getAddresses(), protocol),
             );
             const transaction = new ClusterTransaction();
             transaction.get("key");
@@ -270,8 +271,8 @@ describe("RedisClusterClient", () => {
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `echo with all nodes routing_%p`,
         async (protocol) => {
-            const client = await RedisClusterClient.createClient(
-                getOptions(cluster.ports(), protocol),
+            client = await RedisClusterClient.createClient(
+                getOptions(cluster.getAddresses(), protocol),
             );
             const message = uuidv4();
             const echoDict = await client.echo(message, "allNodes");
@@ -280,7 +281,6 @@ describe("RedisClusterClient", () => {
             expect(Object.values(echoDict)).toEqual(
                 expect.arrayContaining([message]),
             );
-            client.close();
         },
         TIMEOUT,
     );

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -50,7 +50,20 @@ describe("RedisClusterClient", () => {
     }, 20000);
 
     afterEach(async () => {
-        await Promise.all(cluster.ports().map((port) => flushallOnPort(port)));
+        // some tests don't initialize a client
+        if (client == undefined) {
+            return;
+        }
+
+        try {
+            await client.customCommand(["FLUSHALL"]);
+        } catch (e) {
+            expect((e as ClosingError).message).toMatch(
+                "Unable to execute requests; the client is closed. Please create a new client.",
+            );
+        }
+
+        client.close();
     });
 
     afterAll(async () => {

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2203,7 +2203,6 @@ export function runBaseTests<Context>(config: {
                 expect(Number(result?.at(0))).toBeGreaterThan(now);
                 // Test its not more than 1 second
                 expect(Number(result?.at(1))).toBeLessThan(1000000);
-                client.close();
             }, protocol);
         },
     );
@@ -2280,7 +2279,6 @@ export function runBaseTests<Context>(config: {
                 expect(result).toEqual("value");
                 // If key doesn't exist it should throw, it also test that key has successfully been renamed
                 await expect(client.rename(key, newKey)).rejects.toThrow();
-                client.close();
             }, protocol);
         },
         config.timeout,

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -4,6 +4,7 @@
 
 import { beforeAll, expect } from "@jest/globals";
 import { exec } from "child_process";
+import parseArgs from "minimist";
 import { v4 as uuidv4 } from "uuid";
 import { ClusterTransaction, Logger, ReturnType, Transaction } from "..";
 import { checkIfServerVersionLessThan } from "./SharedTests";
@@ -40,6 +41,55 @@ export function flushallOnPort(port: number): Promise<void> {
     );
 }
 
+/**
+ * Parses a string of endpoints into an array of host-port pairs.
+ * Each endpoint in the string should be in the format 'host:port', separated by commas.
+ *
+ * @param endpointsStr - The string containing endpoints in the format 'host:port', separated by commas.
+ * @returns An array of host-port pairs parsed from the endpoints string.
+ * @throws If the endpoints string or its format is invalid.
+ * @example
+ * ```typescript
+ * const endpointsStr = 'localhost:8080,example.com:3000,192.168.1.100:5000';
+ * const endpoints = parseEndpoints(endpointsStr);
+ * console.log(endpoints);
+ * // Output: [['localhost', 8080], ['example.com', 3000], ['192.168.1.100', 5000]]
+ * ```
+ */
+export const parseEndpoints = (endpointsStr: string): [string, number][] => {
+    try {
+        console.log(endpointsStr);
+        const endpoints: string[][] = endpointsStr
+            .split(",")
+            .map((endpoint) => endpoint.split(":"));
+        endpoints.forEach((endpoint) => {
+            // Check if each endpoint has exactly two elements (host and port)
+            if (endpoint.length !== 2) {
+                throw new Error(
+                    "Each endpoint should be in the format 'host:port'.\nEndpoints should be separated by commas.",
+                );
+            }
+
+            // Extract host and port
+            const [host, portStr] = endpoint;
+
+            // Check if both host and port are specified and if port is a valid integer
+            if (!host || !portStr || !/^\d+$/.test(portStr)) {
+                throw new Error(
+                    "Both host and port should be specified and port should be a valid integer.",
+                );
+            }
+        });
+
+        // Convert port strings to numbers and return the result
+        return endpoints.map(([host, portStr]) => [host, Number(portStr)]);
+    } catch (error) {
+        throw new Error(
+            "Invalid endpoints format: " + (error as Error).message,
+        );
+    }
+};
+
 /// This function takes the first result of the response if it got more than one response (like cluster responses).
 export function getFirstResult(
     res: string | number | Record<string, string> | Record<string, number>,
@@ -49,6 +99,22 @@ export function getFirstResult(
     }
 
     return Object.values(res).at(0);
+}
+
+/**
+ * Parses the command-line arguments passed to the Node.js process.
+ *
+ * @returns Parsed command-line arguments.
+ *
+ * @example
+ * ```typescript
+ * // Command: node script.js --name="John Doe" --age=30
+ * const args = parseCommandLineArgs();
+ * // args = { name: 'John Doe', age: 30 }
+ * ```
+ */
+export function parseCommandLineArgs() {
+    return parseArgs(process.argv.slice(2));
 }
 
 export async function transactionTest(
@@ -224,17 +290,17 @@ export async function transactionTest(
 }
 
 export class RedisCluster {
-    private usedPorts: number[];
-    private clusterFolder: string;
+    private addresses: [string, number][];
+    private clusterFolder: string | undefined;
 
-    private constructor(ports: number[], clusterFolder: string) {
-        this.usedPorts = ports;
+    private constructor(addresses: [string, number][], clusterFolder?: string) {
+        this.addresses = addresses;
         this.clusterFolder = clusterFolder;
     }
 
     private static parseOutput(input: string): {
         clusterFolder: string;
-        ports: number[];
+        addresses: [string, number][];
     } {
         const lines = input.split(/\r\n|\r|\n/);
         const clusterFolder = lines
@@ -244,8 +310,11 @@ export class RedisCluster {
             .find((line) => line.startsWith("CLUSTER_NODES"))
             ?.split("=")[1]
             .split(",")
-            .map((address) => address.split(":")[1])
-            .map((port) => Number(port));
+            .map((address) => address.split(":"))
+            .map((address) => [address[0], Number(address[1])]) as [
+            string,
+            number,
+        ][];
 
         if (clusterFolder === undefined || ports === undefined) {
             throw new Error(`Insufficient data in input: ${input}`);
@@ -253,7 +322,7 @@ export class RedisCluster {
 
         return {
             clusterFolder,
-            ports,
+            addresses: ports,
         };
     }
 
@@ -288,30 +357,43 @@ export class RedisCluster {
                     console.error(stderr);
                     reject(error);
                 } else {
-                    const { clusterFolder, ports } = this.parseOutput(stdout);
+                    const { clusterFolder, addresses: ports } =
+                        this.parseOutput(stdout);
                     resolve(new RedisCluster(ports, clusterFolder));
                 }
             });
         });
     }
 
+    public static initFromExistingCluster(
+        addresses: [string, number][],
+    ): RedisCluster {
+        return new RedisCluster(addresses, "");
+    }
+
     public ports(): number[] {
-        return [...this.usedPorts];
+        return this.addresses.map((address) => address[1]);
+    }
+
+    public getAddresses(): [string, number][] {
+        return this.addresses;
     }
 
     public async close() {
-        await new Promise<void>((resolve, reject) =>
-            exec(
-                `python3 ../utils/cluster_manager.py stop --cluster-folder ${this.clusterFolder}`,
-                (error, _, stderr) => {
-                    if (error) {
-                        console.error(stderr);
-                        reject(error);
-                    } else {
-                        resolve();
-                    }
-                },
-            ),
-        );
+        if (this.clusterFolder) {
+            await new Promise<void>((resolve, reject) => {
+                exec(
+                    `python3 ../utils/cluster_manager.py stop --cluster-folder ${this.clusterFolder}`,
+                    (error, _, stderr) => {
+                        if (error) {
+                            console.error(stderr);
+                            reject(error);
+                        } else {
+                            resolve();
+                        }
+                    },
+                );
+            });
+        }
     }
 }

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -259,7 +259,8 @@ class TestRedisClients:
             # Delete this user
             await redis_client.custom_command(["ACL", "DELUSER", username])
 
-    async def test_select_standalone_database_id(self, request):
+    @pytest.mark.parametrize("cluster_mode", [False])
+    async def test_select_standalone_database_id(self, request, cluster_mode):
         redis_client = await create_client(request, cluster_mode=False, database_id=4)
         client_info = await redis_client.custom_command(["CLIENT", "INFO"])
         assert "db=4" in client_info

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -261,7 +261,9 @@ class TestRedisClients:
 
     @pytest.mark.parametrize("cluster_mode", [False])
     async def test_select_standalone_database_id(self, request, cluster_mode):
-        redis_client = await create_client(request, cluster_mode=False, database_id=4)
+        redis_client = await create_client(
+            request, cluster_mode=cluster_mode, database_id=4
+        )
         client_info = await redis_client.custom_command(["CLIENT", "INFO"])
         assert "db=4" in client_info
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR introduces the ability to specify endpoints when running tests for both Python and Node environments.

To run the tests in python using with external endpoints:
`pytest --asyncio-mode=auto --cluster-endpoints=host:port,host2:port2 --standalone-endpoints=host1:port
`

In Node:
`npm run test -- --cluster-endpoints=host:port,host2:port2 --standalone-endpoints=host1:port
`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
