### PR TITLE
Java: add `XDEL` command (#318)

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -196,6 +196,7 @@ enum RequestType {
     BLMPop = 158;
     XLen = 159;
     LSet = 165;
+    XDel = 166;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -166,6 +166,7 @@ pub enum RequestType {
     BLMPop = 158,
     XLen = 159,
     LSet = 165,
+    XDel = 166,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -335,6 +336,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::PExpireTime => RequestType::PExpireTime,
             ProtobufRequestType::XLen => RequestType::XLen,
             ProtobufRequestType::LSet => RequestType::LSet,
+            ProtobufRequestType::XDel => RequestType::XDel,
         }
     }
 }
@@ -500,6 +502,7 @@ impl RequestType {
             RequestType::PExpireTime => Some(cmd("PEXPIRETIME")),
             RequestType::XLen => Some(cmd("XLEN")),
             RequestType::LSet => Some(cmd("LSET")),
+            RequestType::XDel => Some(cmd("XDEL")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -101,6 +101,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Touch;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.XDel;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -1234,6 +1235,12 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Long> xlen(@NonNull String key) {
         return commandManager.submitNewCommand(XLen, new String[] {key}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> xdel(@NonNull String key, @NonNull String[] ids) {
+        String[] arguments = ArrayUtils.addFirst(ids, key);
+        return commandManager.submitNewCommand(XDel, arguments, this::handleLongResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -88,4 +88,21 @@ public interface StreamBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> xlen(String key);
+
+    /**
+     * Removes the specified entries by id from a stream, and returns the number of entries deleted.
+     *
+     * @see <a href="https://valkey.io/commands/xdel/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param ids An array of entry ids.
+     * @return The number of entries removed from the stream. This number may be less than the number
+     *     of entries in <code>ids</code>, if the specified <code>ids</code> don't exist in the
+     *     stream.
+     * @example
+     *     <pre>{@code
+     * Long num = client.xdel("key", new String[] {"1538561698944-0", "1538561698944-1"}).get();
+     * assert num == 2L; // Stream marked 2 entries as deleted
+     * }</pre>
+     */
+    CompletableFuture<Long> xdel(String key, String[] ids);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -120,6 +120,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Touch;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.XDel;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -2644,6 +2645,22 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public T xlen(@NonNull String key) {
         protobufTransaction.addCommands(buildCommand(XLen, buildArgs(key)));
+        return getThis();
+    }
+
+    /**
+     * Removes the specified entries by id from a stream, and returns the number of entries deleted.
+     *
+     * @see <a href="https://valkey.io/commands/xdel/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param ids An array of entry ids.
+     * @return Command Response - The number of entries removed from the stream. This number may be
+     *     less than the number of entries in <code>ids</code>, if the specified <code>ids</code>
+     *     don't exist in the stream.
+     */
+    public T xdel(String key, String[] ids) {
+        ArgsArray commandArgs = buildArgs(ArrayUtils.addFirst(ids, key));
+        protobufTransaction.addCommands(buildCommand(XDel, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -141,6 +141,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Touch;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.XDel;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -3992,6 +3993,31 @@ public class RedisClientTest {
 
         // exercise
         CompletableFuture<Long> response = service.xlen(key);
+        Long payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(completedResult, payload);
+    }
+
+    @Test
+    @SneakyThrows
+    public void xdel_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] ids = {"one-1", "two-2", "three-3"};
+        Long completedResult = 69L;
+
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(completedResult);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(
+                        eq(XDel), eq(new String[] {key, "one-1", "two-2", "three-3"}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.xdel(key, ids);
         Long payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -130,6 +130,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Touch;
 import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
+import static redis_request.RedisRequestOuterClass.RequestType.XDel;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XTrim;
 import static redis_request.RedisRequestOuterClass.RequestType.ZAdd;
@@ -680,6 +681,9 @@ public class TransactionTests {
 
         transaction.xlen("key");
         results.add(Pair.of(XLen, buildArgs("key")));
+
+        transaction.xdel("key", new String[] {"12345-1", "98765-4"});
+        results.add(Pair.of(XDel, buildArgs("key", "12345-1", "98765-4")));
 
         transaction.time();
         results.add(Pair.of(Time, buildArgs()));

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -540,7 +540,8 @@ public class TransactionTestUtilities {
                 .xadd(streamKey1, Map.of("field2", "value2"), StreamAddOptions.builder().id("0-2").build())
                 .xadd(streamKey1, Map.of("field3", "value3"), StreamAddOptions.builder().id("0-3").build())
                 .xlen(streamKey1)
-                .xtrim(streamKey1, new MinId(true, "0-2"));
+                .xtrim(streamKey1, new MinId(true, "0-2"))
+                .xdel(streamKey1, new String[] {"0-3", "0-5"});
 
         return new Object[] {
             "0-1", // xadd(streamKey1, Map.of("field1", "value1"), ... .id("0-1").build());
@@ -548,6 +549,7 @@ public class TransactionTestUtilities {
             "0-3", // xadd(streamKey1, Map.of("field3", "value3"), ... .id("0-3").build());
             3L, // xlen(streamKey1)
             1L, // xtrim(streamKey1, new MinId(true, "0-2"))
+            1L, // .xdel(streamKey1, new String[] {"0-1", "0-5"});
         };
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds the [XDEL](https://valkey.io/commands/xdel/) command for Java client

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
