### PR TITLE
Python: fix minor error in zmpop documentation

### DIFF
--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -3159,7 +3159,7 @@ class CoreCommands(Protocol):
         Returns:
             Optional[List[Union[str, Mapping[str, float]]]]: A two-element list containing the key name of the set from
                 which elements were popped, and a member-score mapping of the popped elements. If no members could be
-                popped and the timeout expired, returns None.
+                popped, returns None.
 
         Examples:
             >>> await client.zadd("zSet1", {"one": 1.0, "two": 2.0, "three": 3.0})

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2226,7 +2226,7 @@ class BaseTransaction:
         Command response:
             Optional[List[Union[str, Mapping[str, float]]]]: A two-element list containing the key name of the set from
                 which elements were popped, and a member-score mapping of the popped elements. If no members could be
-                popped and the timeout expired, returns None.
+                popped, returns None.
 
         Since: Redis version 7.0.0.
         """


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- the zmpop docs contain a copy-pasted section from bzmpop that is not applicable to zmpop since zmpop does not have a timeout. This PR fixes the doc for zmpop by removing the mention of the timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
