### PR TITLE
Adding support for node:alpine

### DIFF
--- a/.github/workflows/build-node-wrapper/action.yml
+++ b/.github/workflows/build-node-wrapper/action.yml
@@ -65,14 +65,15 @@ runs:
             named_os: ${{ inputs.named_os }}
             arch: ${{ inputs.arch }}
             npm_scope: ${{ inputs.npm_scope }}
-
+            target: ${{ inputs.target }}
+    
         - name: npm install
           shell: bash
           working-directory: ./node
           run: |
               rm -rf node_modules && npm install --frozen-lockfile
               cd rust-client
-              npm install
+              npm install --frozen-lockfile
 
         - name: Build
           shell: bash

--- a/.github/workflows/install-rust-and-protoc/action.yml
+++ b/.github/workflows/install-rust-and-protoc/action.yml
@@ -1,0 +1,32 @@
+name: Install Rust tool chain and protoc
+
+inputs:
+    target:
+        description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
+        type: string
+        required: false
+        default: "x86_64-unknown-linux-gnu"
+        options:
+            - x86_64-unknown-linux-gnu
+            - aarch64-unknown-linux-gnu
+            - x86_64-apple-darwin
+            - aarch64-apple-darwin
+    github-token:
+        description: "GitHub token"
+        type: string
+        required: true
+
+
+runs:
+    using: "composite"
+    steps:
+        - name: Install Rust toolchain
+          uses: dtolnay/rust-toolchain@stable
+          with:
+              targets: ${{ inputs.target }}
+
+        - name: Install protoc (protobuf)
+          uses: arduino/setup-protoc@v3
+          with:
+              version: "25.1"
+              repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/install-shared-dependencies/action.yml
+++ b/.github/workflows/install-shared-dependencies/action.yml
@@ -19,10 +19,13 @@ inputs:
             - aarch64-unknown-linux-gnu
             - x86_64-apple-darwin
             - aarch64-apple-darwin
+            - aarch64-unknown-linux-musl
+            - x86_64-unknown-linux-musl
     github-token:
         description: "GITHUB_TOKEN, GitHub App installation access token"
         required: true
         type: string
+
 
 runs:
     using: "composite"
@@ -35,12 +38,21 @@ runs:
               brew upgrade || true
               brew install git gcc pkgconfig openssl redis coreutils
 
-        - name: Install software dependencies for Ubuntu
+        - name: Install software dependencies for Ubuntu GNU
           shell: bash
-          if: "${{ inputs.os == 'ubuntu' }}"
+          if: "${{ inputs.os == 'ubuntu' && !contains(inputs.target, 'musl')}}"
           run: |
               sudo apt update -y
               sudo apt install -y git gcc pkg-config openssl libssl-dev
+          
+        - name: Install software dependencies for Ubuntu MUSL
+          shell: bash
+          if: "${{ contains(inputs.target, 'musl') }}"
+          run: |
+              apk update
+              wget -O - https://sh.rustup.rs | sh -s -- -y
+              source "$HOME/.cargo/env"
+              apk add protobuf-dev musl-dev make gcc redis envsubst
 
         - name: Install software dependencies for Amazon-Linux
           shell: bash
@@ -48,13 +60,9 @@ runs:
           run: |
               yum install -y gcc pkgconfig openssl openssl-devel which curl redis6 gettext --allowerasing
 
-        - name: Install Rust toolchain
-          uses: dtolnay/rust-toolchain@stable
+        - name: Install Rust toolchain and protoc
+          if: "${{ !contains(inputs.target, 'musl') }}"
+          uses: ./.github/workflows/install-rust-and-protoc
           with:
-              targets: ${{ inputs.target }}
-
-        - name: Install protoc (protobuf)
-          uses: arduino/setup-protoc@v3
-          with:
-              version: "25.1"
-              repo-token: ${{ inputs.github-token }}
+            target: ${{ inputs.target }}
+            github-token: ${{ inputs.github-token }}

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -5,6 +5,10 @@ inputs:
         description: "folder that contains the target Cargo.toml file"
         required: true
         type: string
+    github-token:
+        description: "github token"
+        required: false
+        type: string
 
 runs:
     using: "composite"
@@ -16,6 +20,8 @@ runs:
 
         - name: Install Rust toolchain and protoc
           uses: ./.github/workflows/install-rust-and-protoc
