### PR TITLE
Node: add SUNIONSTORE command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Python: Added SORT command ([#1439](https://github.com/aws/glide-for-redis/pull/1439))
 * Node: Added OBJECT ENCODING command ([#1518](https://github.com/aws/glide-for-redis/pull/1518))
 * Python: Added LMOVE and BLMOVE commands ([#1536](https://github.com/aws/glide-for-redis/pull/1536))
+* Node: Added SUNIONSTORE command ([#1549](https://github.com/aws/glide-for-redis/pull/1549))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1314,6 +1314,7 @@ export class BaseClient {
      * @param destination - The key of the destination set.
      * @param keys - The keys from which to retrieve the set members.
      * @returns The number of elements in the resulting set.
+     *
      * @example
      * ```typescript
      * const length = await client.sunionstore("mySet", ["set1", "set2"]);

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -94,6 +94,7 @@ import {
     createZRemRangeByRank,
     createZRemRangeByScore,
     createZScore,
+    createSUnionStore,
 } from "./Commands";
 import {
     ClosingError,
@@ -1301,6 +1302,26 @@ export class BaseClient {
         return this.createWritePromise<string[]>(createSInter(keys)).then(
             (sinter) => new Set<string>(sinter),
         );
+    }
+
+    /**
+     * Stores the members of the union of all given sets specified by `keys` into a new set
+     * at `destination`.
+     *
+     * See https://valkey.io/commands/sunionstore/ for details.
+     *
+     * @remarks When in cluster mode, `destination` and all `keys` must map to the same hash slot.
+     * @param destination - The key of the destination set.
+     * @param keys - The keys from which to retrieve the set members.
+     * @returns The number of elements in the resulting set.
+     * @example
+     * ```typescript
+     * const length = await client.sunionstore("mySet", ["set1", "set2"]);
+     * console.log(length); // Output: 2 - Two elements were stored in "mySet", and those two members are the union of "set1" and "set2".
+     * ```
+     */
+    public sunionstore(destination: string, keys: string[]): Promise<number> {
+        return this.createWritePromise(createSUnionStore(destination, keys));
     }
 
     /** Returns if `member` is a member of the set stored at `key`.

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -602,6 +602,16 @@ export function createSInter(keys: string[]): redis_request.Command {
 /**
  * @internal
  */
+export function createSUnionStore(
+    destination: string,
+    keys: string[],
+): redis_request.Command {
+    return createCommand(RequestType.SUnionStore, [destination].concat(keys));
+}
+
+/**
+ * @internal
+ */
 export function createSIsMember(
     key: string,
     member: string,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -99,6 +99,7 @@ import {
     createZRemRangeByRank,
     createZRemRangeByScore,
     createZScore,
+    createSUnionStore,
 } from "./Commands";
 import { redis_request } from "./ProtobufMessage";
 
@@ -721,6 +722,21 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public sinter(keys: string[]): T {
         return this.addAndReturn(createSInter(keys), true);
+    }
+
+    /**
+     * Stores the members of the union of all given sets specified by `keys` into a new set
+     * at `destination`.
+     *
+     * See https://valkey.io/commands/sunionstore/ for details.
+     *
+     * @param destination - The key of the destination set.
+     * @param keys - The keys from which to retrieve the set members.
+     *
+     * Command Response - The number of elements in the resulting set.
+     */
+    public sunionstore(destination: string, keys: string[]): T {
+        return this.addAndReturn(createSUnionStore(destination, keys));
     }
 
     /** Returns if `member` is a member of the set stored at `key`.

--- a/node/tests/RedisClusterClient.test.ts
+++ b/node/tests/RedisClusterClient.test.ts
@@ -289,6 +289,7 @@ describe("RedisClusterClient", () => {
                 client.renamenx("abc", "zxy"),
                 client.sinter(["abc", "zxy", "lkn"]),
                 client.zinterstore("abc", ["zxy", "lkn"]),
+                client.sunionstore("abc", ["zxy", "lkn"]),
                 // TODO all rest multi-key commands except ones tested below
             ];
 

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -305,6 +305,8 @@ export async function transactionTest(
     args.push([field + "2", field + "1"]);
     baseTransaction.sadd(key7, ["bar", "foo"]);
     args.push(2);
+    baseTransaction.sunionstore(key7, [key7, key7]);
+    args.push(2);
     baseTransaction.sinter([key7, key7]);
     args.push(new Set(["bar", "foo"]));
     baseTransaction.srem(key7, ["foo"]);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/sunionstore/
- Stores the members of the union of all sets specified by the `keys` arg into a new set
at `destination`
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/sunionstore.json))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
