### PR TITLE
Core: Fix clippy linting error

### DIFF
--- a/glide-core/tests/utilities/cluster.rs
+++ b/glide-core/tests/utilities/cluster.rs
@@ -122,7 +122,7 @@ impl RedisCluster {
         let (cluster_folder, addresses) = Self::parse_start_script_output(&stdout, &stderr);
         let mut password: Option<String> = None;
         if let Some(info) = conn_info {
-            password = info.password.clone();
+            password.clone_from(&info.password);
         };
         RedisCluster {
             cluster_folder,


### PR DESCRIPTION
*Issue #, if available:*
N/A

A new version of Rust just dropped today (https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html) and it is causing linting to fail on main, which breaks our CI builds. This change fixes the new clippy linting error.
```
error: assigning the result of `Clone::clone()` may be inefficient
   --> tests/utilities/cluster.rs:125:13
    |
125 |             password = info.password.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `password.clone_from(&info.password)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `-D clippy::assigning-clones` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::assigning_clones)]`
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
