### PR TITLE
Node: add OBJECT IDLETIME command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Node: Added XLEN command ([#1555](https://github.com/aws/glide-for-redis/pull/1555))
 * Node: Added ZINTERCARD command ([#1553](https://github.com/aws/glide-for-redis/pull/1553))
 * Python: Added LMPOP and BLMPOP commands ([#1547](https://github.com/aws/glide-for-redis/pull/1547))
+* Node: Added OBJECT IDLETIME command ([#1567](https://github.com/aws/glide-for-redis/pull/1567))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -101,6 +101,7 @@ import {
     createSUnionStore,
     createXLen,
     createZInterCard,
+    createObjectIdletime,
 } from "./Commands";
 import {
     ClosingError,
@@ -2572,6 +2573,24 @@ export class BaseClient {
      */
     public object_freq(key: string): Promise<number | null> {
         return this.createWritePromise(createObjectFreq(key));
+    }
+
+    /**
+     * Returns the time in seconds since the last access to the value stored at `key`.
+     *
+     * See https://valkey.io/commands/object-idletime/ for more details.
+     *
+     * @param key - The key of the object to get the idle time of.
+     * @returns If `key` exists, returns the idle time in seconds. Otherwise, returns `null`.
+     *
+     * @example
+     * ```typescript
+     * const result = await client.objectIdletime("my_hash");
+     * console.log(result); // Output: 13 - "my_hash" was last accessed 13 seconds ago.
+     * ```
+     */
+    public objectIdletime(key: string): Promise<number | null> {
+        return this.createWritePromise(createObjectIdletime(key));
     }
 
     /**

--- a/node/src/Commands.ts
+++ b/node/src/Commands.ts
@@ -1493,3 +1493,10 @@ export function createObjectEncoding(key: string): redis_request.Command {
 export function createObjectFreq(key: string): redis_request.Command {
     return createCommand(RequestType.ObjectFreq, [key]);
 }
+
+/**
+ * @internal
+ */
+export function createObjectIdletime(key: string): redis_request.Command {
+    return createCommand(RequestType.ObjectIdleTime, [key]);
+}

--- a/node/src/Transaction.ts
+++ b/node/src/Transaction.ts
@@ -106,6 +106,7 @@ import {
     createSUnionStore,
     createXLen,
     createZInterCard,
+    createObjectIdletime,
 } from "./Commands";
 import { redis_request } from "./ProtobufMessage";
 
@@ -1492,6 +1493,19 @@ export class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public object_freq(key: string): T {
         return this.addAndReturn(createObjectFreq(key));
+    }
+
+    /**
+     * Returns the time in seconds since the last access to the value stored at `key`.
+     *
+     * See https://valkey.io/commands/object-idletime/ for more details.
+     *
+     * @param key - The key of the object to get the idle time of.
+     *
+     * Command Response - If `key` exists, returns the idle time in seconds. Otherwise, returns `null`.
+     */
+    public objectIdletime(key: string): T {
+        return this.addAndReturn(createObjectIdletime(key));
     }
 }
 

--- a/node/tests/RedisClient.test.ts
+++ b/node/tests/RedisClient.test.ts
@@ -221,6 +221,51 @@ describe("RedisClient", () => {
         },
     );
 
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "object idletime transaction test_%p",
+        async (protocol) => {
+            const client = await RedisClient.createClient(
+                getClientConfigurationOption(cluster.getAddresses(), protocol),
+            );
+
+            const key = uuidv4();
+            const maxmemoryPolicyKey = "maxmemory-policy";
+            const config = await client.configGet([maxmemoryPolicyKey]);
+            const maxmemoryPolicy = String(config[maxmemoryPolicyKey]);
+
+            try {
+                const transaction = new Transaction();
+                transaction.configSet({
+                    // OBJECT IDLETIME requires a non-LFU maxmemory-policy
+                    [maxmemoryPolicyKey]: "allkeys-random",
+                });
+                transaction.set(key, "foo");
+                transaction.objectIdletime(key);
+
+                const response = await client.exec(transaction);
+                expect(response).not.toBeNull();
+
+                if (response != null) {
+                    expect(response.length).toEqual(3);
+                    // transaction.configSet({[maxmemoryPolicyKey]: "allkeys-random"});
+                    expect(response[0]).toEqual("OK");
+                    // transaction.set(key, "foo");
+                    expect(response[1]).toEqual("OK");
+                    // transaction.objectIdletime(key);
+                    expect(response[2]).toBeGreaterThanOrEqual(0);
+                }
+            } finally {
+                expect(
+                    await client.configSet({
+                        [maxmemoryPolicyKey]: maxmemoryPolicy,
+                    }),
+                ).toEqual("OK");
+            }
+
+            client.close();
+        },
+    );
+
     runBaseTests<Context>({
         init: async (protocol, clientName?) => {
             const options = getClientConfigurationOption(

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -3254,6 +3254,49 @@ export function runBaseTests<Context>(config: {
         },
         config.timeout,
     );
+
+    it.each([ProtocolVersion.RESP2, ProtocolVersion.RESP3])(
+        "object idletime test_%p",
+        async (protocol) => {
+            await runTest(async (client: BaseClient) => {
+                const key = uuidv4();
+                const nonExistingKey = uuidv4();
+                const maxmemoryPolicyKey = "maxmemory-policy";
+                const config = await client.configGet([maxmemoryPolicyKey]);
+                const maxmemoryPolicy = String(config[maxmemoryPolicyKey]);
+
+                try {
+                    expect(
+                        await client.configSet({
+                            // OBJECT IDLETIME requires a non-LFU maxmemory-policy
+                            [maxmemoryPolicyKey]: "allkeys-random",
+                        }),
+                    ).toEqual("OK");
+                    expect(await client.objectIdletime(nonExistingKey)).toEqual(
+                        null,
+                    );
+                    expect(await client.set(key, "foobar")).toEqual("OK");
+
+                    await wait(2000);
+
+                    expect(await client.objectIdletime(key)).toBeGreaterThan(0);
+                } finally {
+                    expect(
+                        await client.configSet({
+                            [maxmemoryPolicyKey]: maxmemoryPolicy,
+                        }),
+                    ).toEqual("OK");
+                }
+            }, protocol);
+        },
+        config.timeout,
+    );
+
+    function wait(numMilliseconds: number) {
+        return new Promise((resolve) => {
+            setTimeout(resolve, numMilliseconds);
+        });
+    }
 }
 
 export function runCommonTests<Context>(config: {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/object-idletime/
- Returns the time in seconds since the last access to the value stored at `key`.
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/object-idletime.json))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
