### PR TITLE
Java: Add the `XGROUP CREATE` and `XGROUP DESTROY` commands 

### DIFF
--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -700,9 +700,8 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
         }),
         b"INCRBYFLOAT" | b"HINCRBYFLOAT" | b"ZINCRBY" => Some(ExpectedReturnType::Double),
         b"HEXISTS" | b"HSETNX" | b"EXPIRE" | b"EXPIREAT" | b"PEXPIRE" | b"PEXPIREAT"
-        | b"SISMEMBER" | b"PERSIST" | b"SMOVE" | b"RENAMENX" | b"MOVE" | b"COPY" => {
-            Some(ExpectedReturnType::Boolean)
-        }
+        | b"SISMEMBER" | b"PERSIST" | b"SMOVE" | b"RENAMENX" | b"MOVE" | b"COPY"
+        | b"XGROUP DESTROY" => Some(ExpectedReturnType::Boolean),
         b"SMISMEMBER" => Some(ExpectedReturnType::ArrayOfBools),
         b"SMEMBERS" | b"SINTER" | b"SDIFF" => Some(ExpectedReturnType::Set),
         b"ZSCORE" | b"GEODIST" => Some(ExpectedReturnType::DoubleOrNull),

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -115,6 +115,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.XDel;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
@@ -179,6 +181,7 @@ import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
@@ -1356,6 +1359,29 @@ public abstract class BaseClient
                 XRevRange,
                 arguments,
                 response -> castMapOf2DArray(handleMapResponse(response), String.class));
