### PR TITLE
Java: Add `BITPOS` command 

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -186,6 +186,7 @@ enum RequestType {
     ZMPop = 144;
     GetBit = 145;
     ZInter = 146;
+    BitPos = 147;
     FunctionLoad = 150;
 }
 

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -156,6 +156,7 @@ pub enum RequestType {
     ZMPop = 144,
     GetBit = 145,
     ZInter = 146,
+    BitPos = 147,
     FunctionLoad = 150,
 }
 
@@ -317,6 +318,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::GetBit => RequestType::GetBit,
             ProtobufRequestType::ZInter => RequestType::ZInter,
             ProtobufRequestType::FunctionLoad => RequestType::FunctionLoad,
+            ProtobufRequestType::BitPos => RequestType::BitPos,
         }
     }
 }
@@ -473,6 +475,7 @@ impl RequestType {
             RequestType::GetBit => Some(cmd("GETBIT")),
             RequestType::ZInter => Some(cmd("ZINTER")),
             RequestType::FunctionLoad => Some(get_two_word_command("FUNCTION", "LOAD")),
+            RequestType::BitPos => Some(cmd("BITPOS")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -14,6 +14,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.Del;
@@ -1352,5 +1353,34 @@ public abstract class BaseClient
     public CompletableFuture<Long> getbit(@NonNull String key, long offset) {
         String[] arguments = new String[] {key, Long.toString(offset)};
         return commandManager.submitNewCommand(GetBit, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> bitpos(@NonNull String key, long bit) {
+        String[] arguments = new String[] {key, Long.toString(bit)};
+        return commandManager.submitNewCommand(BitPos, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> bitpos(@NonNull String key, long bit, long start) {
+        String[] arguments = new String[] {key, Long.toString(bit), Long.toString(start)};
+        return commandManager.submitNewCommand(BitPos, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> bitpos(@NonNull String key, long bit, long start, long end) {
+        String[] arguments =
+                new String[] {key, Long.toString(bit), Long.toString(start), Long.toString(end)};
+        return commandManager.submitNewCommand(BitPos, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> bitpos(
+            @NonNull String key, long bit, long start, long end, @NonNull BitmapIndexType options) {
+        String[] arguments =
+                new String[] {
+                    key, Long.toString(bit), Long.toString(start), Long.toString(end), options.toString()
+                };
+        return commandManager.submitNewCommand(BitPos, arguments, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
@@ -119,7 +119,7 @@ public interface BitmapBaseCommands {
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @return The position of the first occurrence matching <code>bit</code> in the binary value of
      *     the string held at <code>key</code>. If <code>bit</code> is not found, a <code>-1</code> is
      *     returned.
@@ -158,7 +158,7 @@ public interface BitmapBaseCommands {
     CompletableFuture<Long> bitpos(String key, long bit, long start);
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offsets
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offsets
      * <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code> being the
      * first byte of the list, <code>1</code> being the next byte and so on. These offsets can also be
      * negative numbers indicating offsets starting at the end of the list, with <code>-1</code> being

--- a/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
@@ -113,4 +113,95 @@ public interface BitmapBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> getbit(String key, long offset);
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @return The position of the first occurrence matching <code>bit</code> in the binary value of
+     *     the string held at <code>key</code>. If <code>bit</code> is not found, a <code>-1</code> is
+     *     returned.
+     * @example
+     *     <pre>{@code
+     * Long payload = client.bitpos("myKey1", 0).get();
+     * assert payload == 3L; // Indicates that the first occurrence of a 0 bit value of the string stored at "myKey1" is at the fourth position.
+     * }</pre>
+     */
+    CompletableFuture<Long> bitpos(String key, long bit);
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * <code>start</code> is a zero-based index, with <code>0</code> being the first byte of the list,
+     * <code>1</code> being the next byte and so on. These offsets can also be negative numbers
+     * indicating offsets starting at the end of the list, with <code>-1</code> being the last byte of
+     * the list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @return The position of the first occurrence beginning at the <code>start</code> offset of the
+     *     <code>bit</code> in the binary value of the string held at <code>key</code>.
+     * @example
+     *     <pre>{@code
+     * Long payload = client.bitpos("myKey1", 1, 4).get();
+     * assert payload == 9L; // Indicates that the first occurrence of a 1 bit value starting from fifth byte of the string stored at "myKey1" is at the tenth position.
+     * }</pre>
+     */
+    CompletableFuture<Long> bitpos(String key, long bit, long start);
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offsets
+     * <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code> being the
+     * first byte of the list, <code>1</code> being the next byte and so on. These offsets can also be
+     * negative numbers indicating offsets starting at the end of the list, with <code>-1</code> being
+     * the last byte of the list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @param end The ending offset.
+     * @return The position of the first occurrence from the <code>start</code> to the <code>end
+     *     </code> offsets of the <code>bit</code> in the binary value of the string held at <code>key
+     *     </code>.
+     * @example
+     *     <pre>{@code
+     * Long payload = client.bitpos("myKey1", 1, 4, 6).get();
+     * assert payload == 7L;// Indicates that the first occurrence of a 1 bit value starting from fifth to the sixth bytes of the string stored at "myKey1" is at the 8th position.
+     * }</pre>
+     */
+    CompletableFuture<Long> bitpos(String key, long bit, long start, long end);
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * <code>offsetType</code> specifies whether the offset is a BIT or BYTE. If BIT is specified,
+     * <code>start==0</code> and <code>end==2</code> means to look at the first three bits. If BYTE is
+     * specified, <code>start==0</code> and <code>end==2</code> means to look at the first three bytes
+     * The offsets are zero-based indexes, with <code>0</code> being the first element of the list,
+     * <code>1</code> being the next, and so on. These offsets can also be negative numbers indicating
+     * offsets starting at the end of the list, with <code>-1</code> being the last element of the
+     * list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @param end The ending offset.
+     * @param offsetType The index offset type. Could be either {@link BitmapIndexType#BIT} or {@link
+     *     BitmapIndexType#BYTE}.
+     * @return The position of the first occurrence from the <code>start</code> to the <code>end
+     *     </code> offsets of the <code>bit</code> in the binary value of the string held at <code>key
+     *     </code>.
+     * @example
+     *     <pre>{@code
+     * Long payload = client.bitpos("myKey1", 1, 4, 6, BIT).get();
+     * assert payload == 7L;// Indicates that the first occurrence of a 1 bit value starting from fifth to the sixth bits of the string stored at "myKey1" is at the 8th position.
+     * }</pre>
+     */
+    CompletableFuture<Long> bitpos(
+            String key, long bit, long start, long end, BitmapIndexType offsetType);
 }

--- a/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
@@ -115,7 +115,7 @@ public interface BitmapBaseCommands {
     CompletableFuture<Long> getbit(String key, long offset);
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value.
+     * Returns the position of the first bit matching the given <code>bit</code> value.
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
@@ -126,13 +126,15 @@ public interface BitmapBaseCommands {
      * @example
      *     <pre>{@code
      * Long payload = client.bitpos("myKey1", 0).get();
-     * assert payload == 3L; // Indicates that the first occurrence of a 0 bit value of the string stored at "myKey1" is at the fourth position.
+     * // Indicates that the first occurrence of a 0 bit value is the fourth bit of the binary value
+     * // of the string stored at "myKey1".
+     * assert payload == 3L;
      * }</pre>
      */
     CompletableFuture<Long> bitpos(String key, long bit);
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offset
      * <code>start</code> is a zero-based index, with <code>0</code> being the first byte of the list,
      * <code>1</code> being the next byte and so on. These offsets can also be negative numbers
      * indicating offsets starting at the end of the list, with <code>-1</code> being the last byte of
@@ -140,14 +142,17 @@ public interface BitmapBaseCommands {
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @return The position of the first occurrence beginning at the <code>start</code> offset of the
-     *     <code>bit</code> in the binary value of the string held at <code>key</code>.
+     *     <code>bit</code> in the binary value of the string held at <code>key</code>. If <code>bit
+     *     </code> is not found, a <code>-1</code> is returned.
      * @example
      *     <pre>{@code
      * Long payload = client.bitpos("myKey1", 1, 4).get();
-     * assert payload == 9L; // Indicates that the first occurrence of a 1 bit value starting from fifth byte of the string stored at "myKey1" is at the tenth position.
+     * // Indicates that the first occurrence of a 1 bit value starting from fifth byte is the 34th
+     * // bit of the binary value of the string stored at "myKey1".
+     * assert payload == 33L;
      * }</pre>
      */
     CompletableFuture<Long> bitpos(String key, long bit, long start);
@@ -161,22 +166,24 @@ public interface BitmapBaseCommands {
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @param end The ending offset.
      * @return The position of the first occurrence from the <code>start</code> to the <code>end
      *     </code> offsets of the <code>bit</code> in the binary value of the string held at <code>key
-     *     </code>.
+     *     </code>. If <code>bit</code> is not found, a <code>-1</code> is returned.
      * @example
      *     <pre>{@code
      * Long payload = client.bitpos("myKey1", 1, 4, 6).get();
-     * assert payload == 7L;// Indicates that the first occurrence of a 1 bit value starting from fifth to the sixth bytes of the string stored at "myKey1" is at the 8th position.
+     * // Indicates that the first occurrence of a 1 bit value starting from the fifth to seventh
+     * // bytes is the 34th bit of the binary value of the string stored at "myKey1".
+     * assert payload == 33L;
      * }</pre>
      */
     CompletableFuture<Long> bitpos(String key, long bit, long start, long end);
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offset
      * <code>offsetType</code> specifies whether the offset is a BIT or BYTE. If BIT is specified,
      * <code>start==0</code> and <code>end==2</code> means to look at the first three bits. If BYTE is
      * specified, <code>start==0</code> and <code>end==2</code> means to look at the first three bytes
@@ -188,18 +195,20 @@ public interface BitmapBaseCommands {
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @param end The ending offset.
      * @param offsetType The index offset type. Could be either {@link BitmapIndexType#BIT} or {@link
      *     BitmapIndexType#BYTE}.
      * @return The position of the first occurrence from the <code>start</code> to the <code>end
      *     </code> offsets of the <code>bit</code> in the binary value of the string held at <code>key
-     *     </code>.
+     *     </code>. If <code>bit</code> is not found, a <code>-1</code> is returned.
      * @example
      *     <pre>{@code
      * Long payload = client.bitpos("myKey1", 1, 4, 6, BIT).get();
-     * assert payload == 7L;// Indicates that the first occurrence of a 1 bit value starting from fifth to the sixth bits of the string stored at "myKey1" is at the 8th position.
+     * // Indicates that the first occurrence of a 1 bit value starting from the fifth to seventh
+     * // bits is the sixth bit of the binary value of the string stored at "myKey1".
+     * assert payload == 5L;
      * }</pre>
      */
     CompletableFuture<Long> bitpos(

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3308,11 +3308,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value.
+     * Returns the position of the first bit matching the given <code>bit</code> value.
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @return Command Response - The position of the first occurrence matching <code>bit</code> in
      *     the binary value of the string held at <code>key</code>. If <code>bit</code> is not found,
      *     a <code>-1</code> is returned.
@@ -3324,7 +3324,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offset
      * <code>start</code> is a zero-based index, with <code>0</code> being the first byte of the list,
      * <code>1</code> being the next byte and so on. These offsets can also be negative numbers
      * indicating offsets starting at the end of the list, with <code>-1</code> being the last byte of
@@ -3332,11 +3332,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @return Command Response - The position of the first occurrence beginning at the <code>start
      *     </code> offset of the <code>bit</code> in the binary value of the string held at <code>key
-     *     </code>.
+     *     </code>. If <code>bit</code> is not found, a <code>-1</code> is returned.
      */
     public T bitpos(@NonNull String key, long bit, long start) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(bit), Long.toString(start));
@@ -3345,7 +3345,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offsets
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offsets
      * <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code> being the
      * first byte of the list, <code>1</code> being the next byte and so on. These offsets can also be
      * negative numbers indicating offsets starting at the end of the list, with <code>-1</code> being
@@ -3353,12 +3353,12 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @param end The ending offset.
      * @return Command Response - The position of the first occurrence from the <code>start</code> to
      *     the <code>end</code> offsets of the <code>bit</code> in the binary value of the string held
-     *     at <code>key</code>.
+     *     at <code>key</code>. If <code>bit</code> is not found, a <code>-1</code> is returned.
      */
     public T bitpos(@NonNull String key, long bit, long start, long end) {
         ArgsArray commandArgs =
@@ -3368,7 +3368,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * Returns the position of the first bit matching the given <code>bit</code> value. The offset
      * <code>offsetType</code> specifies whether the offset is a BIT or BYTE. If BIT is specified,
      * <code>start==0</code> and <code>end==2</code> means to look at the first three bits. If BYTE is
      * specified, <code>start==0</code> and <code>end==2</code> means to look at the first three bytes
@@ -3380,14 +3380,14 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @since Redis 7.0 and above.
      * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
      * @param key The key of the string.
-     * @param bit The bit value to match.
+     * @param bit The bit value to match. The value must be <code>0</code> or <code>1</code>.
      * @param start The starting offset.
      * @param end The ending offset.
      * @param offsetType The index offset type. Could be either {@link BitmapIndexType#BIT} or {@link
      *     BitmapIndexType#BYTE}.
      * @return Command Response - The position of the first occurrence from the <code>start</code> to
      *     the <code>end</code> offsets of the <code>bit</code> in the binary value of the string held
-     *     at <code>key</code>.
+     *     at <code>key</code>. If <code>bit</code> is not found, a <code>-1</code> is returned.
      */
     public T bitpos(
             @NonNull String key, long bit, long start, long end, @NonNull BitmapIndexType offsetType) {

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -17,6 +17,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigGet;
@@ -3112,7 +3113,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     start</code>, <code>end</code>, and <code>options</code>. Returns zero if the key is
      *     missing as it is treated as an empty string.
      */
-    public T bitcount(@NonNull String key, long start, long end, BitmapIndexType options) {
+    public T bitcount(@NonNull String key, long start, long end, @NonNull BitmapIndexType options) {
         ArgsArray commandArgs =
                 buildArgs(key, Long.toString(start), Long.toString(end), options.toString());
 
@@ -3303,6 +3304,102 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T getbit(@NonNull String key, long offset) {
         ArgsArray commandArgs = buildArgs(key, Long.toString(offset));
         protobufTransaction.addCommands(buildCommand(GetBit, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @return Command Response - The position of the first occurrence matching <code>bit</code> in
+     *     the binary value of the string held at <code>key</code>. If <code>bit</code> is not found,
+     *     a <code>-1</code> is returned.
+     */
+    public T bitpos(@NonNull String key, long bit) {
+        ArgsArray commandArgs = buildArgs(key, Long.toString(bit));
+        protobufTransaction.addCommands(buildCommand(BitPos, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * <code>start</code> is a zero-based index, with <code>0</code> being the first byte of the list,
+     * <code>1</code> being the next byte and so on. These offsets can also be negative numbers
+     * indicating offsets starting at the end of the list, with <code>-1</code> being the last byte of
+     * the list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @return Command Response - The position of the first occurrence beginning at the <code>start
+     *     </code> offset of the <code>bit</code> in the binary value of the string held at <code>key
+     *     </code>.
+     */
+    public T bitpos(@NonNull String key, long bit, long start) {
+        ArgsArray commandArgs = buildArgs(key, Long.toString(bit), Long.toString(start));
+        protobufTransaction.addCommands(buildCommand(BitPos, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offsets
+     * <code>start</code> and <code>end</code> are zero-based indexes, with <code>0</code> being the
+     * first byte of the list, <code>1</code> being the next byte and so on. These offsets can also be
+     * negative numbers indicating offsets starting at the end of the list, with <code>-1</code> being
+     * the last byte of the list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @param end The ending offset.
+     * @return Command Response - The position of the first occurrence from the <code>start</code> to
+     *     the <code>end</code> offsets of the <code>bit</code> in the binary value of the string held
+     *     at <code>key</code>.
+     */
+    public T bitpos(@NonNull String key, long bit, long start, long end) {
+        ArgsArray commandArgs =
+                buildArgs(key, Long.toString(bit), Long.toString(start), Long.toString(end));
+        protobufTransaction.addCommands(buildCommand(BitPos, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Return the position of the first bit matching the given <code>bit</code> value. The offset
+     * <code>offsetType</code> specifies whether the offset is a BIT or BYTE. If BIT is specified,
+     * <code>start==0</code> and <code>end==2</code> means to look at the first three bits. If BYTE is
+     * specified, <code>start==0</code> and <code>end==2</code> means to look at the first three bytes
+     * The offsets are zero-based indexes, with <code>0</code> being the first element of the list,
+     * <code>1</code> being the next, and so on. These offsets can also be negative numbers indicating
+     * offsets starting at the end of the list, with <code>-1</code> being the last element of the
+     * list, <code>-2</code> being the penultimate, and so on.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/commands/bitpos/">redis.io</a> for details.
+     * @param key The key of the string.
+     * @param bit The bit value to match.
+     * @param start The starting offset.
+     * @param end The ending offset.
+     * @param offsetType The index offset type. Could be either {@link BitmapIndexType#BIT} or {@link
+     *     BitmapIndexType#BYTE}.
+     * @return Command Response - The position of the first occurrence from the <code>start</code> to
+     *     the <code>end</code> offsets of the <code>bit</code> in the binary value of the string held
+     *     at <code>key</code>.
+     */
+    public T bitpos(
+            @NonNull String key, long bit, long start, long end, @NonNull BitmapIndexType offsetType) {
+        ArgsArray commandArgs =
+                buildArgs(
+                        key,
+                        Long.toString(bit),
+                        Long.toString(start),
+                        Long.toString(end),
+                        offsetType.toString());
+
+        protobufTransaction.addCommands(buildCommand(BitPos, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -38,6 +38,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigGet;
@@ -4588,5 +4589,114 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(bit, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void bitpos_returns_success() {
+        // setup
+        String key = "testKey";
+        Long bit = 0L;
+        Long bitPosition = 10L;
+        String[] arguments = new String[] {key, Long.toString(bit)};
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(bitPosition);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(BitPos), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.bitpos(key, bit);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(bitPosition, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void bitpos_with_start_returns_success() {
+        // setup
+        String key = "testKey";
+        Long bit = 0L;
+        Long start = 5L;
+        Long bitPosition = 10L;
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(bitPosition);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(
+                        eq(BitPos), eq(new String[] {key, Long.toString(bit), Long.toString(start)}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.bitpos(key, bit, start);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(bitPosition, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void bitpos_with_start_and_end_returns_success() {
+        // setup
+        String key = "testKey";
+        Long bit = 0L;
+        Long start = 5L;
+        Long end = 10L;
+        Long bitPosition = 10L;
+        String[] arguments =
+                new String[] {key, Long.toString(bit), Long.toString(start), Long.toString(end)};
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(bitPosition);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(BitPos), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.bitpos(key, bit, start, end);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(bitPosition, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void bitpos_with_start_and_end_and_type_returns_success() {
+        // setup
+        String key = "testKey";
+        Long bit = 0L;
+        Long start = 5L;
+        Long end = 10L;
+        Long bitPosition = 10L;
+        String[] arguments =
+                new String[] {
+                    key,
+                    Long.toString(bit),
+                    Long.toString(start),
+                    Long.toString(end),
+                    BitmapIndexType.BIT.toString()
+                };
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(bitPosition);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(BitPos), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.bitpos(key, bit, start, end, BitmapIndexType.BIT);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(bitPosition, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -29,6 +29,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
 import static redis_request.RedisRequestOuterClass.RequestType.ConfigGet;
@@ -789,6 +790,15 @@ public class TransactionTests {
 
         transaction.setbit("key", 8, 1);
         results.add(Pair.of(SetBit, buildArgs("key", "8", "1")));
+
+        transaction.bitpos("key", 1);
+        results.add(Pair.of(BitPos, buildArgs("key", "1")));
+        transaction.bitpos("key", 0, 8);
+        results.add(Pair.of(BitPos, buildArgs("key", "0", "8")));
+        transaction.bitpos("key", 1, 8, 10);
+        results.add(Pair.of(BitPos, buildArgs("key", "1", "8", "10")));
+        transaction.bitpos("key", 1, 8, 10, BitmapIndexType.BIT);
+        results.add(Pair.of(BitPos, buildArgs("key", "1", "8", "10", BitmapIndexType.BIT.toString())));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -543,14 +543,14 @@ public class TransactionTestUtilities {
                 .setbit(key2, 1, 1)
                 .setbit(key2, 1, 0)
                 .getbit(key1, 1)
-                .bitpos(key, 1)
-                .bitpos(key, 1, 3)
-                .bitpos(key, 1, 3, 5);
+                .bitpos(key1, 1)
+                .bitpos(key1, 1, 3)
+                .bitpos(key1, 1, 3, 5);
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             transaction
-                .bitcount(key1, 5, 30, BitmapIndexType.BIT)
-                .bitpos(key, 1, 44, 50, BitmapIndexType.BIT);
+                    .bitcount(key1, 5, 30, BitmapIndexType.BIT)
+                    .bitpos(key1, 1, 44, 50, BitmapIndexType.BIT);
         }
 
         var expectedResults =

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -542,10 +542,15 @@ public class TransactionTestUtilities {
                 .bitcount(key1, 1, 1)
                 .setbit(key2, 1, 1)
                 .setbit(key2, 1, 0)
-                .getbit(key1, 1);
+                .getbit(key1, 1)
+                .bitpos(key, 1)
+                .bitpos(key, 1, 3)
+                .bitpos(key, 1, 3, 5);
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
-            transaction.bitcount(key1, 5, 30, BitmapIndexType.BIT);
+            transaction
+                .bitcount(key1, 5, 30, BitmapIndexType.BIT)
+                .bitpos(key, 1, 44, 50, BitmapIndexType.BIT);
         }
 
         var expectedResults =
@@ -556,6 +561,9 @@ public class TransactionTestUtilities {
                     0L, // setbit(key2, 1, 1)
                     1L, // setbit(key2, 1, 0)
                     1L, // getbit(key1, 1)
+                    1L, // bitpos(key, 1)
+                    25L, // bitpos(key, 1, 3)
+                    25L, // bitpos(key, 1, 3, 5)
                 };
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
@@ -563,6 +571,7 @@ public class TransactionTestUtilities {
                     expectedResults,
                     new Object[] {
                         17L, // bitcount(key, 5, 30, BitmapIndexType.BIT)
+                        46L, // bitpos(key, 1, 44, 50, BitmapIndexType.BIT)
                     });
         }
         return expectedResults;


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Implements `BITPOS` command in the java client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.