### PR TITLE
HOT-FIX: CRITICAL - fixed set command optional arguments and added tests to set command

### DIFF
--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -145,13 +145,13 @@ export function createSet(
         if (options.expiry === "keepExisting") {
             args.push("KEEPTTL");
         } else if (options.expiry?.type === "seconds") {
-            args.push("EX " + options.expiry.count);
+            args.push("EX", options.expiry.count.toString());
         } else if (options.expiry?.type === "milliseconds") {
-            args.push("PX " + options.expiry.count);
+            args.push("PX", options.expiry.count.toString());
         } else if (options.expiry?.type === "unixSeconds") {
-            args.push("EXAT " + options.expiry.count);
+            args.push("EXAT", options.expiry.count.toString());
         } else if (options.expiry?.type === "unixMilliseconds") {
-            args.push("PXAT " + options.expiry.count);
+            args.push("PXAT", options.expiry.count.toString());
         }
     }
 

--- a/node/tests/RedisClientInternals.test.ts
+++ b/node/tests/RedisClientInternals.test.ts
@@ -524,12 +524,13 @@ describe("SocketConnectionInternals", () => {
                     throw new Error("no args");
                 }
 
-                expect(args.length).toEqual(5);
+                expect(args.length).toEqual(6);
                 expect(args[0]).toEqual("foo");
                 expect(args[1]).toEqual("bar");
                 expect(args[2]).toEqual("XX");
                 expect(args[3]).toEqual("GET");
-                expect(args[4]).toEqual("EX 10");
+                expect(args[4]).toEqual("EX");
+                expect(args[5]).toEqual("10");
                 sendResponse(socket, ResponseType.OK, request.callbackIdx);
             });
             const request1 = connection.set("foo", "bar", {
@@ -538,7 +539,7 @@ describe("SocketConnectionInternals", () => {
                 expiry: { type: "seconds", count: 10 },
             });
 
-            await expect(await request1).toMatch("OK");
+            expect(await request1).toMatch("OK");
         });
     });
 


### PR DESCRIPTION
#1507 
The set command options are not functioning properly.
We found out about it thanks to @Ealenn open an issue.

In order to avoid the repetition of similar bugs, the PR incorporates a fix and a large quantity of tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
