### PR TITLE
changing sleep duration for ObjectIdletime Test

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3517,7 +3517,7 @@ public class SharedCommandTests {
     public void objectIdletime(BaseClient client) {
         String key = UUID.randomUUID().toString();
         assertEquals(OK, client.set(key, "").get());
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         assertTrue(client.objectIdletime(key).get() > 0L);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- objectIdleTime test fails intermittently, we suspect that idletime doesn't update frequently enough within 1 second, changing to a longer duration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
