### PR TITLE
Java: Adding command `LCS` (No IDX option)

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -214,6 +214,7 @@ enum RequestType {
     XRevRange = 176;
     Copy = 178;
     MSetNX = 179;
+    LCS = 181;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -184,6 +184,7 @@ pub enum RequestType {
     XRevRange = 176,
     Copy = 178,
     MSetNX = 179,
+    LCS = 181,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -371,6 +372,7 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::Sort => RequestType::Sort,
             ProtobufRequestType::XRevRange => RequestType::XRevRange,
             ProtobufRequestType::MSetNX => RequestType::MSetNX,
+            ProtobufRequestType::LCS => RequestType::LCS,
         }
     }
 }
@@ -554,6 +556,7 @@ impl RequestType {
             RequestType::Sort => Some(cmd("SORT")),
             RequestType::XRevRange => Some(cmd("XREVRANGE")),
             RequestType::MSetNX => Some(cmd("MSETNX")),
+            RequestType::LCS => Some(cmd("LCS")),
         }
     }
 }

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -60,6 +60,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.HVals;
 import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrByFloat;
+import static redis_request.RedisRequestOuterClass.RequestType.LCS;
 import static redis_request.RedisRequestOuterClass.RequestType.LIndex;
 import static redis_request.RedisRequestOuterClass.RequestType.LInsert;
 import static redis_request.RedisRequestOuterClass.RequestType.LLen;
