### PR TITLE
Java: Upgrade to protoc 27.1

### DIFF
--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.26.1'
+    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.27.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
 
     implementation group: 'io.netty', name: 'netty-handler', version: '4.1.100.Final'

--- a/java/client/build.gradle
+++ b/java/client/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.27.0'
+    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '4.27.1'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.13.0'
 
     implementation group: 'io.netty', name: 'netty-handler', version: '4.1.100.Final'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the release of [protobuf 27.1](https://github.com/protocolbuffers/protobuf/releases/tag/v27.1) we want to update our compilers to compile against the latest and greatest protobuf. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
