### PR TITLE
Java: Add `BITOP` command

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -187,6 +187,7 @@ enum RequestType {
     GetBit = 145;
     ZInter = 146;
     BitPos = 147;
+    BitOp = 148;
     FunctionLoad = 150;
 }
 

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -157,6 +157,7 @@ pub enum RequestType {
     GetBit = 145,
     ZInter = 146,
     BitPos = 147,
+    BitOp = 148,
     FunctionLoad = 150,
 }
 
@@ -319,6 +320,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ZInter => RequestType::ZInter,
             ProtobufRequestType::FunctionLoad => RequestType::FunctionLoad,
             ProtobufRequestType::BitPos => RequestType::BitPos,
+            ProtobufRequestType::BitOp => RequestType::BitOp,
         }
     }
 }
@@ -476,6 +478,7 @@ impl RequestType {
             RequestType::ZInter => Some(cmd("ZINTER")),
             RequestType::FunctionLoad => Some(get_two_word_command("FUNCTION", "LOAD")),
             RequestType::BitPos => Some(cmd("BITPOS")),
+            RequestType::BitOp => Some(cmd("BITOP")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -15,6 +15,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitOp;
 import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.Decr;
 import static redis_request.RedisRequestOuterClass.RequestType.DecrBy;
@@ -143,6 +144,7 @@ import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
@@ -1409,5 +1411,15 @@ public abstract class BaseClient
                     key, Long.toString(bit), Long.toString(start), Long.toString(end), options.toString()
                 };
         return commandManager.submitNewCommand(BitPos, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> bitop(
+            @NonNull BitwiseOperation bitwiseOperation,
+            @NonNull String destination,
+            @NonNull String[] keys) {
+        String[] arguments =
+                concatenateArrays(new String[] {bitwiseOperation.toString(), destination}, keys);
+        return commandManager.submitNewCommand(BitOp, arguments, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
@@ -2,6 +2,7 @@
 package glide.api.commands;
 
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -213,4 +214,27 @@ public interface BitmapBaseCommands {
      */
     CompletableFuture<Long> bitpos(
             String key, long bit, long start, long end, BitmapIndexType offsetType);
+
+    /**
+     * Perform a bitwise operation between multiple keys (containing string values) and store the
+     * result in the <code>destination</code>.
+     *
+     * @apiNote When in cluster mode, <code>destination</code> and all <code>keys</code> must map to
+     *     the same hash slot.
+     * @see <a href="https://redis.io/commands/bitop/">redis.io</a> for details.
+     * @param bitwiseOperation The bitwise operation to perform.
+     * @param destination The key that will store the resulting string.
+     * @param keys The list of keys to perform the bitwise operation on.
+     * @return The size of the string stored in <code>destination</code>.
+     * @example
+     *     <pre>{@code
+     * client.set("key1", "A"); // "A" has binary value 01000001
+     * client.set("key2", "B"); // "B" has binary value 01000010
+     * Long payload = client.bitop(BitwiseOperation.AND, "destination", new String[] {key1, key2}).get();
+     * assert "@" == client.get("destination").get(); // "@" has binary value 01000000
+     * assert payload == 1L; // The size of the resulting string is 1.
+     * }</pre>
+     */
+    CompletableFuture<Long> bitop(
+            BitwiseOperation bitwiseOperation, String destination, String[] keys);
 }

--- a/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/BitmapBaseCommands.java
@@ -231,7 +231,7 @@ public interface BitmapBaseCommands {
      * client.set("key1", "A"); // "A" has binary value 01000001
      * client.set("key2", "B"); // "B" has binary value 01000010
      * Long payload = client.bitop(BitwiseOperation.AND, "destination", new String[] {key1, key2}).get();
-     * assert "@" == client.get("destination").get(); // "@" has binary value 01000000
+     * assert "@".equals(client.get("destination").get()); // "@" has binary value 01000000
      * assert payload == 1L; // The size of the resulting string is 1.
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -18,6 +18,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitOp;
 import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
@@ -164,6 +165,7 @@ import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeys;
 import glide.api.models.commands.WeightAggregateOptions.WeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.function.FunctionLoadOptions;
 import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
@@ -3450,6 +3452,27 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
                         offsetType.toString());
 
         protobufTransaction.addCommands(buildCommand(BitPos, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Perform a bitwise operation between multiple keys (containing string values) and store the
+     * result in the <code>destination</code>.
+     *
+     * @see <a href="https://redis.io/commands/bitop/">redis.io</a> for details.
+     * @param bitwiseOperation The bitwise operation to perform.
+     * @param destination The key that will store the resulting string.
+     * @param keys The list of keys to perform the bitwise operation on.
+     * @return Command Response - The size of the string stored in <code>destination</code>.
+     */
+    public T bitop(
+            @NonNull BitwiseOperation bitwiseOperation,
+            @NonNull String destination,
+            @NonNull String[] keys) {
+        ArgsArray commandArgs =
+                buildArgs(concatenateArrays(new String[] {bitwiseOperation.toString(), destination}, keys));
+
+        protobufTransaction.addCommands(buildCommand(BitOp, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/commands/bitmap/BitwiseOperation.java
+++ b/java/client/src/main/java/glide/api/models/commands/bitmap/BitwiseOperation.java
@@ -5,7 +5,7 @@ import glide.api.commands.BitmapBaseCommands;
 
 /**
  * Defines bitwise operation for {@link BitmapBaseCommands#bitop(BitwiseOperation, String,
- * String[])}. Specifies bitwise operation to perform between keys
+ * String[])}. Specifies bitwise operation to perform between keys.
  *
  * @see <a href="https://redis.io/commands/bitop/">redis.io</a>
  */

--- a/java/client/src/main/java/glide/api/models/commands/bitmap/BitwiseOperation.java
+++ b/java/client/src/main/java/glide/api/models/commands/bitmap/BitwiseOperation.java
@@ -1,0 +1,17 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands.bitmap;
+
+import glide.api.commands.BitmapBaseCommands;
+
+/**
+ * Defines bitwise operation for {@link BitmapBaseCommands#bitop(BitwiseOperation, String,
+ * String[])}. Specifies bitwise operation to perform between keys
+ *
+ * @see <a href="https://redis.io/commands/bitop/">redis.io</a>
+ */
+public enum BitwiseOperation {
+    AND,
+    OR,
+    XOR,
+    NOT
+}

--- a/java/client/src/main/java/module-info.java
+++ b/java/client/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module glide.api {
     exports glide.api.models.commands.stream;
     exports glide.api.models.configuration;
     exports glide.api.models.exceptions;
+    exports glide.api.models.commands.bitmap;
     exports glide.api.models.commands.geospatial;
     exports glide.api.models.commands.function;
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -39,6 +39,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitOp;
 import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
@@ -179,6 +180,7 @@ import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.WeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.function.FunctionLoadOptions;
 import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
@@ -4772,5 +4774,30 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(bitPosition, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void bitop_returns_success() {
+        // setup
+        String destination = "destination";
+        String[] keys = new String[] {"key1", "key2"};
+        Long result = 6L;
+        BitwiseOperation bitwiseAnd = BitwiseOperation.AND;
+        String[] arguments = concatenateArrays(new String[] {bitwiseAnd.toString(), destination}, keys);
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(result);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(BitOp), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.bitop(bitwiseAnd, destination, keys);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(result, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -30,6 +30,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.BZMPop;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMax;
 import static redis_request.RedisRequestOuterClass.RequestType.BZPopMin;
 import static redis_request.RedisRequestOuterClass.RequestType.BitCount;
+import static redis_request.RedisRequestOuterClass.RequestType.BitOp;
 import static redis_request.RedisRequestOuterClass.RequestType.BitPos;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientGetName;
 import static redis_request.RedisRequestOuterClass.RequestType.ClientId;
@@ -163,6 +164,7 @@ import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.WeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
@@ -808,6 +810,9 @@ public class TransactionTests {
         results.add(Pair.of(BitPos, buildArgs("key", "1", "8", "10")));
         transaction.bitpos("key", 1, 8, 10, BitmapIndexType.BIT);
         results.add(Pair.of(BitPos, buildArgs("key", "1", "8", "10", BitmapIndexType.BIT.toString())));
+
+        transaction.bitop(BitwiseOperation.AND, "destination", new String[] {"key"});
+        results.add(Pair.of(BitOp, buildArgs(BitwiseOperation.AND.toString(), "destination", "key")));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3939,6 +3939,7 @@ public class SharedCommandTests {
         assertEquals(1L, client.bitop(BitwiseOperation.NOT, destination, new String[] {key1}).get());
         // First bit is flipped to 1 and throws 'utf-8' codec can't decode byte 0x9e in position 0:
         // invalid start byte
+        // TODO: update once fix is implemented for https://github.com/aws/glide-for-redis/issues/1447
         ExecutionException executionException =
                 assertThrows(ExecutionException.class, () -> client.get(destination).get());
         assertTrue(executionException.getCause() instanceof RuntimeException);

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3963,42 +3963,12 @@ public class SharedCommandTests {
                 assertThrows(
                         ExecutionException.class,
                         () -> client.bitop(BitwiseOperation.AND, destination, new String[] {emptyKey1}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.OR, destination, new String[] {emptyKey1}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.XOR, destination, new String[] {emptyKey1}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.NOT, destination, new String[] {emptyKey1}).get());
 
         // Source keys is an empty list
         executionException =
                 assertThrows(
                         ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.AND, destination, new String[] {}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
                         () -> client.bitop(BitwiseOperation.OR, destination, new String[] {}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.XOR, destination, new String[] {}).get());
-        assertTrue(executionException.getCause() instanceof RequestException);
-        executionException =
-                assertThrows(
-                        ExecutionException.class,
-                        () -> client.bitop(BitwiseOperation.NOT, destination, new String[] {}).get());
         assertTrue(executionException.getCause() instanceof RequestException);
 
         // NOT with more than one source key

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -47,6 +47,7 @@ import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.WeightedKeys;
 import glide.api.models.commands.ZAddOptions;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
@@ -3899,5 +3900,112 @@ public class SharedCommandTests {
                             () -> client.bitpos(key1, 1, 43, -2, BitmapIndexType.BIT).get());
             assertTrue(executionException.getCause() instanceof RequestException);
         }
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void bitop(BaseClient client) {
+        String key1 = "{key}-1".concat(UUID.randomUUID().toString());
+        String key2 = "{key}-2".concat(UUID.randomUUID().toString());
+        String emptyKey1 = "{key}-3".concat(UUID.randomUUID().toString());
+        String emptyKey2 = "{key}-4".concat(UUID.randomUUID().toString());
+        String destination = "{key}-5".concat(UUID.randomUUID().toString());
+        String[] keys = new String[] {key1, key2};
+        String[] emptyKeys = new String[] {emptyKey1, emptyKey2};
+        String value1 = "foobar";
+        String value2 = "abcdef";
+
+        assertEquals(OK, client.set(key1, value1).get());
+        assertEquals(OK, client.set(key2, value2).get());
+        assertEquals(6L, client.bitop(BitwiseOperation.AND, destination, keys).get());
+        assertEquals("`bc`ab", client.get(destination).get());
+        assertEquals(6L, client.bitop(BitwiseOperation.OR, destination, keys).get());
+        assertEquals("goofev", client.get(destination).get());
+
+        // Reset values for simplicity of results in XOR
+        assertEquals(OK, client.set(key1, "a").get());
+        assertEquals(OK, client.set(key2, "b").get());
+        assertEquals(1L, client.bitop(BitwiseOperation.XOR, destination, keys).get());
+        assertEquals("\u0003", client.get(destination).get());
+
+        // Test single source key
+        assertEquals(1L, client.bitop(BitwiseOperation.AND, destination, new String[] {key1}).get());
+        assertEquals("a", client.get(destination).get());
+        assertEquals(1L, client.bitop(BitwiseOperation.OR, destination, new String[] {key1}).get());
+        assertEquals("a", client.get(destination).get());
+        assertEquals(1L, client.bitop(BitwiseOperation.XOR, destination, new String[] {key1}).get());
+        assertEquals("a", client.get(destination).get());
+        assertEquals(1L, client.bitop(BitwiseOperation.NOT, destination, new String[] {key1}).get());
+        // First bit is flipped to 1 and throws 'utf-8' codec can't decode byte 0x9e in position 0:
+        // invalid start byte
+        ExecutionException executionException =
+                assertThrows(ExecutionException.class, () -> client.get(destination).get());
+        assertTrue(executionException.getCause() instanceof RuntimeException);
+        assertEquals(0, client.setbit(key1, 0, 1).get());
+        assertEquals(1L, client.bitop(BitwiseOperation.NOT, destination, new String[] {key1}).get());
+        assertEquals("\u001e", client.get(destination).get());
+
+        // Returns null when all keys hold empty strings
+        assertEquals(0L, client.bitop(BitwiseOperation.AND, destination, emptyKeys).get());
+        assertEquals(null, client.get(destination).get());
+        assertEquals(0L, client.bitop(BitwiseOperation.OR, destination, emptyKeys).get());
+        assertEquals(null, client.get(destination).get());
+        assertEquals(0L, client.bitop(BitwiseOperation.XOR, destination, emptyKeys).get());
+        assertEquals(null, client.get(destination).get());
+        assertEquals(
+                0L, client.bitop(BitwiseOperation.NOT, destination, new String[] {emptyKey1}).get());
+        assertEquals(null, client.get(destination).get());
+
+        // Exception thrown due to the key holding a value with the wrong type
+        assertEquals(1, client.sadd(emptyKey1, new String[] {value1}).get());
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.AND, destination, new String[] {emptyKey1}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.OR, destination, new String[] {emptyKey1}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.XOR, destination, new String[] {emptyKey1}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.NOT, destination, new String[] {emptyKey1}).get());
+
+        // Source keys is an empty list
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.AND, destination, new String[] {}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.OR, destination, new String[] {}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.XOR, destination, new String[] {}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.NOT, destination, new String[] {}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
+
+        // NOT with more than one source key
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () -> client.bitop(BitwiseOperation.NOT, destination, new String[] {key1, key2}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
     }
 }

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -20,6 +20,7 @@ import glide.api.models.commands.SetOptions;
 import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.bitmap.BitmapIndexType;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
@@ -543,6 +544,8 @@ public class TransactionTestUtilities {
     private static Object[] bitmapCommands(BaseTransaction<?> transaction) {
         String key1 = "{bitmapKey}-1" + UUID.randomUUID();
         String key2 = "{bitmapKey}-2" + UUID.randomUUID();
+        String key3 = "{bitmapKey}-3" + UUID.randomUUID();
+        String key4 = "{bitmapKey}-4" + UUID.randomUUID();
 
         transaction
                 .set(key1, "foobar")
@@ -553,7 +556,10 @@ public class TransactionTestUtilities {
                 .getbit(key1, 1)
                 .bitpos(key1, 1)
                 .bitpos(key1, 1, 3)
-                .bitpos(key1, 1, 3, 5);
+                .bitpos(key1, 1, 3, 5)
+                .set(key3, "abcdef")
+                .bitop(BitwiseOperation.AND, key4, new String[] {key1, key3})
+                .get(key4);
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             transaction
@@ -572,6 +578,9 @@ public class TransactionTestUtilities {
                     1L, // bitpos(key, 1)
                     25L, // bitpos(key, 1, 3)
                     25L, // bitpos(key, 1, 3, 5)
+                    OK, // set(key3, "abcdef")
+                    6L, // bitop(BitwiseOperation.AND, key4, new String[] {key1, key3})
+                    "`bc`ab", // get(key4)
                 };
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -38,6 +38,7 @@ import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.RangeOptions.RangeByIndex;
 import glide.api.models.commands.WeightAggregateOptions.KeyArray;
+import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.configuration.NodeAddress;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
@@ -691,7 +692,21 @@ public class CommandTests {
                 Arguments.of(
                         "zmpop", "7.0.0", clusterClient.zmpop(new String[] {"abc", "zxy", "lkn"}, MAX)),
                 Arguments.of(
-                        "bzmpop", "7.0.0", clusterClient.bzmpop(new String[] {"abc", "zxy", "lkn"}, MAX, .1)));
+                        "bzmpop", "7.0.0", clusterClient.bzmpop(new String[] {"abc", "zxy", "lkn"}, MAX, .1)),
+                Arguments.of(
+                        "bitop",
+                        null,
+                        clusterClient.bitop(BitwiseOperation.AND, "abc", new String[] {"zxy", "lkn"})),
+                Arguments.of(
+                        "bitop",
+                        null,
+                        clusterClient.bitop(BitwiseOperation.OR, "abc", new String[] {"zxy", "lkn"})),
+                Arguments.of(
+                        "bitop",
+                        null,
+                        clusterClient.bitop(BitwiseOperation.XOR, "abc", new String[] {"zxy", "lkn"})),
+                Arguments.of(
+                        "bitop", null, clusterClient.bitop(BitwiseOperation.NOT, "abc", new String[] {"zxy"})));
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -696,17 +696,7 @@ public class CommandTests {
                 Arguments.of(
                         "bitop",
                         null,
-                        clusterClient.bitop(BitwiseOperation.AND, "abc", new String[] {"zxy", "lkn"})),
-                Arguments.of(
-                        "bitop",
-                        null,
-                        clusterClient.bitop(BitwiseOperation.OR, "abc", new String[] {"zxy", "lkn"})),
-                Arguments.of(
-                        "bitop",
-                        null,
-                        clusterClient.bitop(BitwiseOperation.XOR, "abc", new String[] {"zxy", "lkn"})),
-                Arguments.of(
-                        "bitop", null, clusterClient.bitop(BitwiseOperation.NOT, "abc", new String[] {"zxy"})));
+                        clusterClient.bitop(BitwiseOperation.OR, "abc", new String[] {"zxy", "lkn"})));
     }
 
     @SneakyThrows


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Implements `BITOP` command in the java client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.