+    }
+
+    @Override
+    public CompletableFuture<String> xgroupCreate(
+            @NonNull String key, @NonNull String groupname, @NonNull String id) {
+        return commandManager.submitNewCommand(
+                XGroupCreate, new String[] {key, groupname, id}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> xgroupCreate(
+            @NonNull String key,
+            @NonNull String groupname,
+            @NonNull String id,
+            @NonNull StreamGroupOptions options) {
+        String[] arguments = concatenateArrays(new String[] {key, groupname, id}, options.toArgs());
+        return commandManager.submitNewCommand(XGroupCreate, arguments, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> xgroupDestroy(@NonNull String key, @NonNull String groupname) {
+        return commandManager.submitNewCommand(
+                XGroupDestroy, new String[] {key, groupname}, this::handleBooleanResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -3,6 +3,7 @@ package glide.api.commands;
 
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamAddOptions.StreamAddOptionsBuilder;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
@@ -23,7 +24,7 @@ public interface StreamBaseCommands {
      * Adds an entry to the specified stream stored at <code>key</code>.<br>
      * If the <code>key</code> doesn't exist, the stream is created.
      *
-     * @see <a href="https://redis.io/commands/xadd/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xadd/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param values Field-value pairs to be added to the entry.
      * @return The id of the added entry.
@@ -39,7 +40,7 @@ public interface StreamBaseCommands {
      * Adds an entry to the specified stream stored at <code>key</code>.<br>
      * If the <code>key</code> doesn't exist, the stream is created.
      *
-     * @see <a href="https://redis.io/commands/xadd/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xadd/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param values Field-value pairs to be added to the entry.
      * @param options Stream add options {@link StreamAddOptions}.
@@ -63,7 +64,7 @@ public interface StreamBaseCommands {
      *
      * @apiNote When in cluster mode, all keys in <code>keysAndIds</code> must map to the same hash
      *     slot.
-     * @see <a href="https://redis.io/commands/xread/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xread/">valkey.io</a> for details.
      * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
@@ -89,7 +90,7 @@ public interface StreamBaseCommands {
      *
      * @apiNote When in cluster mode, all keys in <code>keysAndIds</code> must map to the same hash
      *     slot.
-     * @see <a href="https://redis.io/commands/xread/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xread/">valkey.io</a> for details.
      * @param keysAndIds A <code>Map</code> of keys and entry ids to read from. The <code>
      *     Map</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
@@ -117,7 +118,7 @@ public interface StreamBaseCommands {
     /**
      * Trims the stream by evicting older entries.
      *
-     * @see <a href="https://redis.io/commands/xtrim/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xtrim/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param options Stream trim options {@link StreamTrimOptions}.
      * @return The number of entries deleted from the stream.
@@ -169,6 +170,7 @@ public interface StreamBaseCommands {
     /**
      * Returns stream entries matching a given range of IDs.
      *
+     * @see <a href="https://valkey.io/commands/xrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param start Starting stream ID bound for range.
      *     <ul>
@@ -205,6 +207,7 @@ public interface StreamBaseCommands {
     /**
      * Returns stream entries matching a given range of IDs.
      *
+     * @see <a href="https://valkey.io/commands/xrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param start Starting stream ID bound for range.
      *     <ul>
@@ -242,6 +245,7 @@ public interface StreamBaseCommands {
      * Equivalent to {@link #xrange(String, StreamRange, StreamRange)} but returns the entries in
      * reverse order.
      *
+     * @see <a href="https://valkey.io/commands/xrevrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param end Ending stream ID bound for range.
      *     <ul>
@@ -281,6 +285,7 @@ public interface StreamBaseCommands {
      * Equivalent to {@link #xrange(String, StreamRange, StreamRange, long)} but returns the entries
      * in reverse order.
      *
+     * @see <a href="https://valkey.io/commands/xrevrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param end Ending stream ID bound for range.
      *     <ul>
@@ -312,4 +317,59 @@ public interface StreamBaseCommands {
      */
     CompletableFuture<Map<String, String[][]>> xrevrange(
             String key, StreamRange end, StreamRange start, long count);
+
+    /**
+     * Creates a new consumer group uniquely identified by <code>groupname</code> for the stream
+     * stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
+     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
+     *     stream.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * // Create the consumer group "mygroup", using zero as the starting ID:
+     * assert client.xgroupCreate("mystream", "mygroup", "0-0").get().equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> xgroupCreate(String key, String groupname, String id);
+
+    /**
+     * Creates a new consumer group uniquely identified by <code>groupname</code> for the stream
+     * stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
+     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
+     *     stream.
+     * @param options The group options {@link StreamGroupOptions}.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
+     * assert client.xgroupCreate("mystream", "mygroup", "$", new StreamGroupOptions(true)).get().equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> xgroupCreate(
+            String key, String groupname, String id, StreamGroupOptions options);
+
+    /**
+     * Destroys the consumer group <code>groupname</code> for the stream stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-destroy/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @return <code>true</code> if the consumer group is destroyed. Otherwise, <code>false</code>.
+     * @example
+     *     <pre>{@code
+     * // Destroys the consumer group "mygroup"
+     * assert client.xgroupDestroy("mystream", "mygroup").get().equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<Boolean> xgroupDestroy(String key, String groupname);
 }

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -325,9 +325,9 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupname The newly created consumer group name.
-     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
-     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
-     *     stream.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
@@ -344,9 +344,9 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupname The newly created consumer group name.
-     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
-     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
-     *     stream.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
      * @param options The group options {@link StreamGroupOptions}.
      * @return <code>OK</code>.
      * @example

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -140,6 +140,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.XDel;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
@@ -216,6 +218,7 @@ import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
 import glide.api.models.commands.stream.StreamAddOptions.StreamAddOptionsBuilder;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
@@ -2619,7 +2622,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Adds an entry to the specified stream stored at <code>key</code>.<br>
      * If the <code>key</code> doesn't exist, the stream is created.
      *
-     * @see <a href="https://redis.io/commands/xadd/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xadd/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param values Field-value pairs to be added to the entry.
      * @return Command Response - The id of the added entry.
@@ -2632,7 +2635,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Adds an entry to the specified stream stored at <code>key</code>.<br>
      * If the <code>key</code> doesn't exist, the stream is created.
      *
-     * @see <a href="https://redis.io/commands/xadd/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xadd/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param values Field-value pairs to be added to the entry.
      * @param options Stream add options {@link StreamAddOptions}.
@@ -2653,7 +2656,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Reads entries from the given streams.
      *
-     * @see <a href="https://redis.io/commands/xread/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xread/">valkey.io</a> for details.
      * @param keysAndIds An array of <code>Pair</code>s of keys and entry ids to read from. A <code>
      *     pair</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
@@ -2667,7 +2670,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Reads entries from the given streams.
      *
-     * @see <a href="https://redis.io/commands/xread/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xread/">valkey.io</a> for details.
      * @param keysAndIds An array of <code>Pair</code>s of keys and entry ids to read from. A <code>
      *     pair</code> is composed of a stream's key and the id of the entry after which the stream
      *     will be read.
@@ -2683,7 +2686,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Trims the stream by evicting older entries.
      *
-     * @see <a href="https://redis.io/commands/xtrim/">redis.io</a> for details.
+     * @see <a href="https://valkey.io/commands/xtrim/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param options Stream trim options {@link StreamTrimOptions}.
      * @return Command Response - The number of entries deleted from the stream.
@@ -2726,6 +2729,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns stream entries matching a given range of IDs.
      *
+     * @see <a href="https://valkey.io/commands/xrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param start Starting stream ID bound for range.
      *     <ul>
@@ -2754,6 +2758,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     /**
      * Returns stream entries matching a given range of IDs.
      *
+     * @see <a href="https://valkey.io/commands/xrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param start Starting stream ID bound for range.
      *     <ul>
@@ -2787,6 +2792,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Equivalent to {@link #xrange(String, StreamRange, StreamRange)} but returns the entries in
      * reverse order.
      *
+     * @see <a href="https://valkey.io/commands/xrevrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param end Ending stream ID bound for range.
      *     <ul>
@@ -2817,6 +2823,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * Equivalent to {@link #xrange(String, StreamRange, StreamRange, long)} but returns the entries
      * in reverse order.
      *
+     * @see <a href="https://valkey.io/commands/xrevrange/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param start Starting stream ID bound for range.
      *     <ul>
@@ -2842,6 +2849,61 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
         ArgsArray commandArgs =
                 buildArgs(ArrayUtils.addFirst(StreamRange.toArgs(end, start, count), key));
         protobufTransaction.addCommands(buildCommand(XRevRange, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Creates a new consumer group uniquely identified by <code>groupname</code> for the stream
+     * stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
+     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
+     *     stream.
+     * @return Command Response - <code>OK</code>.
+     */
+    public T xgroupCreate(@NonNull String key, @NonNull String groupname, @NonNull String id) {
+        protobufTransaction.addCommands(buildCommand(XGroupCreate, buildArgs(key, groupname, id)));
+        return getThis();
+    }
+
+    /**
+     * Creates a new consumer group uniquely identified by <code>groupname</code> for the stream
+     * stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
+     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
+     *     stream.
+     * @param options The group options {@link StreamGroupOptions}.
+     * @return Command Response - <code>OK</code>.
+     */
+    public T xgroupCreate(
+            @NonNull String key,
+            @NonNull String groupname,
+            @NonNull String id,
+            @NonNull StreamGroupOptions options) {
+        ArgsArray commandArgs =
+                buildArgs(concatenateArrays(new String[] {key, groupname, id}, options.toArgs()));
+        protobufTransaction.addCommands(buildCommand(XGroupCreate, commandArgs));
+        return getThis();
+    }
+
+    /**
+     * Destroys the consumer group <code>groupname</code> for the stream stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-destroy/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupname The newly created consumer group name.
+     * @return Command Response - <code>true</code> if the consumer group is destroyed. Otherwise,
+     *     <code>false</code>.
+     */
+    public T xgroupDestroy(@NonNull String key, @NonNull String groupname) {
+        protobufTransaction.addCommands(buildCommand(XGroupDestroy, buildArgs(key, groupname)));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -2878,9 +2878,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupname The newly created consumer group name.
-     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
-     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
-     *     stream.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
      * @return Command Response - <code>OK</code>.
      */
     public T xgroupCreate(@NonNull String key, @NonNull String groupname, @NonNull String id) {
@@ -2895,9 +2895,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupname The newly created consumer group name.
-     * @param id Stream ID that specifies the last delivered entry in the stream from the new group’s
-     *     perspective. The special ID <code>"$"</code> can be used to specify the last entry in the
-     *     stream.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
      * @param options The group options {@link StreamGroupOptions}.
      * @return Command Response - <code>OK</code>.
      */

--- a/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
@@ -1,0 +1,89 @@
+/** Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.api.models.commands.stream;
+
+import glide.api.commands.StreamBaseCommands;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Optional arguments for {@link StreamBaseCommands#xgroupCreate(String, String, String,
+ * StreamGroupOptions)}
+ *
+ * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a>
+ */
+public final class StreamGroupOptions {
+
+    public static final String MAKE_STREAM_REDIS_API = "MKSTREAM";
+    public static final String ENTRIES_READ_REDIS_API = "ENTRIESREAD";
+
+    /** If the stream doesn't exist, creates a new stream with a length of <code>0</code>. */
+    boolean makeStream;
+
+    /**
+     * An arbitrary ID (that isn't the first ID, last ID, or the zero <code>"0-0"</code>. Use it to
+     * find out how many entries are between the arbitrary ID (excluding it) and the stream's last
+     * entry.
+     *
+     * @since Redis 7.0.0
+     */
+    String entriesRead;
+
+    /**
+     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
+     *
+     * @param makeStream If the stream doesn't exist, creates a new stream with a length of <code>0
+     *     </code>.
+     */
+    public StreamGroupOptions(Boolean makeStream) {
+        this.makeStream = makeStream;
+    }
+
+    /**
+     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
+     *
+     * @param entriesRead An arbitrary ID that isn't the first ID, last ID, or the zero <code>"0-0"
+     *     </code>. Use it to find out how many entries are between the arbitrary ID (excluding it)
+     *     and the stream's last entry.
+     * @since ENTRIESREAD was added in Redis 7.0.0.
+     */
+    public StreamGroupOptions(String entriesRead) {
+        this.makeStream = false;
+        this.entriesRead = entriesRead;
+    }
+
+    /**
+     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
+     *
+     * @param makeStream If the stream doesn't exist, creates a new stream with a length of <code>0
+     *     </code>.
+     * @param entriesRead An arbitrary ID that isn't the first ID, last ID, or the zero <code>"0-0"
+     *     </code>. Use it to find out how many entries are between the arbitrary ID (excluding it)
+     *     and the stream's last entry.
+     * @since ENTRIESREAD was added in Redis 7.0.0.
+     */
+    public StreamGroupOptions(Boolean makeStream, String entriesRead) {
+        this.makeStream = makeStream;
+        this.entriesRead = entriesRead;
+    }
+
+    /**
+     * Converts options and the key-to-id input for {@link StreamBaseCommands#xgroupCreate(String,
+     * String, String, StreamGroupOptions)} into a String[].
+     *
+     * @return String[]
+     */
+    public String[] toArgs() {
+        List<String> optionArgs = new ArrayList<>();
+
+        if (this.makeStream) {
+            optionArgs.add(MAKE_STREAM_REDIS_API);
+        }
+
+        if (this.entriesRead != null) {
+            optionArgs.add(ENTRIES_READ_REDIS_API);
+            optionArgs.add(this.entriesRead);
+        }
+
+        return optionArgs.toArray(new String[0]);
+    }
+}

--- a/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
@@ -4,6 +4,7 @@ package glide.api.models.commands.stream;
 import glide.api.commands.StreamBaseCommands;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
 
 /**
  * Optional arguments for {@link StreamBaseCommands#xgroupCreate(String, String, String,
@@ -11,13 +12,28 @@ import java.util.List;
  *
  * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a>
  */
+@Builder
 public final class StreamGroupOptions {
 
+    // Redis API String argument for makeStream
     public static final String MAKE_STREAM_REDIS_API = "MKSTREAM";
+
+    // Redis API String argument for entriesRead
     public static final String ENTRIES_READ_REDIS_API = "ENTRIESREAD";
 
-    /** If the stream doesn't exist, creates a new stream with a length of <code>0</code>. */
-    boolean makeStream;
+    /**
+     * If <code>true</code> and the stream doesn't exist, creates a new stream with a length of <code>
+     * 0</code>.
+     */
+    @Builder.Default private boolean mkStream = false;
+
+    public static class StreamGroupOptionsBuilder {
+
+        /** If the stream doesn't exist, this creates a new stream with a length of <code>0</code>. */
+        public StreamGroupOptionsBuilder makeStream() {
+            return mkStream(true);
+        }
+    }
 
     /**
      * An arbitrary ID (that isn't the first ID, last ID, or the zero <code>"0-0"</code>. Use it to
@@ -26,45 +42,7 @@ public final class StreamGroupOptions {
      *
      * @since Redis 7.0.0
      */
-    String entriesRead;
-
-    /**
-     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
-     *
-     * @param makeStream If the stream doesn't exist, creates a new stream with a length of <code>0
-     *     </code>.
-     */
-    public StreamGroupOptions(Boolean makeStream) {
-        this.makeStream = makeStream;
-    }
-
-    /**
-     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
-     *
-     * @param entriesRead An arbitrary ID that isn't the first ID, last ID, or the zero <code>"0-0"
-     *     </code>. Use it to find out how many entries are between the arbitrary ID (excluding it)
-     *     and the stream's last entry.
-     * @since ENTRIESREAD was added in Redis 7.0.0.
-     */
-    public StreamGroupOptions(String entriesRead) {
-        this.makeStream = false;
-        this.entriesRead = entriesRead;
-    }
-
-    /**
-     * Options for {@link StreamBaseCommands#xgroupCreate(String, String, String, StreamGroupOptions)}
-     *
-     * @param makeStream If the stream doesn't exist, creates a new stream with a length of <code>0
-     *     </code>.
-     * @param entriesRead An arbitrary ID that isn't the first ID, last ID, or the zero <code>"0-0"
-     *     </code>. Use it to find out how many entries are between the arbitrary ID (excluding it)
-     *     and the stream's last entry.
-     * @since ENTRIESREAD was added in Redis 7.0.0.
-     */
-    public StreamGroupOptions(Boolean makeStream, String entriesRead) {
-        this.makeStream = makeStream;
-        this.entriesRead = entriesRead;
-    }
+    private String entriesRead;
 
     /**
      * Converts options and the key-to-id input for {@link StreamBaseCommands#xgroupCreate(String,
@@ -75,7 +53,7 @@ public final class StreamGroupOptions {
     public String[] toArgs() {
         List<String> optionArgs = new ArrayList<>();
 
-        if (this.makeStream) {
+        if (this.mkStream) {
             optionArgs.add(MAKE_STREAM_REDIS_API);
         }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -27,6 +27,8 @@ import static glide.api.models.commands.function.FunctionListOptions.LIBRARY_NAM
 import static glide.api.models.commands.function.FunctionListOptions.WITH_CODE_REDIS_API;
 import static glide.api.models.commands.geospatial.GeoAddOptions.CHANGED_REDIS_API;
 import static glide.api.models.commands.stream.StreamAddOptions.NO_MAKE_STREAM_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MINIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.RANGE_COUNT_REDIS_API;
@@ -173,6 +175,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.XDel;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
@@ -244,6 +248,7 @@ import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
@@ -4240,6 +4245,83 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(completedResult, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xgroupCreate() {
+        // setup
+        String key = "testKey";
+        String groupName = "testGroupName";
+        String id = "testId";
+        String[] arguments = new String[] {key, groupName, id};
+
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(XGroupCreate), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.xgroupCreate(key, groupName, id);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xgroupCreate_withOptions() {
+        // setup
+        String key = "testKey";
+        String groupName = "testGroupName";
+        String id = "testId";
+        String testEntry = "testEntry";
+        StreamGroupOptions options = new StreamGroupOptions(true, testEntry);
+        String[] arguments =
+                new String[] {key, groupName, id, MAKE_STREAM_REDIS_API, ENTRIES_READ_REDIS_API, testEntry};
+
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(XGroupCreate), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.xgroupCreate(key, groupName, id, options);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xgroupDestroy() {
+        // setup
+        String key = "testKey";
+        String groupName = "testGroupName";
+        String[] arguments = new String[] {key, groupName};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(XGroupDestroy), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.xgroupDestroy(key, groupName);
+        Boolean payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(Boolean.TRUE, payload);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -4308,7 +4308,8 @@ public class RedisClientTest {
         String groupName = "testGroupName";
         String id = "testId";
         String testEntry = "testEntry";
-        StreamGroupOptions options = new StreamGroupOptions(true, testEntry);
+        StreamGroupOptions options =
+                StreamGroupOptions.builder().makeStream().entriesRead(testEntry).build();
         String[] arguments =
                 new String[] {key, groupName, id, MAKE_STREAM_REDIS_API, ENTRIES_READ_REDIS_API, testEntry};
 

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -744,7 +744,11 @@ public class TransactionTests {
         transaction.xgroupCreate("key", "group", "id");
         results.add(Pair.of(XGroupCreate, buildArgs("key", "group", "id")));
 
-        transaction.xgroupCreate("key", "group", "id", new StreamGroupOptions(true, "entry"));
+        transaction.xgroupCreate(
+                "key",
+                "group",
+                "id",
+                StreamGroupOptions.builder().makeStream().entriesRead("entry").build());
         results.add(
                 Pair.of(
                         XGroupCreate,

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -24,6 +24,8 @@ import static glide.api.models.commands.ZAddOptions.UpdateOptions.SCORE_LESS_THA
 import static glide.api.models.commands.function.FunctionListOptions.LIBRARY_NAME_REDIS_API;
 import static glide.api.models.commands.function.FunctionListOptions.WITH_CODE_REDIS_API;
 import static glide.api.models.commands.geospatial.GeoAddOptions.CHANGED_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MINIMUM_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.RANGE_COUNT_REDIS_API;
@@ -153,6 +155,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.Type;
 import static redis_request.RedisRequestOuterClass.RequestType.Unlink;
 import static redis_request.RedisRequestOuterClass.RequestType.XAdd;
 import static redis_request.RedisRequestOuterClass.RequestType.XDel;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
 import static redis_request.RedisRequestOuterClass.RequestType.XRead;
@@ -217,6 +221,7 @@ import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
 import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
@@ -730,6 +735,19 @@ public class TransactionTests {
                                 MINIMUM_RANGE_REDIS_API,
                                 RANGE_COUNT_REDIS_API,
                                 "99")));
+
+        transaction.xgroupCreate("key", "group", "id");
+        results.add(Pair.of(XGroupCreate, buildArgs("key", "group", "id")));
+
+        transaction.xgroupCreate("key", "group", "id", new StreamGroupOptions(true, "entry"));
+        results.add(
+                Pair.of(
+                        XGroupCreate,
+                        buildArgs(
+                                "key", "group", "id", MAKE_STREAM_REDIS_API, ENTRIES_READ_REDIS_API, "entry")));
+
+        transaction.xgroupDestroy("key", "group");
+        results.add(Pair.of(XGroupDestroy, buildArgs("key", "group")));
 
         transaction.time();
         results.add(Pair.of(Time, buildArgs()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3341,7 +3341,8 @@ public class SharedCommandTests {
 
         // Stream with option to create creates stream & Group
         assertEquals(
-                OK, client.xgroupCreate(key, groupName, streamId, new StreamGroupOptions(true)).get());
+                OK, client.xgroupCreate(key, groupName, streamId, StreamGroupOptions.builder().makeStream()
+                .build()).get());
 
         // ...and again results in BUSYGROUP error, because group names must be unique
         executionException =
@@ -3357,7 +3358,7 @@ public class SharedCommandTests {
         assertEquals(false, client.xgroupDestroy(key, groupName).get());
 
         // ENTRIESREAD option was added in redis 7.0.0
-        StreamGroupOptions entriesReadOption = new StreamGroupOptions("10");
+        StreamGroupOptions entriesReadOption = StreamGroupOptions.builder().entriesRead("10").build();
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             assertEquals(OK, client.xgroupCreate(key, groupName, streamId, entriesReadOption).get());
         } else {
@@ -3375,7 +3376,7 @@ public class SharedCommandTests {
                         ExecutionException.class,
                         () ->
                                 client
-                                        .xgroupCreate(stringKey, groupName, streamId, new StreamGroupOptions(true))
+                                        .xgroupCreate(stringKey, groupName, streamId, StreamGroupOptions.builder().makeStream().build())
                                         .get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -3341,8 +3341,11 @@ public class SharedCommandTests {
 
         // Stream with option to create creates stream & Group
         assertEquals(
-                OK, client.xgroupCreate(key, groupName, streamId, StreamGroupOptions.builder().makeStream()
-                .build()).get());
+                OK,
+                client
+                        .xgroupCreate(
+                                key, groupName, streamId, StreamGroupOptions.builder().makeStream().build())
+                        .get());
 
         // ...and again results in BUSYGROUP error, because group names must be unique
         executionException =
@@ -3376,7 +3379,11 @@ public class SharedCommandTests {
                         ExecutionException.class,
                         () ->
                                 client
-                                        .xgroupCreate(stringKey, groupName, streamId, StreamGroupOptions.builder().makeStream().build())
+                                        .xgroupCreate(
+                                                stringKey,
+                                                groupName,
+                                                streamId,
+                                                StreamGroupOptions.builder().makeStream().build())
                                         .get());
         assertInstanceOf(RequestException.class, executionException.getCause());
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -65,6 +65,7 @@ import glide.api.models.commands.geospatial.GeoAddOptions;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
 import glide.api.models.commands.stream.StreamReadOptions;
@@ -3320,6 +3321,67 @@ public class SharedCommandTests {
                                 client
                                         .xrevrange(key, InfRangeBound.MAX, IdBound.ofExclusive("not_a_stream_id"))
                                         .get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+    }
+
+    @SneakyThrows
+    @ParameterizedTest(autoCloseArguments = false)
+    @MethodSource("getClients")
+    public void xgroupCreate_xgroupDestroy(BaseClient client) {
+        String key = UUID.randomUUID().toString();
+        String stringKey = UUID.randomUUID().toString();
+        String groupName = "group" + UUID.randomUUID();
+        String streamId = "0-1";
+
+        // Stream not created results in error
+        Exception executionException =
+                assertThrows(
+                        ExecutionException.class, () -> client.xgroupCreate(key, groupName, streamId).get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+
+        // Stream with option to create creates stream & Group
+        assertEquals(
+                OK, client.xgroupCreate(key, groupName, streamId, new StreamGroupOptions(true)).get());
+
+        // ...and again results in BUSYGROUP error, because group names must be unique
+        executionException =
+                assertThrows(
+                        ExecutionException.class, () -> client.xgroupCreate(key, groupName, streamId).get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+        assertTrue(executionException.getMessage().contains("BUSYGROUP"));
+
+        // Stream Group can be destroyed returns: true
+        assertEquals(true, client.xgroupDestroy(key, groupName).get());
+
+        // ...and again results in: false
+        assertEquals(false, client.xgroupDestroy(key, groupName).get());
+
+        // ENTRIESREAD option was added in redis 7.0.0
+        StreamGroupOptions entriesReadOption = new StreamGroupOptions("10");
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
+            assertEquals(OK, client.xgroupCreate(key, groupName, streamId, entriesReadOption).get());
+        } else {
+            executionException =
+                    assertThrows(
+                            ExecutionException.class,
+                            () -> client.xgroupCreate(key, groupName, streamId, entriesReadOption).get());
+            assertInstanceOf(RequestException.class, executionException.getCause());
+        }
+
+        // key is a string and cannot be created as a stream
+        assertEquals(OK, client.set(stringKey, "not_a_stream").get());
+        executionException =
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                client
+                                        .xgroupCreate(stringKey, groupName, streamId, new StreamGroupOptions(true))
+                                        .get());
+        assertInstanceOf(RequestException.class, executionException.getCause());
+
+        executionException =
+                assertThrows(
+                        ExecutionException.class, () -> client.xgroupDestroy(stringKey, groupName).get());
         assertInstanceOf(RequestException.class, executionException.getCause());
     }
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -687,7 +687,8 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
                 .xgroupCreate(streamKey1, groupName1, "0-0")
-                .xgroupCreate(streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
+                .xgroupCreate(
+                        streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
                 .xdel(streamKey1, new String[] {"0-3", "0-5"});

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -687,7 +687,7 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
                 .xgroupCreate(streamKey1, groupName1, "0-0")
-                .xgroupCreate(streamKey1, groupName2, "0-0", new StreamGroupOptions(true))
+                .xgroupCreate(streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
                 .xdel(streamKey1, new String[] {"0-3", "0-5"});

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -34,6 +34,7 @@ import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoUnit;
 import glide.api.models.commands.geospatial.GeospatialData;
 import glide.api.models.commands.stream.StreamAddOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamRange.IdBound;
 import glide.api.models.commands.stream.StreamTrimOptions.MinId;
 import java.util.HashMap;
@@ -659,6 +660,8 @@ public class TransactionTestUtilities {
 
     private static Object[] streamCommands(BaseTransaction<?> transaction) {
         final String streamKey1 = "{streamKey}-1-" + UUID.randomUUID();
+        final String groupName1 = "{groupName}-1-" + UUID.randomUUID();
+        final String groupName2 = "{groupName}-2-" + UUID.randomUUID();
 
         transaction
                 .xadd(streamKey1, Map.of("field1", "value1"), StreamAddOptions.builder().id("0-1").build())
@@ -671,6 +674,10 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"))
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
+                .xgroupCreate(streamKey1, groupName1, "0-0")
+                .xgroupCreate(streamKey1, groupName2, "0-0", new StreamGroupOptions(true))
+                .xgroupDestroy(streamKey1, groupName1)
+                .xgroupDestroy(streamKey1, groupName2)
                 .xdel(streamKey1, new String[] {"0-3", "0-5"});
 
         return new Object[] {
@@ -687,6 +694,10 @@ public class TransactionTestUtilities {
             Map.of(
                     "0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1", 1l)
             1L, // xtrim(streamKey1, new MinId(true, "0-2"))
+            OK, // xgroupCreate(streamKey1, groupName1, "0-0")
+            OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
+            true, // xgroupDestroy(streamKey1, groupName1)
+            true, // xgroupDestroy(streamKey1, groupName2)
             1L, // .xdel(streamKey1, new String[] {"0-1", "0-5"});
         };
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds the following commands: 
https://valkey.io/commands/xgroup-create/
https://valkey.io/commands/xgroup-destroy/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