+          with:
+              github-token: ${{ inputs.github-token }}
 
         - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -14,13 +14,10 @@ runs:
           with:
               submodules: recursive
 
-        - uses: dtolnay/rust-toolchain@stable
-        - uses: Swatinem/rust-cache@v2
+        - name: Install Rust toolchain and protoc
+          uses: ./.github/workflows/install-rust-and-protoc
 
-        - name: Install protoc (protobuf)
-          uses: arduino/setup-protoc@v3
-          with:
-            version: "25.1"
+        - uses: Swatinem/rust-cache@v2
 
         - run: cargo fmt --all -- --check
           working-directory: ${{ inputs.cargo-toml-folder }}

--- a/.github/workflows/node-create-package-file/action.yml
+++ b/.github/workflows/node-create-package-file/action.yml
@@ -34,6 +34,17 @@ inputs:
         required: false
         type: string
         default: "@aws"
+    target:
+        description: "Specified target for rust toolchain, ex. x86_64-apple-darwin"
+        type: string
+        required: true
+        options:
+            - x86_64-unknown-linux-gnu
+            - aarch64-unknown-linux-gnu
+            - x86_64-apple-darwin
+            - aarch64-apple-darwin
+            - aarch64-unknown-linux-musl
+            - x86_64-unknown-linux-musl
 
 runs:
     using: "composite"
@@ -42,6 +53,8 @@ runs:
           shell: bash
           working-directory: ./node
           run: |
+              # echo -musl if inputs.target is musl
+              export MUSL_FLAG=`if [[ "${{ inputs.target }}" =~ .*"musl".*  ]]; then echo "-musl"; fi`
               # set the package name
               name="glide-for-redis"
               # derive the OS and architecture from the inputs
@@ -50,7 +63,7 @@ runs:
               # set the version
               export package_version="${{ inputs.release_version }}"
               # set the package name
-              export pkg_name="${name}-${node_os}-${node_arch}"
+              export pkg_name="${name}-${node_os}${MUSL_FLAG}-${node_arch}"
               # set the scope
               export scope=`if [ "${{ inputs.npm_scope }}" != ''  ]; then echo "${{ inputs.npm_scope }}/"; fi`
               # set the registry scope

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -217,25 +217,12 @@ jobs:
             image: node:alpine
             options: --user root --privileged --rm
         steps:
-          - name: Install dependencies
-            run: |
-              apk update
-              apk add bash git sed python3
-
-          - name: Set up access
-            run: |
-              chown -R $(whoami):$(whoami) $GITHUB_WORKSPACE
-
-          # Since we currently cannot use the checkout action with musl on arm, we are checking-out the repo out of the container and here we are just resetting the repo
-          # to make sure we get the clean checkout of the action.
-          - name: Clean repository
-            shell: bash
-            run: |
-                git config --global --add safe.directory $GITHUB_WORKSPACE
-                git clean -xdf
-                git reset --hard
-                git submodule sync
-                git submodule update --init --recursive
+          - name: Setup musl on Linux ARM
+            uses: ./.github/workflows/setup-musl-on-linux
+            with:
+                workspace: $GITHUB_WORKSPACE
+                npm-scope: ${{ secrets.NPM_SCOPE }}
+                npm-auth-token: ${{ secrets.NPM_AUTH_TOKEN }}
 
           - name: Build Node wrapper
             uses: ./.github/workflows/build-node-wrapper

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -177,4 +177,90 @@ jobs:
 
             - name: Test compatibility
               run: npm test -- -t "set and get flow works"
