### PR TITLE
Node: update `XTRIM` and `XADD` options (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Python: Added ZMSCORE command ([#1357](https://github.com/aws/glide-for-redis/pull/1357))
 * Python: Added HRANDFIELD command ([#1334](https://github.com/aws/glide-for-redis/pull/1334))
 * Node: Added BLPOP command ([#1223](https://github.com/aws/glide-for-redis/pull/1223))
-* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320))
+* Python: Added XADD, XTRIM commands ([#1320](https://github.com/aws/glide-for-redis/pull/1320), TODO)
 * Python: Added BLPOP and BRPOP commands ([#1369](https://github.com/aws/glide-for-redis/pull/1369))
 * Python: Added ZRANGESTORE command ([#1377](https://github.com/aws/glide-for-redis/pull/1377))
 * Python: Added ZDIFFSTORE command ([#1378](https://github.com/aws/glide-for-redis/pull/1378))

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -2153,7 +2153,7 @@ export function runBaseTests<Context>(config: {
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
-        `streams add and trim test_%p`,
+        `streams add test_%p`,
         async () => {
             await runTest(async (client: BaseClient) => {
                 const key = uuidv4();
@@ -2235,6 +2235,76 @@ export function runBaseTests<Context>(config: {
                 ).toEqual(1);
                 expect(await client.customCommand(["XLEN", key])).toEqual(1);
             }, ProtocolVersion.RESP2);
+        },
+        config.timeout,
+    );
+
+    it.only.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `streams trim options test_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient) => {
+                const key = uuidv4();
+                const field = uuidv4();
+                const value = uuidv4();
+
+                for (let counter = 1; counter <= 300; counter++) {
+                    const id = "12345-" + counter;
+                    expect(
+                        await client.xadd(
+                            key,
+                            [[field + counter, value + counter]],
+                            { id: id },
+                        ),
+                    ).toEqual(id);
+                }
+
+                // TODO: Update when XLEN is implemented
+                expect(await client.customCommand(["XLEN", key])).toEqual(300);
+
+                // trim ids from 12345-1..12345-9 using MinId
+                expect(
+                    await client.xtrim(key, {
+                        method: "minid",
+                        threshold: "12345-10",
+                    }),
+                ).toEqual(9);
+                // TODO: Update when XLEN is implemented
+                expect(await client.customCommand(["XLEN", key])).toEqual(291);
+
+                // trim 91 items (already trimmed 9 items, and Redis trims only another 91 items)
+                expect(
+                    await client.xtrim(key, {
+                        method: "minid",
+                        threshold: "12345-300",
+                        exact: false,
+                        limit: 100,
+                    }),
+                ).toEqual(81);
+                // TODO: Update when XLEN is implemented
+                expect(await client.customCommand(["XLEN", key])).toEqual(210);
+
+                // trim another 100 items using maxlen of 0
+                expect(
+                    await client.xtrim(key, {
+                        method: "maxlen",
+                        threshold: 0,
+                        limit: 100,
+                    }),
+                ).toEqual(88);
+                // TODO: Update when XLEN is implemented
+                expect(await client.customCommand(["XLEN", key])).toEqual(122);
+
+                // trims the remainder of items
+                expect(
+                    await client.xtrim(key, {
+                        method: "maxlen",
+                        exact: true,
+                        threshold: 0,
+                    }),
+                ).toEqual(122);
+                // TODO: Update when XLEN is implemented
+                expect(await client.customCommand(["XLEN", key])).toEqual(0);
+            }, protocol);
         },
         config.timeout,
     );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


Update [XTRIM](https://valkey.io/commands/xtrim/) tests for Python and added constructors to discourage client users from using XTRIM options constructor with both exact and limit variables. 

XTRIM options also applies to XADD.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
