### PR TITLE
Reduce GLIDE core binary size

### DIFF
--- a/csharp/lib/Cargo.toml
+++ b/csharp/lib/Cargo.toml
@@ -18,5 +18,6 @@ tokio = { version = "^1", features = ["rt", "macros", "rt-multi-thread", "time"]
 logger_core = {path = "../../logger_core"}
 
 [profile.release]
-lto = true
-debug = true
+lto = "fat"
+debug = false
+strip = true

--- a/go/Cargo.toml
+++ b/go/Cargo.toml
@@ -15,5 +15,6 @@ tokio = { version = "^1", features = ["rt", "macros", "rt-multi-thread", "time"]
 protobuf = { version = "3.3.0", features = [] }
 
 [profile.release]
-lto = true
-debug = true
+lto = "fat"
+debug = false
+strip = true

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -19,5 +19,6 @@ jni = "0.21.1"
 log = "0.4.20"
 
 [profile.release]
-lto = true
-debug = true
+lto = "fat"
+debug = false
+strip = true

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -90,12 +90,6 @@ tasks.register('buildRustRelease', Exec) {
     environment CARGO_TERM_COLOR: 'always'
 }
 
-tasks.register('buildRustReleaseStrip', Exec) {
-    commandLine 'cargo', 'build', '--release', '--strip'
-    workingDir project.rootDir
-    environment CARGO_TERM_COLOR: 'always'
-}
-
 tasks.register('buildRust', Exec) {
     commandLine 'cargo', 'build'
     workingDir project.rootDir

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -27,8 +27,9 @@ tikv-jemallocator = {version = "0.5.4", features = ["disable_initial_exec_tls"] 
 napi-build = "2.0.1"
 
 [profile.release]
-lto = true
-debug = true
+lto = "fat"
+debug = false
+strip = true
 
 [features]
 testing_utilities = ["num-bigint"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -20,5 +20,6 @@ logger_core = {path = "../logger_core"}
 python-source = "python"
 
 [profile.release]
-lto = true
-debug = true
+lto = "fat"
+debug = false
+strip = true


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Reduce size of the native lib in release mode from 50 to 4 Mb.

Benchmarking results:
[#254.zip](https://github.com/Bit-Quill/glide-for-redis/files/15312193/254.zip)
|language|is_cluster|data_size|num_of_tasks|baseline|after|delta|
|---|---|---|---|---|---|---|
|java|TRUE|100|1|1021,842105|1017,75|0,402073718|
|java|TRUE|100|10|6275,631579|6464,5|-2,921624581|
|java|TRUE|100|100|52538,15789|52448,7|0,170562654|
|java|TRUE|100|1000|81781,57895|81618,45|0,199867735|
|java|TRUE|4000|1|1015|1014,15|0,083814031|
|java|TRUE|4000|10|7030,526316|6930,3|1,446204577|
|java|TRUE|4000|100|62546,52632|62399,55|0,235540666|
|java|TRUE|4000|1000|72709,78947|72460,3|0,344311952|

With these optimizations client became slower in less than 1%. Tested on java client in cluster mode with TLS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
