### PR TITLE
Java: PoC: Handle binary strings from GLIDE

### DIFF
--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -30,6 +30,7 @@ import glide.api.commands.ConnectionManagementCommands;
 import glide.api.commands.GenericCommands;
 import glide.api.commands.ScriptingAndFunctionsCommands;
 import glide.api.commands.ServerManagementCommands;
+import glide.api.models.GlideString;
 import glide.api.models.Transaction;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions;
@@ -69,6 +70,11 @@ public class RedisClient extends BaseClient
     @Override
     public CompletableFuture<Object> customCommand(@NonNull String[] args) {
         return commandManager.submitNewCommand(CustomCommand, args, this::handleObjectOrNullResponse);
+    }
+
+    public CompletableFuture<Object> customCommandBinary(@NonNull GlideString[] args) {
+        return commandManager.submitNewCommand(
+                CustomCommand, args, this::handleBinaryObjectOrNullResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -32,6 +32,7 @@ import glide.api.commands.ScriptingAndFunctionsClusterCommands;
 import glide.api.commands.ServerManagementClusterCommands;
 import glide.api.models.ClusterTransaction;
 import glide.api.models.ClusterValue;
+import glide.api.models.GlideString;
 import glide.api.models.commands.FlushMode;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.configuration.RedisClusterClientConfiguration;
@@ -77,6 +78,13 @@ public class RedisClusterClient extends BaseClient
         // TODO if a command returns a map as a single value, ClusterValue misleads user
         return commandManager.submitNewCommand(
                 CustomCommand, args, response -> ClusterValue.of(handleObjectOrNullResponse(response)));
+    }
+
+    public CompletableFuture<ClusterValue<Object>> customCommandBinary(@NonNull GlideString[] args) {
+        return commandManager.submitNewCommand(
+                CustomCommand,
+                args,
+                response -> ClusterValue.of(handleBinaryObjectOrNullResponse(response)));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/models/GlideString.java
+++ b/java/client/src/main/java/glide/api/models/GlideString.java
@@ -1,0 +1,90 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Getter;
+
+// TODO docs for the god of docs
+public class GlideString {
+
+    @Getter private byte[] bytes;
+    private String string = null;
+
+    /** Flag whether possibility to convert to string was checked. */
+    private final AtomicBoolean conversionChecked = new AtomicBoolean(false);
+
+    private GlideString() {}
+
+    public static GlideString of(String string) {
+        var res = new GlideString();
+        res.string = string;
+        res.bytes = string.getBytes(StandardCharsets.UTF_8);
+        return res;
+    }
+
+    public static GlideString of(byte[] bytes) {
+        var res = new GlideString();
+        res.bytes = bytes;
+        return res;
+    }
+
+    @Override
+    public String toString() {
+        return getString();
+    }
+
+    public String getString() {
+        if (string != null) {
+            return string;
+        }
+
+        assert canConvertToString() : "Value cannot be represented as a string";
+        return string;
+    }
+
+    public boolean canConvertToString() {
+        if (string != null) {
+            return true;
+        }
+
+        // double-checked locking
+        if (conversionChecked.get()) {
+            return false;
+        } else {
+            synchronized (this) {
+                if (conversionChecked.get()) {
+                    return false;
+                } else
+                    try {
+                        // TODO find a better way to check this
+                        // Detect whether `bytes` could be represented by a `String` without data corruption
+                        var tmpStr = new String(bytes, StandardCharsets.UTF_8);
+                        if (Arrays.equals(bytes, tmpStr.getBytes(StandardCharsets.UTF_8))) {
+                            string = tmpStr;
+                            return true;
+                        } else {
+                            return false;
+                        }
+                    } finally {
+                        conversionChecked.set(true);
+                    }
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GlideString)) return false;
+        GlideString that = (GlideString) o;
+
+        return Arrays.equals(bytes, that.bytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(bytes);
+    }
+}

--- a/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
+++ b/java/client/src/main/java/glide/managers/BaseCommandResponseResolver.java
@@ -3,6 +3,7 @@ package glide.managers;
 
 import static glide.api.BaseClient.OK;
 
+import glide.api.models.GlideString;
 import glide.api.models.exceptions.RedisException;
 import lombok.AllArgsConstructor;
 import response.ResponseOuterClass.Response;
@@ -27,7 +28,7 @@ public class BaseCommandResponseResolver
         assert !response.hasRequestError() : "Unhandled response request error";
 
         if (response.hasConstantResponse()) {
-            return OK;
+            return GlideString.of(OK);
         }
         if (response.hasRespPointer()) {
             // Return the shared value - which may be a null value

--- a/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
+++ b/java/client/src/main/java/glide/utils/ArrayTransformUtils.java
@@ -2,6 +2,7 @@
 package glide.utils;
 
 import glide.api.commands.GeospatialIndicesBaseCommands;
+import glide.api.models.GlideString;
 import glide.api.models.commands.geospatial.GeospatialData;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -23,6 +24,13 @@ public class ArrayTransformUtils {
         return args.entrySet().stream()
                 .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue().toString()))
                 .toArray(String[]::new);
+    }
+
+    public static GlideString[] convertMapToKeyValueBinaryStringArray(
+            Map<GlideString, GlideString> args) {
+        return args.entrySet().stream()
+                .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
+                .toArray(GlideString[]::new);
     }
 
     /**

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -35,6 +35,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Time;
 
 import glide.api.models.ClusterTransaction;
 import glide.api.models.ClusterValue;
+import glide.api.models.GlideString;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.function.FunctionLoadOptions;
 import glide.api.models.configuration.RequestRoutingConfiguration.Route;
@@ -75,7 +76,7 @@ public class RedisClusterClientTest {
     public void custom_command_returns_single_value() {
         var commandManager = new TestCommandManager(null);
 
-        try (var client = new TestClient(commandManager, "TEST")) {
+        try (var client = new TestClient(commandManager, GlideString.of("TEST"))) {
             var value = client.customCommand(TEST_ARGS).get();
             assertEquals("TEST", value.getSingleValue());
         }
@@ -125,7 +126,7 @@ public class RedisClusterClientTest {
                 new TestCommandManager(
                         Response.newBuilder().setConstantResponse(ConstantResponse.OK).build());
 
-        try (var client = new TestClient(commandManager, "OK")) {
+        try (var client = new TestClient(commandManager, GlideString.of("OK"))) {
             var value = client.customCommand(TEST_ARGS, ALL_NODES).get();
             assertEquals("OK", value.getSingleValue());
         }
@@ -141,10 +142,9 @@ public class RedisClusterClientTest {
         }
 
         @Override
+        @SuppressWarnings("unchecked")
         protected <T> T handleRedisResponse(Class<T> classType, boolean isNullable, Response response) {
-            @SuppressWarnings("unchecked")
-            T returnValue = (T) object;
-            return returnValue;
+            return (T) object;
         }
 
         @Override
@@ -432,7 +432,7 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = "info string";
-        try (var client = new TestClient(commandManager, data)) {
+        try (var client = new TestClient(commandManager, GlideString.of(data))) {
             var value = client.info(RANDOM).get();
             assertAll(
                     () -> assertTrue(value.hasSingleData()),
@@ -459,7 +459,7 @@ public class RedisClusterClientTest {
         var commandManager = new TestCommandManager(null);
 
         var data = "info string";
-        try (var client = new TestClient(commandManager, data)) {
+        try (var client = new TestClient(commandManager, GlideString.of(data))) {
             var value = client.info(InfoOptions.builder().build(), RANDOM).get();
             assertAll(
                     () -> assertTrue(value.hasSingleData()),
@@ -547,7 +547,7 @@ public class RedisClusterClientTest {
     public void clientGetName_with_single_node_route_returns_success() {
         var commandManager = new TestCommandManager(null);
 
-        try (var client = new TestClient(commandManager, "TEST")) {
+        try (var client = new TestClient(commandManager, GlideString.of("TEST"))) {
             var value = client.clientGetName(RANDOM).get();
             assertEquals("TEST", value.getSingleValue());
         }

--- a/java/integTest/src/test/java/glide/SharedClientTests.java
+++ b/java/integTest/src/test/java/glide/SharedClientTests.java
@@ -5,12 +5,16 @@ import static glide.TestUtilities.commonClientConfig;
 import static glide.TestUtilities.commonClusterClientConfig;
 import static glide.TestUtilities.getRandomString;
 import static glide.api.BaseClient.OK;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import glide.api.BaseClient;
 import glide.api.RedisClient;
 import glide.api.RedisClusterClient;
+import glide.api.models.GlideString;
+import glide.api.models.commands.SetOptions;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -20,12 +24,11 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@Timeout(25) // seconds
+// @Timeout(25) // seconds
 public class SharedClientTests {
 
     private static RedisClient standaloneClient = null;
@@ -69,11 +72,92 @@ public class SharedClientTests {
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
     public void send_and_receive_non_ascii_unicode(BaseClient client) {
-        String key = "foo";
-        String value = "\u05E9\u05DC\u05D5\u05DD hello \u6C49\u5B57";
+        GlideString key = GlideString.of("foo");
+        GlideString value1 = GlideString.of("\u05E9\u05DC\u05D5\u05DD hello \u6C49\u5B57");
 
-        assertEquals(OK, client.set(key, value).get());
-        assertEquals(value, client.get(key).get());
+        assertEquals(OK, client.setBinary(key, value1).get());
+        assertEquals(value1, client.getBinary(key).get());
+
+        // Test all possible 1 byte symbols (some of them are ASCII, some of them - not)
+        byte[] arr = new byte[255];
+        for (var i = 0; i < arr.length; i++) {
+            arr[i] = (byte) i;
+        }
+        GlideString value2 = GlideString.of(arr);
+
+        assertEquals(OK, client.setBinary(key, value2).get());
+        assertEquals(value2, client.getBinary(key).get());
+
+        // Test all possible 2 byte symbols (most of them are UTF-8, some of them - not)
+        StringBuilder value3builder = new StringBuilder();
+        for (var i = 0; i < 0xFFFF; i++) {
+            // code points in the range of 0xD800 to 0xDFFF are removed from the Unicode character set
+            // redis doesn't store them (replaced by `?` signs = 0x3F)
+            if (i < 0xD800 || i > 0xDFFF) {
+                value3builder.append(Character.toChars(i));
+            }
+        }
+        GlideString value3 = GlideString.of(value3builder.toString());
+
+        assertEquals(OK, client.setBinary(key, value3).get());
+        var res = client.getBinary(key).get();
+        assertEquals(value3, res);
+
+        // test set with options
+        var options = SetOptions.builder().returnOldValue(true).build();
+        assertEquals(value3, client.setBinary(key, value2, options).get());
+        assertEquals(value2, client.getBinary(key).get());
+
+        // test mset
+        var data =
+                Map.of(
+                        GlideString.of("unicode1"),
+                        value1,
+                        GlideString.of("unicode2"),
+                        value2,
+                        GlideString.of("unicode3"),
+                        value3);
+        assertEquals(OK, client.msetBinary(data).get());
+
+        // test mget
+        assertArrayEquals(
+                data.values().toArray(GlideString[]::new),
+                client.mgetBinary(data.keySet().toArray(new GlideString[0])).get());
+
+        // test dump-restore
+        // TODO replace with commands when implemented
+        // var dumpCmd = new String[] { "DUMP", "unicode2" };
+        var dumpCmd = new GlideString[] {GlideString.of("DUMP"), key};
+        if (client instanceof RedisClient) {
+            var dump = ((RedisClient) client).customCommandBinary(dumpCmd).get();
+            var restoreCmd =
+                    new GlideString[] {
+                        GlideString.of("RESTORE"),
+                        GlideString.of("unicode4"),
+                        GlideString.of("0"),
+                        (GlideString) dump,
+                        GlideString.of("REPLACE")
+                    };
+            assertEquals(
+                    GlideString.of(OK), ((RedisClient) client).customCommandBinary(restoreCmd).get());
+        } else {
+            var dump = ((RedisClusterClient) client).customCommandBinary(dumpCmd).get().getSingleValue();
+            var restoreCmd =
+                    new GlideString[] {
+                        GlideString.of("RESTORE"),
+                        GlideString.of("unicode4"),
+                        GlideString.of("0"),
+                        (GlideString) dump,
+                        GlideString.of("REPLACE")
+                    };
+            assertEquals(
+                    GlideString.of(OK),
+                    ((RedisClusterClient) client).customCommandBinary(restoreCmd).get().getSingleValue());
+        }
+        // compare values
+        assertEquals(
+                client.getBinary(GlideString.of("unicode4")).get(),
+                client.getBinary(GlideString.of("unicode2")).get());
     }
 
     private static Stream<Arguments> clientAndDataSize() {

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4211,7 +4211,8 @@ public class SharedCommandTests {
         // TODO: update once fix is implemented for https://github.com/aws/glide-for-redis/issues/1447
         ExecutionException executionException =
                 assertThrows(ExecutionException.class, () -> client.get(destination).get());
-        assertTrue(executionException.getCause() instanceof RuntimeException);
+        assertTrue(executionException.getCause() instanceof AssertionError);
+
         assertEquals(0, client.setbit(key1, 0, 1).get());
         assertEquals(1L, client.bitop(BitwiseOperation.NOT, destination, new String[] {key1}).get());
         assertEquals("\u001e", client.get(destination).get());
@@ -4233,6 +4234,7 @@ public class SharedCommandTests {
                 assertThrows(
                         ExecutionException.class,
                         () -> client.bitop(BitwiseOperation.AND, destination, new String[] {emptyKey1}).get());
+        assertTrue(executionException.getCause() instanceof RequestException);
 
         // Source keys is an empty list
         executionException =


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Alternate solution for changes from https://github.com/aws/glide-for-redis/pull/1526, https://github.com/aws/glide-for-redis/pull/1535, https://github.com/aws/glide-for-redis/pull/1537

This PR shows PoC of how we can implement support of binary strings in java client/wrapper.
TLDR using `Union[str, byte[]]` like in python

**Some technical details:**
1. Added union-like class `GlideString` (hereby `GS`)
2. `lib.rs` returns `GlideString`s instead of `String`s to the java wrapper
3. Temporary added binary versions of get/set API
4. Added number of shims (e.g. `convertGlideStringsToStrings`) to keep all rest API working - all tests pass
5. Test `send_and_receive_non_ascii_unicode` in `SharedClientTests.java` shows how it works


**Future steps if this gets a green light:**
1. Return `String` when `SimpleString` (hereby `SS`) or `VerbatimString` (`VS`) received from redis.
2. Update response conversion in GLIDE - we convert `SS` and `VS` to `BS` there
3. Remove temporary added APIs
4. Remove shims (`convertGlideStringsToStrings`)
5. Update `handleStringRepsonse` and `handleBinaryStringRepsonse` - first should be used for `SS` and `VS`, second for `BS`
6. Update all API for commands which receive `BS` to return `GS`
7. Update all API for commands which load user data to the server (duplicate if we want to keep user API as simple as possible)
8. Update docs (examples)
9. Update check whether binary string is convertable to a regular java `String` (see `GlideString.java:61`)

**Procs**
1. Works with complex nested structs like `Map<String, Map<String, Object>[]>[]` or `Map<String, Map<String, GlideString[][]>>`
2. Simple change to existing API - just replace `String` with `GlideString` where it is applicable
3. Could be split to complete after GA without introducing breaking changes

**Cons**
1. Big change (it is unavoidable)
2. Requires extra attention to details if we won't convert `SS` & `VS` to `GS`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
