### PR TITLE
Added check if tag include rc init, if so release as @next

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -272,18 +272,18 @@ jobs:
                     fi
                   done
 
-            - name: Check if RC and set tag for the package
+            - name: Check if RC and set a distribution tag for the package
               shell: bash
               run: |
                   if [[ "${GITHUB_REF:11}" == *"rc"* ]]
                   then
                     echo "This is a release candidate"
-                    export tag="next"
+                    export npm_tag="next"
                   else
                     echo "This is a stable release"
-                    export tag="latest"
+                    export npm_tag="latest"
                   fi
-                  echo "TAG=${tag}" >> $GITHUB_ENV
+                  echo "NPM_TAG=${npm_tag}" >> $GITHUB_ENV
                   
             - name: Publish the base package
               if: github.event_name != 'pull_request'
@@ -294,6 +294,6 @@ jobs:
                   cp ../../README.md .
                   npm install
                   npm run build
-                  npm publish --access public --tag ${{ env.tag }}
+                  npm publish --access public --tag ${{ env.NPM_TAG }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -272,6 +272,19 @@ jobs:
                     fi
                   done
 
+            - name: Check if RC and set tag for the package
+              shell: bash
+              run: |
+                  if [[ "${GITHUB_REF:11}" == *"rc"* ]]
+                  then
+                    echo "This is a release candidate"
+                    export tag="next"
+                  else
+                    echo "This is a stable release"
+                    export tag="latest"
+                  fi
+                  echo "TAG=${tag}" >> $GITHUB_ENV
+                  
             - name: Publish the base package
               if: github.event_name != 'pull_request'
               shell: bash
@@ -281,6 +294,6 @@ jobs:
                   cp ../../README.md .
                   npm install
                   npm run build
-                  npm publish --access public
+                  npm publish --access public --tag ${{ env.tag }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Added option of release candidate to the CI.
If a tag including 'rc' in it it will set the publish tag to next, so it won't be install without specific direction.

To my understanding from https://pythonpackaging.info/07-Package-Release.html pypi automatically set version with -rc in their version as prerelease version.
@barshaul @shohamazon please check if i got it right.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
