### PR TITLE
Node: add ZINTERCARD command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Node: Added OBJECT FREQ command ([#1542](https://github.com/aws/glide-for-redis/pull/1542))
 * Node: Added LINSERT command ([#1544](https://github.com/aws/glide-for-redis/pull/1544))
 * Node: Added XLEN command ([#1555](https://github.com/aws/glide-for-redis/pull/1555))
+* Node: Added ZINTERCARD command ([#1553](https://github.com/aws/glide-for-redis/pull/1553))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -1778,7 +1778,7 @@ export class BaseClient {
      *
      * @example
      * ```typescript
-     * const cardinality = await client.zintercard(["key1", "key2"]);
+     * const cardinality = await client.zintercard(["key1", "key2"], 10);
      * console.log(cardinality); // Output: 3 - The intersection of the sorted sets at "key1" and "key2" has a cardinality of 3.
      * ```
      */

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -100,6 +100,7 @@ import {
     createZScore,
     createSUnionStore,
     createXLen,
+    createZInterCard,
 } from "./Commands";
 import {
     ClosingError,
@@ -1760,6 +1761,29 @@ export class BaseClient {
      */
     public zcard(key: string): Promise<number> {
         return this.createWritePromise(createZCard(key));
+    }
+
+    /**
+     * Returns the cardinality of the intersection of the sorted sets specified by `keys`.
+     *
+     * See https://valkey.io/commands/zintercard/ for more details.
+     *
+     * @remarks When in cluster mode, all `keys` must map to the same hash slot.
+     * @param keys - The keys of the sorted sets to intersect.
+     * @param limit - An optional argument that can be used to specify a maximum number for the
+     * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
+     * @returns The cardinality of the intersection of the given sorted sets.
+     *
+     * since - Redis version 7.0.0.
+     *
+     * @example
+     * ```typescript
+     * const cardinality = await client.zintercard(["key1", "key2"]);
+     * console.log(cardinality); // Output: 3 - The intersection of the sorted sets at "key1" and "key2" has a cardinality of 3.
+     * ```
+     */
+    public zintercard(keys: string[], limit?: number): Promise<number> {
+        return this.createWritePromise(createZInterCard(keys, limit));
     }
 
     /** Returns the score of `member` in the sorted set stored at `key`.

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -901,6 +901,23 @@ export function createZCard(key: string): redis_request.Command {
 /**
  * @internal
  */
+export function createZInterCard(
+    keys: string[],
+    limit?: number,
+): redis_request.Command {
+    let args: string[] = keys;
+    args.unshift(keys.length.toString());
+
+    if (limit != undefined) {
+        args = args.concat(["LIMIT", limit.toString()]);
+    }
+
+    return createCommand(RequestType.ZInterCard, args);
+}
+
+/**
+ * @internal
+ */
 export function createZScore(
     key: string,
     member: string,

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -105,6 +105,7 @@ import {
     createZScore,
     createSUnionStore,
     createXLen,
+    createZInterCard,
 } from "./Commands";
 import { redis_request } from "./ProtobufMessage";
 
@@ -977,6 +978,23 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public zcard(key: string): T {
         return this.addAndReturn(createZCard(key));
+    }
+
+    /**
+     * Returns the cardinality of the intersection of the sorted sets specified by `keys`.
+     *
+     * See https://valkey.io/commands/zintercard/ for more details.
+     *
+     * @param keys - The keys of the sorted sets to intersect.
+     * @param limit - An optional argument that can be used to specify a maximum number for the
+     * intersection cardinality. If limit is not supplied, or if it is set to `0`, there will be no limit.
+     *
+     * Command Response - The cardinality of the intersection of the given sorted sets.
+     *
+     * since - Redis version 7.0.0.
+     */
+    public zintercard(keys: string[], limit?: number): T {
+        return this.addAndReturn(createZInterCard(keys, limit));
     }
 
     /** Returns the score of `member` in the sorted set stored at `key`.

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1637,6 +1637,47 @@ export function runBaseTests<Context>(config: {
     );
 
     it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        `zintercard test_%p`,
+        async (protocol) => {
+            await runTest(async (client: BaseClient) => {
+                if (await checkIfServerVersionLessThan("7.0.0")) {
+                    return;
+                }
+
+                const key1 = `{key}:${uuidv4()}`;
+                const key2 = `{key}:${uuidv4()}`;
+                const stringKey = `{key}:${uuidv4()}`;
+                const nonExistingKey = `{key}:${uuidv4()}`;
+                const memberScores1 = { one: 1, two: 2, three: 3 };
+                const memberScores2 = { two: 2, three: 3, four: 4 };
+
+                expect(await client.zadd(key1, memberScores1)).toEqual(3);
+                expect(await client.zadd(key2, memberScores2)).toEqual(3);
+
+                expect(await client.zintercard([key1, key2])).toEqual(2);
+                expect(await client.zintercard([key1, nonExistingKey])).toEqual(
+                    0,
+                );
+
+                expect(await client.zintercard([key1, key2], 0)).toEqual(2);
+                expect(await client.zintercard([key1, key2], 1)).toEqual(1);
+                expect(await client.zintercard([key1, key2], 2)).toEqual(2);
+
+                // invalid argument - key list must not be empty
+                await expect(client.zintercard([])).rejects.toThrow();
+
+                // invalid argument - limit must be non-negative
+                await expect(client.zintercard([], -1)).rejects.toThrow();
+
+                // key exists, but it is not a sorted set
+                expect(await client.set(stringKey, "foo")).toEqual("OK");
+                await expect(client.zintercard([stringKey])).rejects.toThrow();
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
         `zscore test_%p`,
         async (protocol) => {
             await runTest(async (client: BaseClient) => {

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -1667,7 +1667,9 @@ export function runBaseTests<Context>(config: {
                 await expect(client.zintercard([])).rejects.toThrow();
 
                 // invalid argument - limit must be non-negative
-                await expect(client.zintercard([], -1)).rejects.toThrow();
+                await expect(
+                    client.zintercard([key1, key2], -1),
+                ).rejects.toThrow();
 
                 // key exists, but it is not a sorted set
                 expect(await client.set(stringKey, "foo")).toEqual("OK");

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -232,6 +232,7 @@ export async function transactionTest(
     const key11 = "{key}" + uuidv4(); // hyper log log
     const key12 = "{key}" + uuidv4();
     const key13 = "{key}" + uuidv4();
+    const key14 = "{key}" + uuidv4(); // sorted set
     const field = uuidv4();
     const value = uuidv4();
     const args: ReturnType[] = [];
@@ -380,7 +381,17 @@ export async function transactionTest(
         "negativeInfinity",
         "positiveInfinity",
     );
-    args.push(1);
+    args.push(1); // key8 is now empty
+
+    if (!(await checkIfServerVersionLessThan("7.0.0"))) {
+        baseTransaction.zadd(key14, { one: 1.0, two: 2.0 });
+        args.push(2);
+        baseTransaction.zintercard([key8, key14]);
+        args.push(0);
+        baseTransaction.zintercard([key8, key14], 1);
+        args.push(0);
+    }
+
     baseTransaction.xadd(key9, [["field", "value1"]], { id: "0-1" });
     args.push("0-1");
     baseTransaction.xadd(key9, [["field", "value2"]], { id: "0-2" });


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://valkey.io/commands/zintercard/
- Returns the cardinality of the intersection of the sorted sets specified by the given keys.
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/zintercard.json)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
