### PR TITLE
Python: Update `XADD` and `XTRIM` Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 * Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
 * Node: Added BLPOP command ([#1223](https://github.com/aws/glide-for-redis/pull/1223))
-* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320))
+* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320), TODO)
 * Python: Added BLPOP and BRPOP commands ([#1369](https://github.com/aws/glide-for-redis/pull/1369))
 * Python: Added ZRANGESTORE command ([#1377](https://github.com/aws/glide-for-redis/pull/1377))
 * Python: Added ZDIFFSTORE command ([#1378](https://github.com/aws/glide-for-redis/pull/1378))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 * Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
 * Node: Added BLPOP command ([#1223](https://github.com/aws/glide-for-redis/pull/1223))
-* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320), TODO)
+* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320), [#1450](https://github.com/aws/glide-for-redis/pull/1450))
 * Python: Added BLPOP and BRPOP commands ([#1369](https://github.com/aws/glide-for-redis/pull/1369))
 * Python: Added ZRANGESTORE command ([#1377](https://github.com/aws/glide-for-redis/pull/1377))
 * Python: Added ZDIFFSTORE command ([#1378](https://github.com/aws/glide-for-redis/pull/1378))

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -280,7 +280,7 @@ async def transaction_test(
     args.append("0-1")
     transaction.xadd(key11, [("foo", "bar")], StreamAddOptions(id="0-2"))
     args.append("0-2")
-    transaction.xtrim(key11, TrimByMinId(threshold="0-2", exact=True))
+    transaction.xtrim(key11, TrimByMinId.create_withexact(threshold="0-2", exact=True))
     args.append(1)
     return args
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update [XTRIM](https://valkey.io/commands/xtrim/) tests for Python and added constructors to discourage client users from using XTRIM options constructor with both exact and limit variables. 

XTRIM options also applies to XADD.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