-              working-directory: ./node
+              working-directory: ./node                   
+
+    start-self-hosted-runner:
+        if: github.repository_owner == 'aws'
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@v4
+
+          - name: Start self hosted EC2 runner
+            uses: ./.github/workflows/start-self-hosted-runner
+            with:
+                aws-access-key-id: ${{ secrets.AWS_EC2_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.AWS_EC2_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.AWS_REGION }}
+                ec2-instance-id: ${{ secrets.AWS_EC2_INSTANCE_ID }}
+
+    # Since we are running a docker on a self-hosted runner, we need to make sure that the docker container has the same permissions as the self-hosted runner
+    # This is done by changing the ownership of the actions-runner directory to the user that is running the docker container
+    # We also need to checkout the repository, but since it is not possible to use checkout action with musl on arm we are doing it outside of the container,
+    # and later on in the container we just need to reset the repo to make sure we get the clean checkout of the action.
+    checkout-self-hosted-runner:
+      if: github.repository_owner == 'aws'
+      runs-on: [self-hosted, Linux, ARM64]
+      needs: start-self-hosted-runner
+      steps:
+        - name: Setup self-hosted runner access
+          run: sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work/glide-for-redis
+        - name: Checkout
+          uses: actions/checkout@v4
+      
+    build-and-test-linux-musl-latest:
+        if: github.repository_owner == 'aws'
+        needs: [start-self-hosted-runner, checkout-self-hosted-runner]
+        name: Build and test Node wrapper on Linux musl
+        runs-on: [self-hosted, Linux, ARM64]
+        container:
+            image: node:alpine
+            options: --user root --privileged
+        strategy:
+            fail-fast: false
+        steps:
+          - name: Install dependencies
+            run: |
+              apk update
+              apk add bash git sed python3
+
+          - name: Set up access
+            run: |
+              chown -R $(whoami):$(whoami) $GITHUB_WORKSPACE
+
+          # Since we currently cannot use the checkout action with musl on arm, we are checking-out the repo out of the container and here we are just resetting the repo
+          # to make sure we get the clean checkout of the action.
+          - name: Clean repository
+            shell: bash
+            run: |
+                git config --global --add safe.directory $GITHUB_WORKSPACE
+                git clean -xdf
+                git reset --hard
+                git submodule sync
+                git submodule update --init --recursive
+
+          - name: Build Node wrapper
+            uses: ./.github/workflows/build-node-wrapper
+            with:
+                os: ubuntu
+                named_os: linux
+                arch: arm64
+                target: aarch64-unknown-linux-musl
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                npm_scope: ${{ vars.NPM_SCOPE }}
+                publish: false
+          
+          - name: Test compatibility
+            shell: bash
+            run: npm test -- -t "set and get flow works"
+            working-directory: ./node
+
+          # Reset the repository to make sure we get the clean checkout of the action later in other actions.
+          # It is not required since in other actions we are cleaning before the action, but it is a good practice to do it here as well.
+          - name: Reset repository
+            if: always()
+            shell: bash
+            run: |
+                git reset --hard
+                git clean -xdf
+              

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -215,9 +215,7 @@ jobs:
         runs-on: [self-hosted, Linux, ARM64]
         container:
             image: node:alpine
-            options: --user root --privileged
-        strategy:
-            fail-fast: false
+            options: --user root --privileged --rm
         steps:
           - name: Install dependencies
             run: |

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -8,6 +8,7 @@ on:
         - .github/workflows/npm-cd.yml
         - .github/workflows/build-node-wrapper/action.yml
         - .github/workflows/start-self-hosted-runner/action.yml
+        - .github/workflows/install-rust-and-protoc/action.yml
     push:
         tags:
             - "v*.*"
@@ -23,6 +24,7 @@ jobs:
         steps:
           - name: Checkout
             uses: actions/checkout@v4
+
           - name: Start self hosted EC2 runner
             uses: ./.github/workflows/start-self-hosted-runner
             with:
@@ -36,6 +38,9 @@ jobs:
         if: github.repository_owner == 'aws'
         name: Publish packages to NPM
         runs-on: ${{ matrix.build.RUNNER }}
+        container:
+            image: ${{ matrix.build.IMAGE || '' }}
+            options: ${{ matrix.build.CONTAINER_OPTIONS || 'none'}}
         strategy:
             fail-fast: false
             matrix:
@@ -69,12 +74,53 @@ jobs:
                           arch: arm64,
                           TARGET: aarch64-apple-darwin,
                       }
+                    - {
+                          OS: ubuntu,
+                          NAMED_OS: linux,
+                          ARCH: arm64,
+                          TARGET: aarch64-unknown-linux-musl,
+                          RUNNER: [self-hosted, Linux, ARM64],
+                          IMAGE: 'node:alpine',
+                          CONTAINER_OPTIONS: '--user root --privileged',
+                      }
+                    - {
+                          OS: ubuntu,
+                          NAMED_OS: linux,
+                          ARCH: x64,
+                          TARGET: x86_64-unknown-linux-musl,
+                          RUNNER: ubuntu-latest,
+                          IMAGE: 'node:alpine',
+                          CONTAINER_OPTIONS: '--user root --privileged',
+                      }
         steps:
             - name: Setup self-hosted runner access