@@ -1803,5 +1804,17 @@ public abstract class BaseClient
     public CompletableFuture<Boolean> msetnx(@NonNull Map<String, String> keyValueMap) {
         String[] args = convertMapToKeyValueStringArray(keyValueMap);
         return commandManager.submitNewCommand(MSetNX, args, this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> lcs(@NonNull String key1, @NonNull String key2) {
+        String[] arguments = new String[] {key1, key2};
+        return commandManager.submitNewCommand(LCS, arguments, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> lcsLen(@NonNull String key1, @NonNull String key2) {
+        String[] arguments = new String[] {key1, key2, LEN_REDIS_API};
+        return commandManager.submitNewCommand(LCS, arguments, this::handleLongResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
@@ -15,6 +15,9 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface StringBaseCommands {
 
+    /** Redis API keyword used to indicate that the length of the lcs should be returned. */
+    public static final String LEN_REDIS_API = "LEN";
+
     /**
      * Gets the value associated with the given <code>key</code>, or <code>null</code> if no such
      * value exists.
@@ -333,4 +336,46 @@ public interface StringBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> append(String key, String value);
+
+    /**
+     * Returns the longest common subsequence between strings stored at <code>key1</code> and <code>
+     * key2</code>.
+     *
+     * @since Redis 7.0 and above.
+     * @apiNote When in cluster mode, <code>key1</code> and <code>key2</code> must map to the same
+     *     hash slot.
+     * @see <a href="https://valkey.io/commands/lcs/">valkey.io</a> for details.
+     * @param key1 The key that stores the first string.
+     * @param key2 The key that stores the second string.
+     * @return A <code>String</code> containing the longest common subsequence between the 2 strings.
+     *     An empty <code>String</code> is returned if the keys do not exist or have no common
+     *     subsequences.
+     * @example
+     *     <pre>{@code
+     * // testKey1 = abcd, testKey2 = axcd
+     * String result = client.lcs("testKey1", "testKey2").get();
+     * assert result.equals("acd");
+     * }</pre>
+     */
+    CompletableFuture<String> lcs(String key1, String key2);
+
+    /**
+     * Returns the length of the longest common subsequence between strings stored at <code>key1
+     * </code> and <code>key2</code>.
+     *
+     * @since Redis 7.0 and above.
+     * @apiNote When in cluster mode, <code>key1</code> and <code>key2</code> must map to the same
+     *     hash slot.
+     * @see <a href="https://valkey.io/commands/lcs/">valkey.io</a> for details.
+     * @param key1 The key that stores the first string.
+     * @param key2 The key that stores the second string.
+     * @return The length of the longest common subsequence between the 2 strings.
+     * @example
+     *     <pre>{@code
+     * // testKey1 = abcd, testKey2 = axcd
+     * Long result = client.lcs("testKey1", "testKey2").get();
+     * assert result.equals(3L);
+     * }</pre>
+     */
+    CompletableFuture<Long> lcsLen(String key1, String key2);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -10,6 +10,7 @@ import static glide.api.commands.SortedSetBaseCommands.COUNT_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.LIMIT_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.WITH_SCORES_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.WITH_SCORE_REDIS_API;
+import static glide.api.commands.StringBaseCommands.LEN_REDIS_API;
 import static glide.api.models.commands.RangeOptions.createZRangeArgs;
 import static glide.api.models.commands.bitmap.BitFieldOptions.createBitFieldArgs;
 import static glide.api.models.commands.function.FunctionListOptions.LIBRARY_NAME_REDIS_API;
@@ -81,6 +82,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrByFloat;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
+import static redis_request.RedisRequestOuterClass.RequestType.LCS;
 import static redis_request.RedisRequestOuterClass.RequestType.LIndex;
 import static redis_request.RedisRequestOuterClass.RequestType.LInsert;
 import static redis_request.RedisRequestOuterClass.RequestType.LLen;
@@ -4324,6 +4326,41 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public T functionDelete(@NonNull String libName) {
         protobufTransaction.addCommands(buildCommand(FunctionDelete, buildArgs(libName)));
+        return getThis();
+    }
+
+    /**
+     * Returns the longest common subsequence between strings stored at <code>key1</code> and <code>
+     * key2</code>.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/lcs/">valkey.io</a> for details.
+     * @param key1 The key that stores the first string.
+     * @param key2 The key that stores the second string.
+     * @return Command Response - A <code>String</code> containing the longest common subsequence
+     *     between the 2 strings. An empty <code>String</code> is returned if the keys do not exist or
+     *     have no common subsequences.
+     */
+    public T lcs(@NonNull String key1, @NonNull String key2) {
+        protobufTransaction.addCommands(buildCommand(LCS, buildArgs(key1, key2)));
+        return getThis();
+    }
+
+    /**
+     * Returns the length of the longest common subsequence between strings stored at <code>key1
+     * </code> and <code>key2</code>.
+     *
+     * @since Redis 7.0 and above.
+     * @apiNote When in cluster mode, <code>key1</code> and <code>key2</code> must map to the same
+     *     hash slot.
+     * @see <a href="https://valkey.io/commands/lcs/">valkey.io</a> for details.
+     * @param key1 The key that stores the first string.
+     * @param key2 The key that stores the second string.
+     * @return Command Response - The length of the longest common subsequence between the 2 strings.
+     */
+    public T lcsLen(@NonNull String key1, @NonNull String key2) {
+        ArgsArray args = buildArgs(key1, key2, LEN_REDIS_API);
+        protobufTransaction.addCommands(buildCommand(LCS, args));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -11,6 +11,7 @@ import static glide.api.commands.SetBaseCommands.SET_LIMIT_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.LIMIT_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.WITH_SCORES_REDIS_API;
 import static glide.api.commands.SortedSetBaseCommands.WITH_SCORE_REDIS_API;
+import static glide.api.commands.StringBaseCommands.LEN_REDIS_API;
 import static glide.api.models.commands.FlushMode.ASYNC;
 import static glide.api.models.commands.FlushMode.SYNC;
 import static glide.api.models.commands.LInsertOptions.InsertPosition.BEFORE;
@@ -113,6 +114,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrByFloat;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
+import static redis_request.RedisRequestOuterClass.RequestType.LCS;
 import static redis_request.RedisRequestOuterClass.RequestType.LIndex;
 import static redis_request.RedisRequestOuterClass.RequestType.LInsert;
 import static redis_request.RedisRequestOuterClass.RequestType.LLen;
@@ -6010,6 +6012,56 @@ public class RedisClientTest {
         // exercise
         CompletableFuture<Boolean> response = service.copy(source, destination, destinationDB, true);
         Boolean payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void lcs() {
+        // setup
+        String key1 = "testKey1";
+        String key2 = "testKey2";
+        String[] arguments = new String[] {key1, key2};
+        String value = "foo";
+
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(LCS), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.lcs(key1, key2);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void lcs_with_len_option() {
+        // setup
+        String key1 = "testKey1";
+        String key2 = "testKey2";
+        String[] arguments = new String[] {key1, key2, LEN_REDIS_API};
+        Long value = 3L;
+
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(LCS), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.lcsLen(key1, key2);
+        Long payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -94,6 +94,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Incr;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrBy;
 import static redis_request.RedisRequestOuterClass.RequestType.IncrByFloat;
 import static redis_request.RedisRequestOuterClass.RequestType.Info;
+import static redis_request.RedisRequestOuterClass.RequestType.LCS;
 import static redis_request.RedisRequestOuterClass.RequestType.LIndex;
 import static redis_request.RedisRequestOuterClass.RequestType.LInsert;
 import static redis_request.RedisRequestOuterClass.RequestType.LLen;
@@ -978,6 +979,12 @@ public class TransactionTests {
 
         transaction.copy("key1", "key2", true);
         results.add(Pair.of(Copy, buildArgs("key1", "key2", REPLACE_REDIS_API)));
+
+        transaction.lcs("key1", "key2");
+        results.add(Pair.of(LCS, buildArgs("key1", "key2")));
+
+        transaction.lcsLen("key1", "key2");
+        results.add(Pair.of(LCS, buildArgs("key1", "key2", "LEN")));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -201,6 +201,9 @@ public class TransactionTestUtilities {
         String stringKey3 = "{StringKey}-3-" + UUID.randomUUID();
         String stringKey4 = "{StringKey}-4-" + UUID.randomUUID();
         String stringKey5 = "{StringKey}-5-" + UUID.randomUUID();
+        String stringKey6 = "{StringKey}-6-" + UUID.randomUUID();
+        String stringKey7 = "{StringKey}-7-" + UUID.randomUUID();
+        String stringKey8 = "{StringKey}-8-" + UUID.randomUUID();
 
         transaction
                 .set(stringKey1, value1)
@@ -224,28 +227,57 @@ public class TransactionTestUtilities {
                 .msetnx(Map.of(stringKey4, "foo", stringKey5, "bar"))
                 .mget(new String[] {stringKey4, stringKey5});
 
-        return new Object[] {
-            OK, // set(stringKey1, value1)
-            value1, // get(stringKey1)
-            value1, // getdel(stringKey1)
-            null, // set(stringKey2, value2, returnOldValue(true))
-            (long) value1.length(), // strlen(key2)
-            Long.valueOf(value2.length() * 2), // append(key2, value2)
-            OK, // mset(Map.of(stringKey1, value2, stringKey2, value1))
-            new String[] {value2, value1}, // mget(new String[] {stringKey1, stringKey2})
-            1L, // incr(stringKey3)
-            3L, // incrBy(stringKey3, 2)
-            2L, // decr(stringKey3)
-            0L, // decrBy(stringKey3, 2)
-            0.5, // incrByFloat(stringKey3, 0.5)
-            5L, // setrange(stringKey3, 0, "GLIDE")
-            "GLIDE", // getrange(stringKey3, 0, 5)
-            true, // msetnx(Map.of(stringKey4, "foo", stringKey5, "bar"))
-            new String[] {"foo", "bar"}, // mget({stringKey4, stringKey5})
-            1L, // del(stringKey5)
-            false, // msetnx(Map.of(stringKey4, "foo", stringKey5, "bar"))
-            new String[] {"foo", null}, // mget({stringKey4, stringKey5})
-        };
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
+            transaction
+                    .set(stringKey6, "abcd")
+                    .set(stringKey7, "bcde")
+                    .set(stringKey8, "wxyz")
+                    .lcs(stringKey6, stringKey7)
+                    .lcs(stringKey6, stringKey8)
+                    .lcsLen(stringKey6, stringKey7)
+                    .lcsLen(stringKey6, stringKey8);
+        }
+
+        var expectedResults =
+                new Object[] {
+                    OK, // set(stringKey1, value1)
+                    value1, // get(stringKey1)
+                    value1, // getdel(stringKey1)
+                    null, // set(stringKey2, value2, returnOldValue(true))
+                    (long) value1.length(), // strlen(key2)
+                    Long.valueOf(value2.length() * 2), // append(key2, value2)
+                    OK, // mset(Map.of(stringKey1, value2, stringKey2, value1))
+                    new String[] {value2, value1}, // mget(new String[] {stringKey1, stringKey2})
+                    1L, // incr(stringKey3)
+                    3L, // incrBy(stringKey3, 2)
+                    2L, // decr(stringKey3)
+                    0L, // decrBy(stringKey3, 2)
+                    0.5, // incrByFloat(stringKey3, 0.5)
+                    5L, // setrange(stringKey3, 0, "GLIDE")
+                    "GLIDE", // getrange(stringKey3, 0, 5)
+                    true, // msetnx(Map.of(stringKey4, "foo", stringKey5, "bar"))
+                    new String[] {"foo", "bar"}, // mget({stringKey4, stringKey5})
+                    1L, // del(stringKey5)
+                    false, // msetnx(Map.of(stringKey4, "foo", stringKey5, "bar"))
+                    new String[] {"foo", null}, // mget({stringKey4, stringKey5})
+                };
+
+        if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
+            expectedResults =
+                    concatenateArrays(
+                            expectedResults,
+                            new Object[] {
+                                OK, // set(stringKey6, "abcd")
+                                OK, // set(stringKey6, "bcde")
+                                OK, // set(stringKey6, "wxyz")
+                                "bcd", // lcs(stringKey6, stringKey7)
+                                "", // lcs(stringKey6, stringKey8)
+                                3L, // lcsLEN(stringKey6, stringKey7)
+                                0L, // lcsLEN(stringKey6, stringKey8)
+                            });
+        }
+
+        return expectedResults;
     }
 
     private static Object[] hashCommands(BaseTransaction<?> transaction) {

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -758,7 +758,9 @@ public class CommandTests {
                 Arguments.of(
                         "xread", null, clusterClient.xread(Map.of("abc", "stream1", "zxy", "stream2"))),
                 Arguments.of("copy", "6.2.0", clusterClient.copy("abc", "def", true)),
-                Arguments.of("msetnx", null, clusterClient.msetnx(Map.of("abc", "def", "ghi", "jkl"))));
+                Arguments.of("msetnx", null, clusterClient.msetnx(Map.of("abc", "def", "ghi", "jkl"))),
+                Arguments.of("lcs", "7.0.0", clusterClient.lcs("abc", "def")),
+                Arguments.of("lcsLEN", "7.0.0", clusterClient.lcsLen("abc", "def")));
     }
 
     @SneakyThrows


### PR DESCRIPTION
* Java: Adding command LCS (default & LEN option)

*Issue #, if available:*

*Description of changes:*
This only covers the signature where LCS returns the LCS as a String and LCS length as a Long. Map return type with the IDX option is coming as a part II

`MINMATCHLEN` does not seem to work:
```
127.0.0.1:6379> set a1 abc
OK
127.0.0.1:6379> set a2 bcd
OK
127.0.0.1:6379> lcs a1 a2
"bc"
127.0.0.1:6379> lcs a1 a2 len
(integer) 2
127.0.0.1:6379> lcs a1 a2 MINMATCHLEN 3
"bc"
127.0.0.1:6379> lcs a1 a2 len MINMATCHLEN 3
(integer) 2
127.0.0.1:6379> lcs a1 a2 idx MINMATCHLEN 3
1) "matches"
2) (empty array)
3) "len"
4) (integer) 2
```

And as a reference https://github.com/valkey-io/valkey/pull/420 discusses how `WITHMATCHLEN` and `MINMATCHLEN` only works/makes sense with the `IDX` option but is still allowed to be added when `IDX` isn't present. 

For now, this PR will only include the default behavior without optional keywords and the `LEN` option behavior, which is mutually exclusive with `IDX`, without the MINMATCHLEN option

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
