### PR TITLE
Python: add BITCOUNT command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Node: Added OBJECT REFCOUNT command ([#1568](https://github.com/aws/glide-for-redis/pull/1568))
 * Python: Added SETBIT command ([#1571](https://github.com/aws/glide-for-redis/pull/1571))
 * Python: Added GETBIT command ([#1575](https://github.com/aws/glide-for-redis/pull/1575))
+* Python: Added BITCOUNT command ([#1592](https://github.com/aws/glide-for-redis/pull/1592))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,5 +1,6 @@
 # Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
+from glide.async_commands.bitmap import BitmapIndexType, OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,

--- a/python/python/glide/async_commands/bitmap.py
+++ b/python/python/glide/async_commands/bitmap.py
@@ -1,0 +1,50 @@
+# Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
+from enum import Enum
+from typing import List, Optional
+
+
+class BitmapIndexType(Enum):
+    """
+    Enumeration specifying if index arguments are BYTE indexes or BIT indexes. Can be specified in `OffsetOptions`,
+    which is an optional argument to the `BITCOUNT` command.
+
+    Since: Redis version 7.0.0.
+    """
+
+    BYTE = "BYTE"
+    """
+    Specifies that indexes provided to `OffsetOptions` are byte indexes.
+    """
+    BIT = "BIT"
+    """
+    Specifies that indexes provided to `OffsetOptions` are bit indexes.
+    """
+
+
+class OffsetOptions:
+    def __init__(
+        self, start: int, end: int, index_type: Optional[BitmapIndexType] = None
+    ):
+        """
+        Represents offsets specifying a string interval to analyze in the `BITCOUNT` command. The offsets are
+        zero-based indexes, with `0` being the first index of the string, `1` being the next index and so on.
+        The offsets can also be negative numbers indicating offsets starting at the end of the string, with `-1` being
+        the last index of the string, `-2` being the penultimate, and so on.
+
+        Args:
+            start (int): The starting offset index.
+            end (int): The ending offset index.
+            index_type (Optional[BitmapIndexType]): The index offset type. This option can only be specified if you are
+                using Redis version 7.0.0 or above. Could be either `BitmapIndexType.BYTE` or `BitmapIndexType.BIT`.
+                If no index type is provided, the indexes will be assumed to be byte indexes.
+        """
+        self.start = start
+        self.end = end
+        self.index_type = index_type
+
+    def to_args(self) -> List[str]:
+        args = [str(self.start), str(self.end)]
+        if self.index_type is not None:
+            args.append(self.index_type.value)
+
+        return args

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -3,6 +3,7 @@
 import threading
 from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
+from glide.async_commands.bitmap import OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
@@ -2853,6 +2854,30 @@ class BaseTransaction:
             OK: A simple OK response.
         """
         return self.append_command(RequestType.PfMerge, [destination] + source_keys)
+
+    def bitcount(
+        self: TTransaction, key: str, options: Optional[OffsetOptions] = None
+    ) -> TTransaction:
+        """
+        Counts the number of set bits (population counting) in a string stored at `key`. The `options` argument can
+        optionally be provided to count the number of bits in a specific string interval.
+
+        See https://valkey.io/commands/bitcount for more details.
+
+        Args:
+            key (str): The key for the string to count the set bits of.
+            options (Optional[OffsetOptions]): The offset options.
+
+        Command response:
+            int: If `options` is provided, returns the number of set bits in the string interval specified by `options`.
+                If `options` is not provided, returns the number of set bits in the string stored at `key`.
+                Otherwise, if `key` is missing, returns `0` as it is treated as an empty string.
+        """
+        args = [key]
+        if options is not None:
+            args = args + options.to_args()
+
+        return self.append_command(RequestType.BitCount, args)
 
     def setbit(self: TTransaction, key: str, offset: int, value: int) -> TTransaction:
         """

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -6,6 +6,7 @@ from typing import List, Union, cast
 
 import pytest
 from glide import RequestError
+from glide.async_commands.bitmap import BitmapIndexType, OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import InsertPosition, StreamAddOptions, TrimByMinId
 from glide.async_commands.sorted_set import (
@@ -56,6 +57,7 @@ async def transaction_test(
     key17 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sort
     key18 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # sort
     key19 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # bitmap
+    key20 = "{{{}}}:{}".format(keyslot, get_random_string(3))  # bitmap
 
     value = datetime.now(timezone.utc).strftime("%m/%d/%Y, %H:%M:%S")
     value2 = get_random_string(5)
@@ -352,6 +354,17 @@ async def transaction_test(
     args.append(1)
     transaction.getbit(key19, 1)
     args.append(0)
+
+    transaction.set(key20, "foobar")
+    args.append(OK)
+    transaction.bitcount(key20)
+    args.append(26)
+    transaction.bitcount(key20, OffsetOptions(1, 1))
+    args.append(6)
+
+    if not await check_if_server_version_lt(redis_client, "7.0.0"):
+        transaction.bitcount(key20, OffsetOptions(5, 30, BitmapIndexType.BIT))
+        args.append(17)
 
     transaction.geoadd(
         key12,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/bitcount/
- Counts the number of set bits (population counting) in the string stored at `key`
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/bitcount.json))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