-              if: ${{ contains(matrix.build.RUNNER, 'self-hosted') }}
+              if: ${{ contains(matrix.build.RUNNER, 'self-hosted') && matrix.build.TARGET != 'aarch64-unknown-linux-musl' }}
               run: sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work/glide-for-redis
 
+            - name: Install dependencies
+              if: ${{ contains(matrix.build.TARGET, 'musl') }}
+              run: |
+                apk update
+                apk add bash git sed
+            
+            # Currently "Checkout" action is not supported for musl on ARM64, so the checkout is happening on the runner and 
+            # here we just making sure we getting the clean repo
+            - name: Clean repository for musl on ARM64
+              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl'}}
+              run: |
+                  git config --global --add safe.directory $GITHUB_WORKSPACE
+                  git clean -xdf
+                  git reset --hard
+                  git submodule sync
+                  git submodule update --init --recursive
+            
+            - name: Set up access for musl on ARM
+              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl' }}
+              run: |
+                chown -R $(whoami):$(whoami) $GITHUB_WORKSPACE
+
             - name: Checkout
+              if: ${{ matrix.build.TARGET != 'aarch64-unknown-linux-musl' }}
               uses: actions/checkout@v4
               with:
                   submodules: "true"
@@ -86,6 +132,7 @@ jobs:
                   echo "RELEASE_VERSION=${version}" >> $GITHUB_ENV
 
             - name: Setup node
+              if: ${{ matrix.build.TARGET != 'aarch64-unknown-linux-musl' }}
               uses: actions/setup-node@v3
               with:
                   node-version: "16"
@@ -95,12 +142,20 @@ jobs:
                   always-auth: true
                   token: ${{ secrets.NPM_AUTH_TOKEN }}
             
+            - name: Setup node
+              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl' }}
+              working-directory: ./node
+              run: |
+                npm config set registry https://registry.npmjs.org/
+                npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_AUTH_TOKEN }}
+                npm config set scope ${{ vars.NPM_SCOPE }}
+            
             - name: Update package version in config.toml
               uses: ./.github/workflows/update-glide-version
               with:
                   folder_path: "${{ github.workspace }}/node/rust-client/.cargo"
                   named_os: ${{ matrix.build.NAMED_OS }}
-                
+
             - name: Build Node wrapper
               uses: ./.github/workflows/build-node-wrapper
               with:
@@ -151,6 +206,15 @@ jobs:
                   name: ${{ matrix.build.TARGET }}
                   path: ./node/bin
                   if-no-files-found: error
+
+            # Reset the repository to make sure we get the clean checkout of the action later in other actions.
+            # It is not required since in other actions we are cleaning before the action, but it is a good practice to do it here as well.
+            - name: Reset repository
+              if: ${{ matrix.build.ARCH == 'arm64' }}
+              shell: bash
+              run: |
+                git reset --hard
+                git clean -xdf
 
     publish-base-to-npm:
         if: github.event_name != 'pull_request'

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -24,6 +24,8 @@ jobs:
         steps:
           - name: Checkout
             uses: actions/checkout@v4
+            with:
+                fetch-depth: 0
 
           - name: Start self hosted EC2 runner
             uses: ./.github/workflows/start-self-hosted-runner
@@ -96,33 +98,28 @@ jobs:
               if: ${{ contains(matrix.build.RUNNER, 'self-hosted') && matrix.build.TARGET != 'aarch64-unknown-linux-musl' }}
               run: sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work/glide-for-redis
 
-            - name: Install dependencies
-              if: ${{ contains(matrix.build.TARGET, 'musl') }}
+            # For MUSL on X64 we need to install git since we use the checkout action
+            - name: Install git for musl
+              if: ${{ contains(matrix.build.TARGET, 'x86_64-unknown-linux-musl')}}
               run: |
