### PR TITLE
Python: add GETBIT command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Node: Added OBJECT IDLETIME command ([#1567](https://github.com/aws/glide-for-redis/pull/1567))
 * Node: Added OBJECT REFCOUNT command ([#1568](https://github.com/aws/glide-for-redis/pull/1568))
 * Python: Added SETBIT command ([#1571](https://github.com/aws/glide-for-redis/pull/1571))
+* Python: Added GETBIT command ([#1575](https://github.com/aws/glide-for-redis/pull/1575))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4073,8 +4073,8 @@ class CoreCommands(Protocol):
             offset (int): The index of the bit to return.
 
         Returns:
-            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the positive
-                `offset` exceeds the length of the string.
+            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the `offset` exceeds
+            the length of the string.
 
         Examples:
             >>> await client.getbit("my_key", 1)

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4061,6 +4061,30 @@ class CoreCommands(Protocol):
             ),
         )
 
+    async def getbit(self, key: str, offset: int) -> int:
+        """
+        Returns the bit value at `offset` in the string value stored at `key`.
+        `offset` should be greater than or equal to zero.
+
+        See https://valkey.io/commands/getbit for more details.
+
+        Args:
+            key (str): The key of the string.
+            offset (int): The index of the bit to return.
+
+        Returns:
+            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the positive
+                `offset` exceeds the length of the string.
+
+        Examples:
+            >>> await client.getbit("my_key", 1)
+                1  # Indicates that the second bit of the string stored at "my_key" is set to 1.
+        """
+        return cast(
+            int,
+            await self._execute_command(RequestType.GetBit, [key, str(offset)]),
+        )
+
     async def object_encoding(self, key: str) -> Optional[str]:
         """
         Returns the internal encoding for the Redis object stored at `key`.

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4074,7 +4074,7 @@ class CoreCommands(Protocol):
 
         Returns:
             int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the `offset` exceeds
-            the length of the string.
+                the length of the string.
 
         Examples:
             >>> await client.getbit("my_key", 1)

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2794,6 +2794,23 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.SetBit, [key, str(offset), str(value)])
 
+    def getbit(self: TTransaction, key: str, offset: int) -> TTransaction:
+        """
+        Returns the bit value at `offset` in the string value stored at `key`.
+        `offset` should be greater than or equal to zero.
+
+        See https://valkey.io/commands/getbit for more details.
+
+        Args:
+            key (str): The key of the string.
+            offset (int): The index of the bit to return.
+
+        Command response:
+            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the positive
+                `offset` exceeds the length of the string.
+        """
+        return self.append_command(RequestType.GetBit, [key, str(offset)])
+
     def object_encoding(self: TTransaction, key: str) -> TTransaction:
         """
         Returns the internal encoding for the Redis object stored at `key`.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2806,8 +2806,8 @@ class BaseTransaction:
             offset (int): The index of the bit to return.
 
         Command response:
-            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the positive
-                `offset` exceeds the length of the string.
+            int: The bit at the given `offset` of the string. Returns `0` if the key is empty or if the `offset` exceeds
+                the length of the string.
         """
         return self.append_command(RequestType.GetBit, [key, str(offset)])
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -4057,11 +4057,11 @@ class TestCommands:
 
         assert await redis_client.set(key, value) == OK
         assert await redis_client.getbit(key, 1) == 1
+        # When offset is beyond the string length, the string is assumed to be a contiguous space with 0 bits.
         assert await redis_client.getbit(key, 1000) == 0
+        # When key does not exist it is assumed to be an empty string, so offset is always out of range and the value is
+        # also assumed to be a contiguous space with 0 bits.
         assert await redis_client.getbit(non_existing_key, 1) == 0
-
-        assert await redis_client.setbit(key, 5, 0) == 1
-        assert await redis_client.getbit(key, 5) == 0
 
         # invalid argument - offset can't be negative
         with pytest.raises(RequestError):

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -4049,6 +4049,31 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_getbit(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        non_existing_key = get_random_string(10)
+        set_key = get_random_string(10)
+        value = "foobar"
+
+        assert await redis_client.set(key, value) == OK
+        assert await redis_client.getbit(key, 1) == 1
+        assert await redis_client.getbit(key, 1000) == 0
+        assert await redis_client.getbit(non_existing_key, 1) == 0
+
+        assert await redis_client.setbit(key, 5, 0) == 1
+        assert await redis_client.getbit(key, 5) == 0
+
+        # invalid argument - offset can't be negative
+        with pytest.raises(RequestError):
+            assert await redis_client.getbit(key, -1) == 1
+
+        # key exists, but it is not a string
+        assert await redis_client.sadd(set_key, ["foo"]) == 1
+        with pytest.raises(RequestError):
+            await redis_client.getbit(set_key, 0)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_object_encoding(self, redis_client: TRedisClient):
         string_key = get_random_string(10)
         list_key = get_random_string(10)

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -349,6 +349,8 @@ async def transaction_test(
     args.append(0)
     transaction.setbit(key19, 1, 0)
     args.append(1)
+    transaction.getbit(key19, 1)
+    args.append(0)
 
     transaction.geoadd(
         key12,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/getbit/
- Returns the bit value at `offset` in the string value stored at `key`.
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/getbit.json))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
