### PR TITLE
Python: add BITOP command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * Python: Added GETBIT command ([#1575](https://github.com/aws/glide-for-redis/pull/1575))
 * Python: Added BITCOUNT command ([#1592](https://github.com/aws/glide-for-redis/pull/1592))
 * Python: Added TOUCH command ([#1582](https://github.com/aws/glide-for-redis/pull/1582))
+* Python: Added BITOP command ([#1596](https://github.com/aws/glide-for-redis/pull/1596))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -1,6 +1,6 @@
 # Copyright GLIDE-for-Redis Project Contributors - SPDX Identifier: Apache-2.0
 
-from glide.async_commands.bitmap import BitmapIndexType, OffsetOptions
+from glide.async_commands.bitmap import BitmapIndexType, BitwiseOperation, OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,

--- a/python/python/glide/async_commands/bitmap.py
+++ b/python/python/glide/async_commands/bitmap.py
@@ -48,3 +48,15 @@ class OffsetOptions:
             args.append(self.index_type.value)
 
         return args
+
+
+class BitwiseOperation(Enum):
+    """
+    Enumeration defining the bitwise operation to use in the `BITOP` command. Specifies the bitwise operation to
+    perform between the passed in keys.
+    """
+
+    AND = "AND"
+    OR = "OR"
+    XOR = "XOR"
+    NOT = "NOT"

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -3,7 +3,7 @@
 import threading
 from typing import List, Mapping, Optional, Tuple, TypeVar, Union
 
-from glide.async_commands.bitmap import OffsetOptions
+from glide.async_commands.bitmap import BitwiseOperation, OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import (
     ConditionalChange,
@@ -3105,6 +3105,30 @@ class BaseTransaction:
                 the length of the string.
         """
         return self.append_command(RequestType.GetBit, [key, str(offset)])
+
+    def bitop(
+        self: TTransaction,
+        operation: BitwiseOperation,
+        destination: str,
+        keys: List[str],
+    ) -> TTransaction:
+        """
+        Perform a bitwise operation between multiple keys (containing string values) and store the result in the
+        `destination`.
+
+        See https://valkey.io/commands/bitop for more details.
+
+        Args:
+            operation (BitwiseOperation): The bitwise operation to perform.
+            destination (str): The key that will store the resulting string.
+            keys (List[str]): The list of keys to perform the bitwise operation on.
+
+        Command response:
+            int: The size of the string stored in `destination`.
+        """
+        return self.append_command(
+            RequestType.BitOp, [operation.value, destination] + keys
+        )
 
     def object_encoding(self: TTransaction, key: str) -> TTransaction:
         """

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -6,7 +6,7 @@ from typing import List, Union, cast
 
 import pytest
 from glide import RequestError
-from glide.async_commands.bitmap import BitmapIndexType, OffsetOptions
+from glide.async_commands.bitmap import BitmapIndexType, BitwiseOperation, OffsetOptions
 from glide.async_commands.command_args import Limit, ListDirection, OrderBy
 from glide.async_commands.core import InsertPosition, StreamAddOptions, TrimByMinId
 from glide.async_commands.sorted_set import (
@@ -381,6 +381,13 @@ async def transaction_test(
     args.append(26)
     transaction.bitcount(key20, OffsetOptions(1, 1))
     args.append(6)
+
+    transaction.set(key19, "abcdef")
+    args.append(OK)
+    transaction.bitop(BitwiseOperation.AND, key19, [key19, key20])
+    args.append(6)
+    transaction.get(key19)
+    args.append("`bc`ab")
 
     if not await check_if_server_version_lt(redis_client, "7.0.0"):
         transaction.bitcount(key20, OffsetOptions(5, 30, BitmapIndexType.BIT))


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/bitop/
- Perform a bitwise operation between multiple keys (containing string values) and store the result in the `destination`.
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/bitop.json))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