-                apk update
-                apk add bash git sed
-            
-            # Currently "Checkout" action is not supported for musl on ARM64, so the checkout is happening on the runner and 
-            # here we just making sure we getting the clean repo
-            - name: Clean repository for musl on ARM64
-              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl'}}
-              run: |
-                  git config --global --add safe.directory $GITHUB_WORKSPACE
-                  git clean -xdf
-                  git reset --hard
-                  git submodule sync
-                  git submodule update --init --recursive
-            
-            - name: Set up access for musl on ARM
-              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl' }}
-              run: |
-                chown -R $(whoami):$(whoami) $GITHUB_WORKSPACE
-
+                  apk update
+                  apk add git
+              
             - name: Checkout
               if: ${{ matrix.build.TARGET != 'aarch64-unknown-linux-musl' }}
               uses: actions/checkout@v4
               with:
                   submodules: "true"
+                  fetch-depth: 0
+
+            - name: Setup for musl
+              if: ${{ contains(matrix.build.TARGET, 'musl')}}
+              uses: ./.github/workflows/setup-musl-on-linux
+              with:
+                  workspace: $GITHUB_WORKSPACE
+                  npm-scope: ${{ vars.NPM_SCOPE }}
+                  npm-auth-token: ${{ secrets.NPM_AUTH_TOKEN }}
+                  arch: ${{ matrix.build.ARCH }}       
 
             - name: Set the release version
               shell: bash
@@ -140,14 +137,6 @@ jobs:
                   scope: "${{ vars.NPM_SCOPE }}"
                   always-auth: true
                   token: ${{ secrets.NPM_AUTH_TOKEN }}
-            
-            - name: Setup node
-              if: ${{ matrix.build.TARGET == 'aarch64-unknown-linux-musl' }}
-              working-directory: ./node
-              run: |
-                npm config set registry https://registry.npmjs.org/
-                npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_AUTH_TOKEN }}
-                npm config set scope ${{ vars.NPM_SCOPE }}
             
             - name: Update package version in config.toml
               uses: ./.github/workflows/update-glide-version

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -58,7 +58,6 @@ jobs:
                           RUNNER: [self-hosted, Linux, ARM64],
                           ARCH: arm64,
                           TARGET: aarch64-unknown-linux-gnu,
