### PR TITLE
Python: Adds Sort command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 #### Fixes
 * Node: Fix set command bug with expiry option ([#1508](https://github.com/aws/glide-for-redis/pull/1508))
-* Python: Added SORT command ([#1439](https://github.com/aws/glide-for-redis/pull/1439))
 
 ## 0.4.0 (2024-05-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 #### Fixes
 * Node: Fix set command bug with expiry option ([#1508](https://github.com/aws/glide-for-redis/pull/1508))
+* Python: Added SORT command ([#1439](https://github.com/aws/glide-for-redis/pull/1439))
 
 ## 0.4.0 (2024-05-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Python: Added GETDEL command ([#1514](https://github.com/aws/glide-for-redis/pull/1514))
 * Python: Added ZINTER, ZUNION commands ([#1478](https://github.com/aws/glide-for-redis/pull/1478))
 * Python: Added SINTERCARD command ([#1511](https://github.com/aws/glide-for-redis/pull/1511))
+* Python: Added SORT command ([#1439](https://github.com/aws/glide-for-redis/pull/1439))
 
 ## 0.4.1 (2024-02-06)
 

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -195,6 +195,7 @@ enum RequestType {
     PExpireTime = 157;
     BLMPop = 158;
     XLen = 159;
+    Sort = 160;
     LSet = 165;
     XDel = 166;
     XRange = 167;

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -165,6 +165,7 @@ pub enum RequestType {
     PExpireTime = 157,
     BLMPop = 158,
     XLen = 159,
+    Sort = 160,
     LSet = 165,
     XDel = 166,
     XRange = 167,
@@ -349,6 +350,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::GetDel => RequestType::GetDel,
             ProtobufRequestType::SRandMember => RequestType::SRandMember,
             ProtobufRequestType::SInterCard => RequestType::SInterCard,
+            ProtobufRequestType::Sort => RequestType::Sort,
         }
     }
 }
@@ -521,6 +523,7 @@ impl RequestType {
             RequestType::GetDel => Some(cmd("GETDEL")),
             RequestType::SRandMember => Some(cmd("SRANDMEMBER")),
             RequestType::SInterCard => Some(cmd("SINTERCARD")),
+            RequestType::Sort => Some(cmd("SORT")),
         }
     }
 }

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,5 +1,6 @@
 # Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
+from glide.async_commands.command_args import Limit, SortOrder
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -9,7 +10,6 @@ from glide.async_commands.core import (
     GeoUnit,
     InfoSection,
     InsertPosition,
-    SortOrder,
     StreamAddOptions,
     StreamTrimOptions,
     TrimByMaxLen,
@@ -21,7 +21,6 @@ from glide.async_commands.sorted_set import (
     AggregationType,
     InfBound,
     LexBoundary,
-    Limit,
     RangeByIndex,
     RangeByLex,
     RangeByScore,

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -9,12 +9,12 @@ from glide.async_commands.core import (
     GeoUnit,
     InfoSection,
     InsertPosition,
+    SortOrder,
     StreamAddOptions,
     StreamTrimOptions,
     TrimByMaxLen,
     TrimByMinId,
     UpdateOptions,
-    SortOrder,
 )
 from glide.async_commands.redis_modules import json
 from glide.async_commands.sorted_set import (
@@ -103,12 +103,12 @@ __all__ = [
     "RangeByLex",
     "RangeByScore",
     "ScoreFilter",
+    "SortOrder",
     "StreamAddOptions",
     "StreamTrimOptions",
     "TrimByMaxLen",
     "TrimByMinId",
     "UpdateOptions",
-    "SortOrder",
     # Logger
     "Logger",
     "LogLevel",

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,6 +1,6 @@
 # Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -102,7 +102,7 @@ __all__ = [
     "RangeByLex",
     "RangeByScore",
     "ScoreFilter",
-    "SortOrder",
+    "OrderBy",
     "StreamAddOptions",
     "StreamTrimOptions",
     "TrimByMaxLen",

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -14,6 +14,7 @@ from glide.async_commands.core import (
     TrimByMaxLen,
     TrimByMinId,
     UpdateOptions,
+    SortOrder,
 )
 from glide.async_commands.redis_modules import json
 from glide.async_commands.sorted_set import (
@@ -107,6 +108,7 @@ __all__ = [
     "TrimByMaxLen",
     "TrimByMinId",
     "UpdateOptions",
+    "SortOrder",
     # Logger
     "Logger",
     "LogLevel",

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -386,10 +386,7 @@ class ClusterCommands(CoreCommands):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            limit (Optional[Limit]): The limit argument for a range query. Defaults to None. See `Limit` class for more information.
-            A tuple specifying the offset and count for limiting the number of results returned.
-                The `limit` parameter takes a tuple `(offset, count)` where `offset` specifies the starting position and `count` specifies the maximum number of elements to return.
-                If `offset` exceeds the length of the returned result, an empty list is returned.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements.
                 Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
@@ -422,7 +419,7 @@ class ClusterCommands(CoreCommands):
         self,
         key: str,
         store: str,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> int:
@@ -436,7 +433,7 @@ class ClusterCommands(CoreCommands):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -384,7 +384,7 @@ class ClusterCommands(CoreCommands):
         Sorts the elements in the list, set, or sorted set at `key` and returns the result.
         To store the result into a new key, see `sort_store`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -422,7 +422,7 @@ class ClusterCommands(CoreCommands):
         When in cluster mode, `key` and `store` must map to the same hash slot.
         To get the sort result, see `sort`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Tuple, cast
+from typing import Dict, List, Mapping, Optional, cast
 
 from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import CoreCommands, InfoSection, _build_sort_args

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -413,7 +413,7 @@ class ClusterCommands(CoreCommands):
         """
         args = _build_sort_args(key, None, limit, None, order, alpha)
         result = await self._execute_command(RequestType.Sort, args)
-        return cast(List[Optional[str]], result)
+        return cast(List[str], result)
 
     async def sort_store(
         self,

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -426,7 +426,7 @@ class ClusterCommands(CoreCommands):
         """
         Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
         When in cluster mode, `key` and `store` must map to the same hash slot.
-        To get the sort result, see `sort`.
+        To get the sort result without storing it into a key, see `sort`.
 
         See https://valkey.io/commands/sort for more details.
 

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -418,7 +418,7 @@ class ClusterCommands(CoreCommands):
     async def sort_store(
         self,
         key: str,
-        store: str,
+        destination: str,
         limit: Optional[Limit] = None,
         order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
@@ -432,7 +432,7 @@ class ClusterCommands(CoreCommands):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            store (str): The key where the sorted result will be stored.
+            destination (str): The key where the sorted result will be stored.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements.
                 Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
@@ -449,6 +449,6 @@ class ClusterCommands(CoreCommands):
             >>> await client.lrange("sorted_list", 0, -1)
             ['1', '2', '3']
         """
-        args = _build_sort_args(key, None, limit, None, order, alpha, store=store)
+        args = _build_sort_args(key, None, limit, None, order, alpha, store=destination)
         result = await self._execute_command(RequestType.Sort, args)
         return cast(int, result)

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Mapping, Optional, Tuple, cast
 
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import CoreCommands, InfoSection, _build_sort_args
 from glide.async_commands.transaction import BaseTransaction, ClusterTransaction
 from glide.constants import TOK, TClusterResponse, TResult, TSingleNodeRoute
@@ -373,7 +373,7 @@ class ClusterCommands(CoreCommands):
         self,
         key: str,
         limit: Optional[Limit] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> List[str]:
         """
@@ -390,8 +390,8 @@ class ClusterCommands(CoreCommands):
             A tuple specifying the offset and count for limiting the number of results returned.
                 The `limit` parameter takes a tuple `(offset, count)` where `offset` specifies the starting position and `count` specifies the maximum number of elements to return.
                 If `offset` exceeds the length of the returned result, an empty list is returned.
-            order (Optional[SortOrder]): Specifies the order to sort the elements.
-                Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
                 Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
@@ -403,15 +403,15 @@ class ClusterCommands(CoreCommands):
             >>> await client.sort("mylist")
             ['1', '2', '3']
 
-            >>> await client.sort("mylist", order=SortOrder.DESC)
+            >>> await client.sort("mylist", order=OrderBy.DESC)
             ['3', '2', '1']
 
             >>> await client.lpush("mylist", '2', '1', '2', '3', '3', '1')
-            >>> await client.sort("mylist", limit=(2, 3))
+            >>> await client.sort("mylist", limit=Limit(2, 3))
             ['2', '2', '3']
 
             >>> await client.lpush("mylist", "a", "b", "c", "d")
-            >>> await client.sort("mylist", limit=(3, 2), order=SortOrder.DESC, alpha=True)
+            >>> await client.sort("mylist", limit=Limit(3, 2), order=OrderBy.DESC, alpha=True)
             ['b', 'a']
         """
         args = _build_sort_args(key, None, limit, None, order, alpha)
@@ -423,7 +423,7 @@ class ClusterCommands(CoreCommands):
         key: str,
         store: str,
         limit: Optional[Tuple[int, int]] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> int:
         """
@@ -437,7 +437,7 @@ class ClusterCommands(CoreCommands):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Returns:

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -382,7 +382,7 @@ class ClusterCommands(CoreCommands):
 
         By default, sorting is numeric, and elements are compared by their value interpreted as double precision floating point numbers.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -431,7 +431,7 @@ class ClusterCommands(CoreCommands):
         When in cluster mode, `key` and `store` must map to the same hash slot.
         To get the sort result, see `sort`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, cast, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple, cast
 
 from glide.async_commands.core import (
     CoreCommands,

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -434,8 +434,10 @@ class ClusterCommands(CoreCommands):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Returns:
             int: The number of elements in the sorted key stored at `store`.

--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -405,10 +405,10 @@ class ClusterCommands(CoreCommands):
 
             >>> await client.lpush("mylist", '2', '1', '2', '3', '3', '1')
             >>> await client.sort("mylist", limit=Limit(2, 3))
-            ['2', '2', '3']
+            ['1', '2', '2']
 
             >>> await client.lpush("mylist", "a", "b", "c", "d")
-            >>> await client.sort("mylist", limit=Limit(3, 2), order=OrderBy.DESC, alpha=True)
+            >>> await client.sort("mylist", limit=Limit(2, 2), order=OrderBy.DESC, alpha=True)
             ['b', 'a']
         """
         args = _build_sort_args(key, None, limit, None, order, alpha)

--- a/python/python/glide/async_commands/command_args.py
+++ b/python/python/glide/async_commands/command_args.py
@@ -28,8 +28,6 @@ class Limit:
         self.offset = offset
         self.count = count
 
-        self.count = count
-
 
 class OrderBy(Enum):
     """

--- a/python/python/glide/async_commands/command_args.py
+++ b/python/python/glide/async_commands/command_args.py
@@ -31,7 +31,7 @@ class Limit:
         self.count = count
 
 
-class SortOrder(Enum):
+class OrderBy(Enum):
     """
     SORT order options: options for sorting elements.
     """

--- a/python/python/glide/async_commands/command_args.py
+++ b/python/python/glide/async_commands/command_args.py
@@ -1,7 +1,7 @@
 # Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
 from enum import Enum
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Union
 
 
 class Limit:

--- a/python/python/glide/async_commands/command_args.py
+++ b/python/python/glide/async_commands/command_args.py
@@ -1,0 +1,47 @@
+# Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
+
+from enum import Enum
+from typing import List, Optional, Tuple, Union
+
+
+class Limit:
+    """
+    Represents a limit argument for range queries in various Redis commands.
+
+    The `LIMIT` argument is commonly used to specify a subset of results from the matching elements,
+    similar to the `LIMIT` clause in SQL (e.g., `SELECT LIMIT offset, count`).
+
+    This class can be utilized in multiple Redis commands that support limit options,
+    such as [ZRANGE](https://valkey.io/commands/zrange), [SORT](https://valkey.io/commands/sort/), and others.
+
+    Args:
+        offset (int): The starting position of the range.
+        count (int): The maximum number of elements to include in the range.
+            A negative count returns all elements from the offset.
+
+    Examples:
+        >>> limit = Limit(0, 10)  # Fetch the first 10 elements
+        >>> limit = Limit(5, -1)  # Fetch all elements starting from the 5th element
+    """
+
+    def __init__(self, offset: int, count: int):
+        self.offset = offset
+        self.count = count
+
+        self.count = count
+
+
+class SortOrder(Enum):
+    """
+    SORT order options: options for sorting elements.
+    """
+
+    ASC = "ASC"
+    """
+    ASC: Sort in ascending order.
+    """
+
+    DESC = "DESC"
+    """
+    DESC: Sort in descending order.
+    """

--- a/python/python/glide/async_commands/command_args.py
+++ b/python/python/glide/async_commands/command_args.py
@@ -15,7 +15,7 @@ class Limit:
     such as [ZRANGE](https://valkey.io/commands/zrange), [SORT](https://valkey.io/commands/sort/), and others.
 
     Args:
-        offset (int): The starting position of the range.
+        offset (int): The starting position of the range, zero based.
         count (int): The maximum number of elements to include in the range.
             A negative count returns all elements from the offset.
 

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -138,13 +138,17 @@ class UpdateOptions(Enum):
 class SortOrder(Enum):
     """
     SORT order options: options for sorting elements.
-
-    - ASC: Sort in ascending order.
-    - DESC: Sort in descending order.
     """
 
     ASC = "ASC"
+    """
+    ASC: Sort in ascending order.
+    """
+
     DESC = "DESC"
+    """
+    DESC: Sort in descending order.
+    """
 
 
 class GeospatialData:

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -16,6 +16,7 @@ from typing import (
     get_args,
 )
 
+from glide.async_commands.command_args import Limit, SortOrder
 from glide.async_commands.sorted_set import (
     AggregationType,
     InfBound,
@@ -133,22 +134,6 @@ class UpdateOptions(Enum):
 
     LESS_THAN = "LT"
     GREATER_THAN = "GT"
-
-
-class SortOrder(Enum):
-    """
-    SORT order options: options for sorting elements.
-    """
-
-    ASC = "ASC"
-    """
-    ASC: Sort in ascending order.
-    """
-
-    DESC = "DESC"
-    """
-    DESC: Sort in descending order.
-    """
 
 
 class GeospatialData:
@@ -380,7 +365,7 @@ class InsertPosition(Enum):
 def _build_sort_args(
     key: str,
     by_pattern: Optional[str] = None,
-    limit: Optional[Tuple[int, int]] = None,
+    limit: Optional[Limit] = None,
     get_patterns: Optional[List[str]] = None,
     order: Optional[SortOrder] = None,
     alpha: Optional[bool] = None,
@@ -392,7 +377,7 @@ def _build_sort_args(
         args.extend(["BY", by_pattern])
 
     if limit:
-        args.extend(["LIMIT", str(limit[0]), str(limit[1])])
+        args.extend(["LIMIT", str(limit.offset), str(limit.count)])
 
     if get_patterns:
         for pattern in get_patterns:

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -135,6 +135,18 @@ class UpdateOptions(Enum):
     GREATER_THAN = "GT"
 
 
+class SortOrder(Enum):
+    """
+    SORT order options: options for sorting elements.
+
+    - ASC: Sort in ascending order.
+    - DESC: Sort in descending order.
+    """
+
+    ASC = "ASC"
+    DESC = "DESC"
+
+
 class GeospatialData:
     def __init__(self, longitude: float, latitude: float):
         """
@@ -359,6 +371,39 @@ class ExpirySet:
 class InsertPosition(Enum):
     BEFORE = "BEFORE"
     AFTER = "AFTER"
+
+
+def _build_sort_args(
+    key: str,
+    by_pattern: Optional[str] = None,
+    limit: Optional[Tuple[int, int]] = None,
+    get_patterns: Optional[List[str]] = None,
+    order: Optional[SortOrder] = None,
+    alpha: Optional[bool] = None,
+    store: Optional[str] = None,
+) -> List[str]:
+    args = [key]
+
+    if by_pattern:
+        args.extend(["BY", by_pattern])
+
+    if limit:
+        args.extend(["LIMIT", str(limit[0]), str(limit[1])])
+
+    if get_patterns:
+        for pattern in get_patterns:
+            args.extend(["GET", pattern])
+
+    if order:
+        args.append(order.value)
+
+    if alpha:
+        args.append("ALPHA")
+
+    if store:
+        args.extend(["STORE", store])
+
+    return args
 
 
 class CoreCommands(Protocol):

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -16,7 +16,7 @@ from typing import (
     get_args,
 )
 
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.sorted_set import (
     AggregationType,
     InfBound,
@@ -367,7 +367,7 @@ def _build_sort_args(
     by_pattern: Optional[str] = None,
     limit: Optional[Limit] = None,
     get_patterns: Optional[List[str]] = None,
-    order: Optional[SortOrder] = None,
+    order: Optional[OrderBy] = None,
     alpha: Optional[bool] = None,
     store: Optional[str] = None,
 ) -> List[str]:

--- a/python/python/glide/async_commands/sorted_set.py
+++ b/python/python/glide/async_commands/sorted_set.py
@@ -3,6 +3,8 @@
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
+from glide.async_commands.command_args import Limit
+
 
 class InfBound(Enum):
     """
@@ -86,23 +88,6 @@ class LexBoundary:
     def __init__(self, value: str, is_inclusive: bool = True):
         # Convert the lexicographic boundary to the Redis protocol format
         self.value = f"[{value}" if is_inclusive else f"({value}"
-
-
-class Limit:
-    """
-    Represents a limit argument for a range query in a sorted set to be used in [ZRANGE](https://redis.io/commands/zrange) command.
-
-    The optional LIMIT argument can be used to obtain a sub-range from the matching elements
-        (similar to SELECT LIMIT offset, count in SQL).
-    Args:
-        offset (int): The offset from the start of the range.
-        count (int): The number of elements to include in the range.
-            A negative count returns all elements from the offset.
-    """
-
-    def __init__(self, offset: int, count: int):
-        self.offset = offset
-        self.count = count
 
 
 class RangeByIndex:

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -284,9 +284,24 @@ class StandaloneCommands(CoreCommands):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
+                `by_pattern` can be used to sort these IDs based on an attribute of the objects, like their weights or
+                timestamps.
+                E.g., if `by_pattern` is `weight_*`, the command will sort the elements by the values of the
+                keys `weight_<element>`.
+                If not provided, elements are sorted by their value.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
+            get_pattern (Optional[str]): A pattern used to retrieve external keys' values, instead of the elements at `key`.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from `key` replaces the asterisk to create the key name. This allows the sorted elements to be
+                transformed based on the related keys values. For example, if `key` contains IDs of users, `get_pattern`
+                can be used to retrieve specific attributes of these users, such as their names or email addresses.
+                E.g., if `get_pattern` is `name_*`, the command will return the values of the keys `name_<element>`
+                for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
+                The special value `#` can be used to include the actual element from `key` being sorted.
+                If not provided, only the sorted elements themselves are returned.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
@@ -332,9 +347,24 @@ class StandaloneCommands(CoreCommands):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
-            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
+                `by_pattern` can be used to sort these IDs based on an attribute of the objects, like their weights or
+                timestamps.
+                E.g., if `by_pattern` is `weight_*`, the command will sort the elements by the values of the
+                keys `weight_<element>`.
+                If not provided, elements are sorted by their value.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
+            get_pattern (Optional[str]): A pattern used to retrieve external keys' values, instead of the elements at `key`.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from `key` replaces the asterisk to create the key name. This allows the sorted elements to be
+                transformed based on the related keys values. For example, if `key` contains IDs of users, `get_pattern`
+                can be used to retrieve specific attributes of these users, such as their names or email addresses.
+                E.g., if `get_pattern` is `name_*`, the command will return the values of the keys `name_<element>`
+                for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
+                The special value `#` can be used to include the actual element from `key` being sorted.
+                If not provided, only the sorted elements themselves are returned.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, cast
+from typing import Dict, List, Mapping, Optional, cast, Tuple
 
-from glide.async_commands.core import CoreCommands, InfoSection
+from glide.async_commands.core import (
+    CoreCommands,
+    InfoSection,
+    SortOrder,
+    _build_sort_args,
+)
 from glide.async_commands.transaction import BaseTransaction, Transaction
 from glide.constants import TOK, TResult
 from glide.protobuf.redis_request_pb2 import RequestType
@@ -264,3 +269,91 @@ class StandaloneCommands(CoreCommands):
             int,
             await self._execute_command(RequestType.LastSave, []),
         )
+
+    async def sort(
+        self,
+        key: str,
+        by_pattern: Optional[str] = None,
+        limit: Optional[Tuple[int, int]] = None,
+        get_patterns: Optional[List[str]] = None,
+        order: Optional[SortOrder] = None,
+        alpha: Optional[bool] = None,
+    ) -> List[Optional[str]]:
+        """
+        Sorts the elements in the list, set, or sorted set at `key` and returns the result.
+        The `sort` command can be used to sort elements based on different criteria and apply transformations on sorted elements.
+        To store the result into a new key, see `sort_store`.
+
+        see https://valkey-io.github.io/commands/sort/ for more details.
+
+        Args:
+            key (str): The key of the list, set, or sorted set to be sorted.
+            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
+            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+
+        Returns:
+            List[Optional[str]]: Returns a list of sorted elements.
+
+        Examples:
+            >>> await client.lpush("mylist", 3, 1, 2)
+            >>> await client.sort("mylist")
+            ['1', '2', '3']
+            >>> await client.sort("mylist", order=SortOrder.DESC)
+            ['3', '2', '1']
+            >>> await client.lpush("mylist", 2, 1, 2, 3, 3, 1)
+            >>> await client.sort("mylist", limit=(2, 3))
+            ['2', '2', '3']
+            >>> await client.hset("user:1", "name", "Alice", "age", 30)
+            >>> await client.hset("user:2", "name", "Bob", "age", 25)
+            >>> await client.lpush("user_ids", 2, 1)
+            >>> await client.sort("user_ids", by_pattern="user:*->age", get_patterns=["user:*->name"])
+            ['Bob', 'Alice']
+        """
+        args = _build_sort_args(key, by_pattern, limit, get_patterns, order, alpha)
+        result = await self._execute_command(RequestType.Sort, args)
+        return cast(List[Optional[str]], result)
+
+    async def sort_store(
+        self,
+        key: str,
+        store: str,
+        by_pattern: Optional[str] = None,
+        limit: Optional[Tuple[int, int]] = None,
+        get_patterns: Optional[List[str]] = None,
+        order: Optional[SortOrder] = None,
+        alpha: Optional[bool] = None,
+    ) -> int:
+        """
+        Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
+        The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
+        To get the sort result, see `sort`.
+
+        see https://valkey-io.github.io/commands/sort/ for more details.
+
+        Args:
+            key (str): The key of the list, set, or sorted set to be sorted.
+            store (str): The key where the sorted result will be stored.
+            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
+            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+
+        Returns:
+            int: The number of elements in the sorted key stored at `store`.
+
+        Examples:
+            >>> await client.lpush("mylist", 3, 1, 2)
+            >>> await client.sort_store("mylist", "sorted_list")
+            3  # Indicates that the sorted list "sorted_list" contains three elements.
+            >>> await client.lrange("sorted_list", 0, -1)
+            ['1', '2', '3']
+        """
+        args = _build_sort_args(
+            key, by_pattern, limit, get_patterns, order, alpha, store=store
+        )
+        result = await self._execute_command(RequestType.Sort, args)
+        return cast(int, result)

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Tuple, cast
+from typing import Dict, List, Mapping, Optional, cast
 
 from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import CoreCommands, InfoSection, _build_sort_args

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -340,7 +340,7 @@ class StandaloneCommands(CoreCommands):
         """
         Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
-        To get the sort result, see `sort`.
+        To get the sort result without storing it into a key, see `sort`.
 
         See https://valkey.io/commands/sort for more details.
 

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -314,8 +314,8 @@ class StandaloneCommands(CoreCommands):
             ['1', '2', '3']
             >>> await client.sort("mylist", order=OrderBy.DESC)
             ['3', '2', '1']
-            >>> await client.lpush("mylist", 2, 1, 2, 3, 3, 1)
-            >>> await client.sort("mylist", limit=Limit(2, 3))
+            >>> await client.lpush("mylist2", 2, 1, 2, 3, 3, 1)
+            >>> await client.sort("mylist2", limit=Limit(2, 3))
             ['2', '2', '3']
             >>> await client.hset("user:1", "name", "Alice", "age", 30)
             >>> await client.hset("user:2", "name", "Bob", "age", 25)

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -302,8 +302,10 @@ class StandaloneCommands(CoreCommands):
                 for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
                 The special value `#` can be used to include the actual element from `key` being sorted.
                 If not provided, only the sorted elements themselves are returned.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point
 
         Returns:
             List[Optional[str]]: Returns a list of sorted elements.
@@ -365,8 +367,10 @@ class StandaloneCommands(CoreCommands):
                 for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
                 The special value `#` can be used to include the actual element from `key` being sorted.
                 If not provided, only the sorted elements themselves are returned.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point
 
         Returns:
             int: The number of elements in the sorted key stored at `store`.

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -284,7 +284,7 @@ class StandaloneCommands(CoreCommands):
         The `sort` command can be used to sort elements based on different criteria and apply transformations on sorted elements.
         To store the result into a new key, see `sort_store`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -331,7 +331,7 @@ class StandaloneCommands(CoreCommands):
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
         To get the sort result, see `sort`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 from typing import Dict, List, Mapping, Optional, Tuple, cast
 
-from glide.async_commands.core import (
-    CoreCommands,
-    InfoSection,
-    SortOrder,
-    _build_sort_args,
-)
+from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.core import CoreCommands, InfoSection, _build_sort_args
 from glide.async_commands.transaction import BaseTransaction, Transaction
 from glide.constants import TOK, TResult
 from glide.protobuf.redis_request_pb2 import RequestType
@@ -274,7 +270,7 @@ class StandaloneCommands(CoreCommands):
         self,
         key: str,
         by_pattern: Optional[str] = None,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
@@ -289,7 +285,7 @@ class StandaloneCommands(CoreCommands):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -321,7 +317,7 @@ class StandaloneCommands(CoreCommands):
         key: str,
         store: str,
         by_pattern: Optional[str] = None,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
@@ -337,7 +333,7 @@ class StandaloneCommands(CoreCommands):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, cast, Tuple
+from typing import Dict, List, Mapping, Optional, Tuple, cast
 
 from glide.async_commands.core import (
     CoreCommands,

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List, Mapping, Optional, Tuple, cast
 
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import CoreCommands, InfoSection, _build_sort_args
 from glide.async_commands.transaction import BaseTransaction, Transaction
 from glide.constants import TOK, TResult
@@ -272,7 +272,7 @@ class StandaloneCommands(CoreCommands):
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> List[Optional[str]]:
         """
@@ -287,7 +287,7 @@ class StandaloneCommands(CoreCommands):
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Returns:
@@ -297,10 +297,10 @@ class StandaloneCommands(CoreCommands):
             >>> await client.lpush("mylist", 3, 1, 2)
             >>> await client.sort("mylist")
             ['1', '2', '3']
-            >>> await client.sort("mylist", order=SortOrder.DESC)
+            >>> await client.sort("mylist", order=OrderBy.DESC)
             ['3', '2', '1']
             >>> await client.lpush("mylist", 2, 1, 2, 3, 3, 1)
-            >>> await client.sort("mylist", limit=(2, 3))
+            >>> await client.sort("mylist", limit=Limit(2, 3))
             ['2', '2', '3']
             >>> await client.hset("user:1", "name", "Alice", "age", 30)
             >>> await client.hset("user:2", "name", "Bob", "age", 25)
@@ -319,7 +319,7 @@ class StandaloneCommands(CoreCommands):
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> int:
         """
@@ -335,7 +335,7 @@ class StandaloneCommands(CoreCommands):
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Returns:

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -285,7 +285,7 @@ class StandaloneCommands(CoreCommands):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -333,7 +333,7 @@ class StandaloneCommands(CoreCommands):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -330,7 +330,7 @@ class StandaloneCommands(CoreCommands):
     async def sort_store(
         self,
         key: str,
-        store: str,
+        destination: str,
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
@@ -346,7 +346,7 @@ class StandaloneCommands(CoreCommands):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            store (str): The key where the sorted result will be stored.
+            destination (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
                 The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
                 from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
@@ -379,7 +379,7 @@ class StandaloneCommands(CoreCommands):
             ['1', '2', '3']
         """
         args = _build_sort_args(
-            key, by_pattern, limit, get_patterns, order, alpha, store=store
+            key, by_pattern, limit, get_patterns, order, alpha, store=destination
         )
         result = await self._execute_command(RequestType.Sort, args)
         return cast(int, result)

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -280,7 +280,7 @@ class StandaloneCommands(CoreCommands):
         The `sort` command can be used to sort elements based on different criteria and apply transformations on sorted elements.
         To store the result into a new key, see `sort_store`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -327,7 +327,7 @@ class StandaloneCommands(CoreCommands):
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
         To get the sort result, see `sort`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2766,7 +2766,7 @@ class Transaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -2798,7 +2798,7 @@ class Transaction(BaseTransaction):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -2836,7 +2836,7 @@ class ClusterTransaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
@@ -2864,7 +2864,7 @@ class ClusterTransaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
-            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -3,7 +3,7 @@
 import threading
 from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -2753,7 +2753,7 @@ class Transaction(BaseTransaction):
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
         """
@@ -2768,7 +2768,7 @@ class Transaction(BaseTransaction):
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Command response:
@@ -2784,7 +2784,7 @@ class Transaction(BaseTransaction):
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
         """
@@ -2800,7 +2800,7 @@ class Transaction(BaseTransaction):
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Command response:
@@ -2825,7 +2825,7 @@ class ClusterTransaction(BaseTransaction):
         self: TTransaction,
         key: str,
         limit: Optional[Limit] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
         """
@@ -2837,7 +2837,7 @@ class ClusterTransaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Command response:
@@ -2851,7 +2851,7 @@ class ClusterTransaction(BaseTransaction):
         key: str,
         store: str,
         limit: Optional[Limit] = None,
-        order: Optional[SortOrder] = None,
+        order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
         """
@@ -2865,7 +2865,7 @@ class ClusterTransaction(BaseTransaction):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
-            order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
+            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
         Command response:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -11,10 +11,10 @@ from glide.async_commands.core import (
     GeoUnit,
     InfoSection,
     InsertPosition,
+    SortOrder,
     StreamAddOptions,
     StreamTrimOptions,
     UpdateOptions,
-    SortOrder,
     _build_sort_args,
 )
 from glide.async_commands.sorted_set import (
@@ -2822,12 +2822,12 @@ class ClusterTransaction(BaseTransaction):
     """
 
     def sort(
-        self,
+        self: TTransaction,
         key: str,
         limit: Optional[Tuple[int, int]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
-    ) -> List[Optional[str]]:
+    ) -> TTransaction:
         """
         Sorts the elements in the list, set, or sorted set at `key` and returns the result.
         To store the result into a new key, see `sort_store`.
@@ -2847,13 +2847,13 @@ class ClusterTransaction(BaseTransaction):
         return self.append_command(RequestType.Sort, args)
 
     def sort_store(
-        self,
+        self: TTransaction,
         key: str,
         store: str,
         limit: Optional[Tuple[int, int]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
-    ) -> int:
+    ) -> TTransaction:
         """
         Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
         When in cluster mode, `key` and `store` must map to the same hash slot.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2807,7 +2807,7 @@ class Transaction(BaseTransaction):
         """
         Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
-        To get the sort result, see `sort`.
+        To get the sort result without storing it into a key, see `sort`.
 
         See https://valkey.io/commands/sort for more details.
 
@@ -2893,7 +2893,7 @@ class ClusterTransaction(BaseTransaction):
         """
         Sorts the elements in the list, set, or sorted set at `key` and stores the result in `store`.
         When in cluster mode, `key` and `store` must map to the same hash slot.
-        To get the sort result, see `sort`.
+        To get the sort result without storing it into a key, see `sort`.
 
         See https://valkey.io/commands/sort for more details.
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2765,11 +2765,28 @@ class Transaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
+                `by_pattern` can be used to sort these IDs based on an attribute of the objects, like their weights or
+                timestamps.
+                E.g., if `by_pattern` is `weight_*`, the command will sort the elements by the values of the
+                keys `weight_<element>`.
+                If not provided, elements are sorted by their value.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            get_pattern (Optional[str]): A pattern used to retrieve external keys' values, instead of the elements at `key`.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from `key` replaces the asterisk to create the key name. This allows the sorted elements to be
+                transformed based on the related keys values. For example, if `key` contains IDs of users, `get_pattern`
+                can be used to retrieve specific attributes of these users, such as their names or email addresses.
+                E.g., if `get_pattern` is `name_*`, the command will return the values of the keys `name_<element>`
+                for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
+                The special value `#` can be used to include the actual element from `key` being sorted.
+                If not provided, only the sorted elements themselves are returned.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Command response:
             List[Optional[str]]: Returns a list of sorted elements.
@@ -2796,12 +2813,28 @@ class Transaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            store (str): The key where the sorted result will be stored.
-            by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
+            by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
+                `by_pattern` can be used to sort these IDs based on an attribute of the objects, like their weights or
+                timestamps.
+                E.g., if `by_pattern` is `weight_*`, the command will sort the elements by the values of the
+                keys `weight_<element>`.
+                If not provided, elements are sorted by their value.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            get_pattern (Optional[str]): A pattern used to retrieve external keys' values, instead of the elements at `key`.
+                The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
+                from `key` replaces the asterisk to create the key name. This allows the sorted elements to be
+                transformed based on the related keys values. For example, if `key` contains IDs of users, `get_pattern`
+                can be used to retrieve specific attributes of these users, such as their names or email addresses.
+                E.g., if `get_pattern` is `name_*`, the command will return the values of the keys `name_<element>`
+                for each sorted element. Multiple `get_pattern` arguments can be provided to retrieve multiple attributes.
+                The special value `#` can be used to include the actual element from `key` being sorted.
+                If not provided, only the sorted elements themselves are returned.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Command response:
             int: The number of elements in the sorted key stored at `store`.
@@ -2837,8 +2870,10 @@ class ClusterTransaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Command response:
             List[Optional[str]]: A list of sorted elements.
@@ -2865,8 +2900,10 @@ class ClusterTransaction(BaseTransaction):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
-            order (Optional[OrderBy]): Specifies the order to sort the elements. Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
-            alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
+            order (Optional[OrderBy]): Specifies the order to sort the elements.
+                Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
+            alpha (Optional[bool]): When `True`, sorts elements lexicographically. When `False` (default), sorts elements numerically.
+                Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Command response:
             int: The number of elements in the sorted key stored at `store`.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2761,7 +2761,7 @@ class Transaction(BaseTransaction):
         The `sort` command can be used to sort elements based on different criteria and apply transformations on sorted elements.
         To store the result into a new key, see `sort_store`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2792,7 +2792,7 @@ class Transaction(BaseTransaction):
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
         To get the sort result, see `sort`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2832,7 +2832,7 @@ class ClusterTransaction(BaseTransaction):
         Sorts the elements in the list, set, or sorted set at `key` and returns the result.
         To store the result into a new key, see `sort_store`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2859,7 +2859,7 @@ class ClusterTransaction(BaseTransaction):
         When in cluster mode, `key` and `store` must map to the same hash slot.
         To get the sort result, see `sort`.
 
-        See https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey.io/commands/sort for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2877,7 +2877,7 @@ class ClusterTransaction(BaseTransaction):
                 Use this when the list, set, or sorted set contains string values that cannot be converted into double precision floating point numbers.
 
         Command response:
-            List[Optional[str]]: A list of sorted elements.
+            List[str]: A list of sorted elements.
         """
         args = _build_sort_args(key, None, limit, None, order, alpha)
         return self.append_command(RequestType.Sort, args)

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2761,7 +2761,7 @@ class Transaction(BaseTransaction):
         The `sort` command can be used to sort elements based on different criteria and apply transformations on sorted elements.
         To store the result into a new key, see `sort_store`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2792,7 +2792,7 @@ class Transaction(BaseTransaction):
         The `sort` command can be used to sort elements based on different criteria, apply transformations on sorted elements, and store the result in a new key.
         To get the sort result, see `sort`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2832,7 +2832,7 @@ class ClusterTransaction(BaseTransaction):
         Sorts the elements in the list, set, or sorted set at `key` and returns the result.
         To store the result into a new key, see `sort_store`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
@@ -2859,7 +2859,7 @@ class ClusterTransaction(BaseTransaction):
         When in cluster mode, `key` and `store` must map to the same hash slot.
         To get the sort result, see `sort`.
 
-        see https://valkey-io.github.io/commands/sort/ for more details.
+        See https://valkey-io.github.io/commands/sort/ for more details.
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -3,6 +3,7 @@
 import threading
 from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
+from glide.async_commands.command_args import Limit, SortOrder
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -11,7 +12,6 @@ from glide.async_commands.core import (
     GeoUnit,
     InfoSection,
     InsertPosition,
-    SortOrder,
     StreamAddOptions,
     StreamTrimOptions,
     UpdateOptions,
@@ -2751,7 +2751,7 @@ class Transaction(BaseTransaction):
         self: TTransaction,
         key: str,
         by_pattern: Optional[str] = None,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
@@ -2766,7 +2766,7 @@ class Transaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -2782,7 +2782,7 @@ class Transaction(BaseTransaction):
         key: str,
         store: str,
         by_pattern: Optional[str] = None,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
@@ -2798,7 +2798,7 @@ class Transaction(BaseTransaction):
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by. If not provided, elements are sorted by their value.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             get_patterns (Optional[List[str]]): One or more patterns to extract values to return.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
@@ -2824,7 +2824,7 @@ class ClusterTransaction(BaseTransaction):
     def sort(
         self: TTransaction,
         key: str,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
@@ -2836,7 +2836,7 @@ class ClusterTransaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 
@@ -2850,7 +2850,7 @@ class ClusterTransaction(BaseTransaction):
         self: TTransaction,
         key: str,
         store: str,
-        limit: Optional[Tuple[int, int]] = None,
+        limit: Optional[Limit] = None,
         order: Optional[SortOrder] = None,
         alpha: Optional[bool] = None,
     ) -> TTransaction:
@@ -2864,7 +2864,7 @@ class ClusterTransaction(BaseTransaction):
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
             store (str): The key where the sorted result will be stored.
-            limit (Optional[Tuple[int, int]]): A tuple specifying the offset and count for limiting the number of results.
+            limit (Optional[Limit]): A tuple specifying the offset and count for limiting the number of results.
             order (Optional[SortOrder]): Specifies the order to sort the elements. Can be `SortOrder.ASC` (ascending) or `SortOrder.DESC` (descending).
             alpha (Optional[bool]): Whether to sort elements lexicographically. If `False`, elements are sorted numerically.
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2875,4 +2875,3 @@ class ClusterTransaction(BaseTransaction):
         return self.append_command(RequestType.Sort, args)
 
     # TODO: add all CLUSTER commands
-    pass

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2797,7 +2797,7 @@ class Transaction(BaseTransaction):
     def sort_store(
         self: TTransaction,
         key: str,
-        store: str,
+        destination: str,
         by_pattern: Optional[str] = None,
         limit: Optional[Limit] = None,
         get_patterns: Optional[List[str]] = None,
@@ -2813,6 +2813,7 @@ class Transaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
+            destination (str): The key where the sorted result will be stored.
             by_pattern (Optional[str]): A pattern to sort by external keys instead of by the elements stored at the key themselves.
                 The pattern should contain an asterisk (*) as a placeholder for the element values, where the value
                 from the key replaces the asterisk to create the key name. For example, if `key` contains IDs of objects,
@@ -2840,7 +2841,7 @@ class Transaction(BaseTransaction):
             int: The number of elements in the sorted key stored at `store`.
         """
         args = _build_sort_args(
-            key, by_pattern, limit, get_patterns, order, alpha, store=store
+            key, by_pattern, limit, get_patterns, order, alpha, store=destination
         )
         return self.append_command(RequestType.Sort, args)
 
@@ -2884,7 +2885,7 @@ class ClusterTransaction(BaseTransaction):
     def sort_store(
         self: TTransaction,
         key: str,
-        store: str,
+        destination: str,
         limit: Optional[Limit] = None,
         order: Optional[OrderBy] = None,
         alpha: Optional[bool] = None,
@@ -2898,7 +2899,7 @@ class ClusterTransaction(BaseTransaction):
 
         Args:
             key (str): The key of the list, set, or sorted set to be sorted.
-            store (str): The key where the sorted result will be stored.
+            destination (str): The key where the sorted result will be stored.
             limit (Optional[Limit]): Limiting the range of the query by setting offset and result count. See `Limit` class for more information.
             order (Optional[OrderBy]): Specifies the order to sort the elements.
                 Can be `OrderBy.ASC` (ascending) or `OrderBy.DESC` (descending).
@@ -2908,7 +2909,7 @@ class ClusterTransaction(BaseTransaction):
         Command response:
             int: The number of elements in the sorted key stored at `store`.
         """
-        args = _build_sort_args(key, None, limit, None, order, alpha, store=store)
+        args = _build_sort_args(key, None, limit, None, order, alpha, store=destination)
         return self.append_command(RequestType.Sort, args)
 
     # TODO: add all CLUSTER commands

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -3473,6 +3473,14 @@ class TestCommands:
         )
         assert result == ["Dave", "Bob", "Alice", "Charlie", "Eve"]
 
+        # Test Limit with count 0
+        result = await redis_client.sort(
+            "user_ids",
+            limit=Limit(0, 0),
+            alpha=True,
+        )
+        assert result == []
+
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_sort_and_sort_store_without_get_or_by_args(
@@ -3494,7 +3502,7 @@ class TestCommands:
         # Test each argument separately
         assert await redis_client.lpush(key, ["5", "2", "4", "1", "3"]) == 5
 
-        # by_pattern argument
+        # Test w/o flags
         result = await redis_client.sort(key)
         assert result == ["1", "2", "3", "4", "5"]
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Union, cast
 
 import pytest
 from glide import ClosingError, RequestError, Script
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -3447,7 +3447,7 @@ class TestCommands:
                 key,
                 limit=Limit(0, 2),
                 get_patterns=["user:*->name"],
-                order=SortOrder.ASC,
+                order=OrderBy.ASC,
                 alpha=True,
             )
             assert result == ["Alice", "Bob"]
@@ -3458,7 +3458,7 @@ class TestCommands:
                 store,
                 limit=Limit(0, 2),
                 get_patterns=["user:*->name"],
-                order=SortOrder.ASC,
+                order=OrderBy.ASC,
                 alpha=True,
             )
             assert sort_store_result == 2
@@ -3504,7 +3504,7 @@ class TestCommands:
         assert result == ["2", "3", "4"]
 
         # order argument
-        result = await redis_client.sort(key, order=SortOrder.DESC)
+        result = await redis_client.sort(key, order=OrderBy.DESC)
         assert result == ["5", "4", "3", "2", "1"]
 
         assert await redis_client.lpush(key, ["a"]) == 6
@@ -3519,13 +3519,13 @@ class TestCommands:
 
         # Combining multiple arguments
         result = await redis_client.sort(
-            key, limit=Limit(1, 3), order=SortOrder.DESC, alpha=True
+            key, limit=Limit(1, 3), order=OrderBy.DESC, alpha=True
         )
         assert result == ["5", "4", "3"]
 
         # Test sort_store with combined arguments
         sort_store_result = await redis_client.sort_store(
-            key, store, limit=Limit(1, 3), order=SortOrder.DESC, alpha=True
+            key, store, limit=Limit(1, 3), order=OrderBy.DESC, alpha=True
         )
         assert sort_store_result == 3
         sorted_list = await redis_client.lrange(store, 0, -1)

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Union, cast
 
 import pytest
 from glide import ClosingError, RequestError, Script
+from glide.async_commands.command_args import Limit, SortOrder
 from glide.async_commands.core import (
     ConditionalChange,
     ExpireOptions,
@@ -21,7 +22,6 @@ from glide.async_commands.core import (
     InfBound,
     InfoSection,
     InsertPosition,
-    SortOrder,
     StreamAddOptions,
     TrimByMaxLen,
     TrimByMinId,
@@ -3445,7 +3445,7 @@ class TestCommands:
             assert await redis_client.lpush(key, ["3", "1", "2"]) == 3
             result = await redis_client.sort(
                 key,
-                limit=(0, 2),
+                limit=Limit(0, 2),
                 get_patterns=["user:*->name"],
                 order=SortOrder.ASC,
                 alpha=True,
@@ -3456,7 +3456,7 @@ class TestCommands:
             sort_store_result = await redis_client.sort_store(
                 key,
                 store,
-                limit=(0, 2),
+                limit=Limit(0, 2),
                 get_patterns=["user:*->name"],
                 order=SortOrder.ASC,
                 alpha=True,
@@ -3500,7 +3500,7 @@ class TestCommands:
         assert result == ["1", "2", "3", "4", "5"]
 
         # limit argument
-        result = await redis_client.sort(key, limit=(1, 3))
+        result = await redis_client.sort(key, limit=Limit(1, 3))
         assert result == ["2", "3", "4"]
 
         # order argument
@@ -3519,13 +3519,13 @@ class TestCommands:
 
         # Combining multiple arguments
         result = await redis_client.sort(
-            key, limit=(1, 3), order=SortOrder.DESC, alpha=True
+            key, limit=Limit(1, 3), order=SortOrder.DESC, alpha=True
         )
         assert result == ["5", "4", "3"]
 
         # Test sort_store with combined arguments
         sort_store_result = await redis_client.sort_store(
-            key, store, limit=(1, 3), order=SortOrder.DESC, alpha=True
+            key, store, limit=Limit(1, 3), order=SortOrder.DESC, alpha=True
         )
         assert sort_store_result == 3
         sorted_list = await redis_client.lrange(store, 0, -1)

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -3473,6 +3473,25 @@ class TestCommands:
         )
         assert result == ["Dave", "Bob", "Alice", "Charlie", "Eve"]
 
+        # Test sort with `by` argument with missing keys to sort by
+        assert await redis_client.lpush("user_ids", ["a"]) == 6
+        result = await redis_client.sort(
+            "user_ids",
+            by_pattern="user:*->age",
+            get_patterns=["user:*->name"],
+            alpha=True,
+        )
+        assert result == [None, "Dave", "Bob", "Alice", "Charlie", "Eve"]
+
+        # Test sort with `by` argument with missing keys to sort by
+        result = await redis_client.sort(
+            "user_ids",
+            by_pattern="user:*->name",
+            get_patterns=["user:*->age"],
+            alpha=True,
+        )
+        assert result == [None, "30", "25", "35", "20", "40"]
+
         # Test Limit with count 0
         result = await redis_client.sort(
             "user_ids",

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -3420,7 +3420,7 @@ class TestCommands:
     @pytest.mark.parametrize("cluster_mode", [False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_sort_and_sort_store_with_get_or_by_args(
-        self, redis_client: TRedisClient
+        self, redis_client: RedisClient
     ):
         key = "{SameSlotKey}" + get_random_string(10)
         store = "{SameSlotKey}" + get_random_string(10)
@@ -3440,39 +3440,38 @@ class TestCommands:
         assert await redis_client.hset(user_key5, {"name": "Eve", "age": "40"}) == 2
         assert await redis_client.lpush("user_ids", ["5", "4", "3", "2", "1"]) == 5
 
-        if isinstance(redis_client, RedisClient):
-            # Test sort with all arguments
-            assert await redis_client.lpush(key, ["3", "1", "2"]) == 3
-            result = await redis_client.sort(
-                key,
-                limit=Limit(0, 2),
-                get_patterns=["user:*->name"],
-                order=OrderBy.ASC,
-                alpha=True,
-            )
-            assert result == ["Alice", "Bob"]
+        # Test sort with all arguments
+        assert await redis_client.lpush(key, ["3", "1", "2"]) == 3
+        result = await redis_client.sort(
+            key,
+            limit=Limit(0, 2),
+            get_patterns=["user:*->name"],
+            order=OrderBy.ASC,
+            alpha=True,
+        )
+        assert result == ["Alice", "Bob"]
 
-            # Test sort_store with all arguments
-            sort_store_result = await redis_client.sort_store(
-                key,
-                store,
-                limit=Limit(0, 2),
-                get_patterns=["user:*->name"],
-                order=OrderBy.ASC,
-                alpha=True,
-            )
-            assert sort_store_result == 2
-            sorted_list = await redis_client.lrange(store, 0, -1)
-            assert sorted_list == ["Alice", "Bob"]
+        # Test sort_store with all arguments
+        sort_store_result = await redis_client.sort_store(
+            key,
+            store,
+            limit=Limit(0, 2),
+            get_patterns=["user:*->name"],
+            order=OrderBy.ASC,
+            alpha=True,
+        )
+        assert sort_store_result == 2
+        sorted_list = await redis_client.lrange(store, 0, -1)
+        assert sorted_list == ["Alice", "Bob"]
 
-            # Test sort with `by` argument
-            result = await redis_client.sort(
-                "user_ids",
-                by_pattern="user:*->age",
-                get_patterns=["user:*->name"],
-                alpha=True,
-            )
-            assert result == ["Dave", "Bob", "Alice", "Charlie", "Eve"]
+        # Test sort with `by` argument
+        result = await redis_client.sort(
+            "user_ids",
+            by_pattern="user:*->age",
+            get_patterns=["user:*->name"],
+            alpha=True,
+        )
+        assert result == ["Dave", "Bob", "Alice", "Charlie", "Eve"]
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -6,7 +6,7 @@ from typing import List, Union, cast
 
 import pytest
 from glide import RequestError
-from glide.async_commands.command_args import Limit, SortOrder
+from glide.async_commands.command_args import Limit, OrderBy
 from glide.async_commands.core import (
     GeospatialData,
     InsertPosition,
@@ -370,7 +370,7 @@ async def transaction_test(
     transaction.sort(
         key17,
         limit=Limit(1, 4),
-        order=SortOrder.ASC,
+        order=OrderBy.ASC,
         alpha=True,
     )
     args.append(["2", "3", "4", "a"])
@@ -378,7 +378,7 @@ async def transaction_test(
         key17,
         key18,
         limit=Limit(1, 4),
-        order=SortOrder.ASC,
+        order=OrderBy.ASC,
         alpha=True,
     )
     args.append(4)
@@ -531,7 +531,7 @@ class TestTransaction:
             key1,
             by_pattern="user:*->age",
             get_patterns=["user:*->name"],
-            order=SortOrder.ASC,
+            order=OrderBy.ASC,
             alpha=True,
         )
         transaction.sort_store(
@@ -539,7 +539,7 @@ class TestTransaction:
             "newSortedKey",
             by_pattern="user:*->age",
             get_patterns=["user:*->name"],
-            order=SortOrder.ASC,
+            order=OrderBy.ASC,
             alpha=True,
         )
         transaction.select(0)

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -9,6 +9,7 @@ from glide import RequestError
 from glide.async_commands.core import (
     GeospatialData,
     InsertPosition,
+    SortOrder,
     StreamAddOptions,
     TrimByMinId,
 )
@@ -53,6 +54,8 @@ async def transaction_test(
     key14 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sorted set
     key15 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sorted set
     key16 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sorted set
+    key17 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sort
+    key18 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sort
 
     value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
@@ -362,6 +365,24 @@ async def transaction_test(
     transaction.xtrim(key11, TrimByMinId(threshold="0-2", exact=True))
     args.append(1)
 
+    transaction.lpush(key17, ["2", "1", "4", "3", "a"])
+    args.append(5)
+    transaction.sort(
+        key17,
+        limit=(1, 4),
+        order=SortOrder.ASC,
+        alpha=True,
+    )
+    args.append(["2", "3", "4", "a"])
+    transaction.sort_store(
+        key17,
+        key18,
+        limit=(1, 4),
+        order=SortOrder.ASC,
+        alpha=True,
+    )
+    args.append(4)
+
     min_version = "7.0.0"
     if not await check_if_server_version_lt(redis_client, min_version):
         transaction.zadd(key16, {"a": 1, "b": 2, "c": 3, "d": 4})
@@ -496,12 +517,31 @@ class TestTransaction:
         assert await redis_client.custom_command(["FLUSHALL"]) == OK
         keyslot = get_random_string(3)
         key = "{{{}}}:{}".format(keyslot, get_random_string(3))  # to get the same slot
+        key1 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # to get the same slot
         value = get_random_string(5)
         transaction = Transaction()
         transaction.info()
         transaction.select(1)
         transaction.set(key, value)
         transaction.get(key)
+        transaction.hset("user:1", {"name": "Alice", "age": "30"})
+        transaction.hset("user:2", {"name": "Bob", "age": "25"})
+        transaction.lpush(key1, ["2", "1"])
+        transaction.sort(
+            key1,
+            by_pattern="user:*->age",
+            get_patterns=["user:*->name"],
+            order=SortOrder.ASC,
+            alpha=True,
+        )
+        transaction.sort_store(
+            key1,
+            "newSortedKey",
+            by_pattern="user:*->age",
+            get_patterns=["user:*->name"],
+            order=SortOrder.ASC,
+            alpha=True,
+        )
         transaction.select(0)
         transaction.get(key)
         expected = await transaction_test(transaction, keyslot, redis_client)
@@ -509,8 +549,9 @@ class TestTransaction:
         assert isinstance(result, list)
         assert isinstance(result[0], str)
         assert "# Memory" in result[0]
-        assert result[1:6] == [OK, OK, value, OK, None]
-        assert result[6:] == expected
+        assert result[1:4] == [OK, OK, value]
+        assert result[4:11] == [2, 2, 2, ["Bob", "Alice"], 2, OK, None]
+        assert result[11:] == expected
 
     def test_transaction_clear(self):
         transaction = Transaction()

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -6,10 +6,10 @@ from typing import List, Union, cast
 
 import pytest
 from glide import RequestError
+from glide.async_commands.command_args import Limit, SortOrder
 from glide.async_commands.core import (
     GeospatialData,
     InsertPosition,
-    SortOrder,
     StreamAddOptions,
     TrimByMinId,
 )
@@ -369,7 +369,7 @@ async def transaction_test(
     args.append(5)
     transaction.sort(
         key17,
-        limit=(1, 4),
+        limit=Limit(1, 4),
         order=SortOrder.ASC,
         alpha=True,
     )
@@ -377,7 +377,7 @@ async def transaction_test(
     transaction.sort_store(
         key17,
         key18,
-        limit=(1, 4),
+        limit=Limit(1, 4),
         order=SortOrder.ASC,
         alpha=True,
     )


### PR DESCRIPTION
We separated it into sort and sort_store.
In CME, two arguments (BY/GET) aren't supported, so we dicided to create separate APIs for CMD and CME so in CME those 2 two won't appear as optional.