-                          CONTAINER: "2_28",
                       }
                     - {
                           OS: macos,
@@ -81,7 +80,7 @@ jobs:
                           TARGET: aarch64-unknown-linux-musl,
                           RUNNER: [self-hosted, Linux, ARM64],
                           IMAGE: 'node:alpine',
-                          CONTAINER_OPTIONS: '--user root --privileged',
+                          CONTAINER_OPTIONS: '--user root --privileged --rm',
                       }
                     - {
                           OS: ubuntu,

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,6 @@ jobs:
                   os: "ubuntu"
                   target: "x86_64-unknown-linux-gnu"
 
-            - uses: dtolnay/rust-toolchain@stable
             - uses: Swatinem/rust-cache@v2
 
             - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,7 @@ jobs:
             - uses: ./.github/workflows/lint-rust
               with:
                   cargo-toml-folder: ./glide-core
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
               name: lint glide-core
 
             - uses: ./.github/workflows/lint-rust

--- a/.github/workflows/setup-musl-on-linux/action.yml
+++ b/.github/workflows/setup-musl-on-linux/action.yml
@@ -1,0 +1,61 @@
+name: Setup musl on Linux
+
+inputs:
+    workspace:
+        description: "github workspace"
+        required: true
+        type: string
+    npm-scope:
+        description: "npm scope"
+        required: true
+        type: string
+    npm-auth-token:
+        description: "npm auth token"
+        required: true
+        type: string
+    arch:
+        description: "architecture"
+        required: false
+        type: string
+        options:
+            - "arm64"
+            - "x64"
+        default: "arm64"
+
+runs:
+    using: "composite"
+    steps:
+        - name: Install dependencies
+          shell: sh
+          run: |
+              apk update
+              apk add bash git sed python3
+        
+        - name: Skip all steps if not on ARM64
+          shell: bash
+          if: ${{ inputs.arch != 'arm64' }}
+          run: exit 0
+
+        # Currently "Checkout" action is not supported for musl on ARM64, so the checkout is happening on the runner and 
+        # here we just making sure we getting the clean repo
+        - name: Clean repository for musl on ARM64
+          shell: bash
+          run: |
+            git config --global --add safe.directory "${{ inputs.workspace }}"
+            git clean -xdf
+            git reset --hard
+            git submodule sync
+            git submodule update --init --recursive
+            
+        - name: Set up access for musl on ARM
+          shell: bash
+          run: |
+              chown -R $(whoami):$(whoami) $GITHUB_WORKSPACE
+                
+        - name: Setup node
+          shell: bash
+          working-directory: ./node
+          run: |
+              npm config set registry https://registry.npmjs.org/
+              npm config set '//registry.npmjs.org/:_authToken' ${{ inputs.npm-auth-token }}
+              npm config set scope ${{ inputs.npm-scope }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 ### Breaking Changes
 * Node: Changed `smembers` and `spopCount` functions to return Set instead of string[] ([#1299](https://github.com/aws/glide-for-redis/pull/1299))
 
+#### Features
+* Node: Added support for alpine based platform (Or any x64-musl or arm64-musl based platforms) ([#1379](https://github.com/aws/glide-for-redis/pull/1379))
+
 ## 0.3.3 (2024-03-28)
 
 #### Fixes

--- a/node/npm/glide/index.ts
+++ b/node/npm/glide/index.ts
@@ -4,6 +4,7 @@
  * Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
  */
 
+import { GLIBC, MUSL, familySync } from "detect-libc";
 import { arch, platform } from "process";
 
 let globalObject = global as unknown;
@@ -14,10 +15,30 @@ function loadNativeBinding() {
         case "linux":
             switch (arch) {
                 case "x64":
-                    nativeBinding = require("@scope/glide-for-redis-linux-x64");
+                    switch (familySync()) {
+                        case GLIBC:
+                            nativeBinding = require("@scope/glide-for-redis-linux-x64");
+                            break;
+                        case MUSL:
+                            nativeBinding = require("@scope/glide-for-redis-linux-musl-x64");
+                            break;
+                        default:
+                            nativeBinding = require("@scope/glide-for-redis-linux-x64");
+                            break;
+                    }
                     break;
                 case "arm64":
-                    nativeBinding = require("@scope/glide-for-redis-linux-arm64");
+                    switch (familySync()) {
+                        case GLIBC:
+                            nativeBinding = require("@scope/glide-for-redis-linux-arm64");
+                            break;
+                        case MUSL:
+                            nativeBinding = require("@scope/glide-for-redis-linux-musl-arm64");
+                            break;
+                        default:
+                            nativeBinding = require("@scope/glide-for-redis-linux-arm64");
+                            break;
+                    }
                     break;
                 default:
                     throw new Error(
@@ -85,6 +106,13 @@ function initialize() {
         ConnectionError,
         ClusterTransaction,
         Transaction,
+        createLeakedArray,
+        createLeakedAttribute,
+        createLeakedBigint,
+        createLeakedDouble,
+        createLeakedMap,
+        createLeakedString,
+        parseInfoResponse,
     } = nativeBinding;
 
     module.exports = {
@@ -120,6 +148,13 @@ function initialize() {
         ConnectionError,
         ClusterTransaction,
         Transaction,
+        createLeakedArray,
+        createLeakedAttribute,
+        createLeakedBigint,
+        createLeakedDouble,
+        createLeakedMap,
+        createLeakedString,
+        parseInfoResponse,
     };
 
     globalObject = Object.assign(global, nativeBinding);

--- a/node/npm/glide/package.json
+++ b/node/npm/glide/package.json
@@ -43,7 +43,9 @@
         "${scope}glide-for-redis-darwin-arm64": "${package_version}",
         "${scope}glide-for-redis-darwin-x64": "${package_version}",
         "${scope}glide-for-redis-linux-arm64": "${package_version}",
-        "${scope}glide-for-redis-linux-x64": "${package_version}"
+        "${scope}glide-for-redis-linux-x64": "${package_version}",
+        "${scope}glide-for-redis-linux-musl-arm64": "${package_version}",
+        "${scope}glide-for-redis-linux-musl-x64": "${package_version}"
     },
     "eslintConfig": {
         "extends": [
@@ -58,5 +60,8 @@
             "build-ts/*"
         ],
         "root": true
+    },
+    "dependencies": {
+        "detect-libc": "^2.0.3"
     }
 }


### PR DESCRIPTION
Issues - #1205 #1226 

Adding support for node on alpine (or any MUSL C library)  for arm64 and x64.
Build and tests on arm alpine added to node CI.
Missing exports added since CI fails on them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
