### PR TITLE
Java: reverted byte[] overloading

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -199,7 +199,6 @@ import glide.ffi.resolvers.RedisValueResolver;
 import glide.managers.BaseCommandResponseResolver;
 import glide.managers.CommandManager;
 import glide.managers.ConnectionManager;
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -316,13 +315,9 @@ public abstract class BaseClient
     @SuppressWarnings("unchecked")
     protected <T> T handleRedisResponse(
             Class<T> classType, EnumSet<ResponseFlags> flags, Response response) throws RedisException {
-        boolean encodingUtf8 = flags.contains(ResponseFlags.ENCODING_UTF8);
         boolean isNullable = flags.contains(ResponseFlags.IS_NULLABLE);
         Object value =
-                encodingUtf8
-                        ? new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response)
-                        : new BaseCommandResponseResolver(RedisValueResolver::valueFromPointerBinary)
-                                .apply(response);
+                new BaseCommandResponseResolver(RedisValueResolver::valueFromPointer).apply(response);
         if (isNullable && (value == null)) {
             return null;
         }
@@ -338,21 +333,15 @@ public abstract class BaseClient
     }
 
     protected Object handleObjectOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(
-                Object.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(Object.class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     protected String handleStringResponse(Response response) throws RedisException {
-        return handleRedisResponse(String.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(String.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     protected String handleStringOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(
-                String.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
-    }
-
-    protected byte[] handleBytesOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(byte[].class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
+        return handleRedisResponse(String.class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     protected Boolean handleBooleanResponse(Response response) throws RedisException {
@@ -376,14 +365,11 @@ public abstract class BaseClient
     }
 
     protected Object[] handleArrayResponse(Response response) throws RedisException {
-        return handleRedisResponse(Object[].class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(Object[].class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     protected Object[] handleArrayOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(
-                Object[].class,
-                EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8),
-                response);
+        return handleRedisResponse(Object[].class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     /**
@@ -393,7 +379,7 @@ public abstract class BaseClient
      */
     @SuppressWarnings("unchecked") // raw Map cast to Map<String, V>
     protected <V> Map<String, V> handleMapResponse(Response response) throws RedisException {
-        return handleRedisResponse(Map.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(Map.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     /**
@@ -403,8 +389,7 @@ public abstract class BaseClient
      */
     @SuppressWarnings("unchecked") // raw Map cast to Map<String, V>
     protected <V> Map<String, V> handleMapOrNullResponse(Response response) throws RedisException {
-        return handleRedisResponse(
-                Map.class, EnumSet.of(ResponseFlags.IS_NULLABLE, ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(Map.class, EnumSet.of(ResponseFlags.IS_NULLABLE), response);
     }
 
     /**
@@ -426,7 +411,7 @@ public abstract class BaseClient
 
     @SuppressWarnings("unchecked") // raw Set cast to Set<String>
     protected Set<String> handleSetResponse(Response response) throws RedisException {
-        return handleRedisResponse(Set.class, EnumSet.of(ResponseFlags.ENCODING_UTF8), response);
+        return handleRedisResponse(Set.class, EnumSet.noneOf(ResponseFlags.class), response);
     }
 
     /** Process a <code>FUNCTION LIST</code> standalone response. */
@@ -464,21 +449,9 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<byte[]> get(@NonNull byte[] key) {
-        return commandManager.submitNewCommand(
-                Get, Arrays.asList(key), this::handleBytesOrNullResponse);
-    }
-
-    @Override
     public CompletableFuture<String> getdel(@NonNull String key) {
         return commandManager.submitNewCommand(
                 GetDel, new String[] {key}, this::handleStringOrNullResponse);
-    }
-
-    @Override
-    public CompletableFuture<String> set(@NonNull byte[] key, @NonNull byte[] value) {
-        return commandManager.submitNewCommand(
-                Set, Arrays.asList(key, value), this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/ResponseFlags.java
+++ b/java/client/src/main/java/glide/api/ResponseFlags.java
@@ -2,8 +2,6 @@
 package glide.api;
 
 public enum ResponseFlags {
-    /** Strings in the response are UTF-8 encoded */
-    ENCODING_UTF8,
     /** Null is a valid response */
     IS_NULLABLE,
 }

--- a/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StringBaseCommands.java
@@ -38,25 +38,6 @@ public interface StringBaseCommands {
     CompletableFuture<String> get(String key);
 
     /**
-     * Gets the value associated with the given <code>key</code>, or <code>null</code> if no such
-     * value exists.
-     *
-     * @see <a href="https://redis.io/commands/get/">redis.io</a> for details.
-     * @param key The <code>key</code> to retrieve from the database.
-     * @return Response from Redis. If <code>key</code> exists, returns the <code>value</code> of
-     *     <code>key</code> as a <code>String</code>. Otherwise, return <code>null</code>.
-     * @example
-     *     <pre>{@code
-     * byte[] value = client.get("key").get();
-     * assert Arrays.equals(value, "value".getBytes());
-     *
-     * String value = client.get("non_existing_key").get();
-     * assert value.equals(null);
-     * }</pre>
-     */
-    CompletableFuture<byte[]> get(byte[] key);
-
-    /**
      * Gets a string value associated with the given <code>key</code> and deletes the key.
      *
      * @see <a href="https://redis.io/docs/latest/commands/getdel/">redis.io</a> for details.
@@ -88,21 +69,6 @@ public interface StringBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> set(String key, String value);
-
-    /**
-     * Sets the given <code>key</code> with the given value.
-     *
-     * @see <a href="https://redis.io/commands/set/">redis.io</a> for details.
-     * @param key The <code>key</code> to store.
-     * @param value The value to store with the given <code>key</code>.
-     * @return Response from Redis containing <code>"OK"</code>.
-     * @example
-     *     <pre>{@code
-     * String value = client.set("key".getBytes(), "value".getBytes()).get();
-     * assert value.equals("OK");
-     * }</pre>
-     */
-    CompletableFuture<String> set(byte[] key, byte[] value);
 
     /**
      * Sets the given key with the given value. Return value is dependent on the passed options.

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -17,13 +17,4 @@ public class RedisValueResolver {
      * @return A RESP3 value
      */
     public static native Object valueFromPointer(long pointer);
-
-    /**
-     * Resolve a value received from Redis using given C-style pointer. This method does not assume
-     * that strings are valid UTF-8 encoded strings
-     *
-     * @param pointer A memory pointer from {@link Response}
-     * @return A RESP3 value
-     */
-    public static native Object valueFromPointerBinary(long pointer);
 }

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -324,17 +324,6 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
-    public void set_get_binary_data(BaseClient client) {
-        byte[] key = "set_get_binary_data_key".getBytes();
-        byte[] value = {(byte) 0x01, (byte) 0x00, (byte) 0x01, (byte) 0x00, (byte) 0x02};
-        assert client.set(key, value).get().equals("OK");
-        byte[] data = client.get(key).get();
-        assert Arrays.equals(data, value);
-    }
-
-    @SneakyThrows
-    @ParameterizedTest(autoCloseArguments = false)
-    @MethodSource("getClients")
     public void set_only_if_does_not_exists_existing_key(BaseClient client) {
         String key = "set_only_if_does_not_exists_existing_key";
         SetOptions options = SetOptions.builder().conditionalSet(ONLY_IF_DOES_NOT_EXIST).build();
@@ -4467,9 +4456,9 @@ public class SharedCommandTests {
         // First bit is flipped to 1 and throws 'utf-8' codec can't decode byte 0x9e in position 0:
         // invalid start byte
         // TODO: update once fix is implemented for https://github.com/aws/glide-for-redis/issues/1447
-        ExecutionException executionException =
-                assertThrows(ExecutionException.class, () -> client.get(destination).get());
-        assertTrue(executionException.getCause() instanceof RuntimeException);
+        // ExecutionException executionException =
+        //        assertThrows(ExecutionException.class, () -> client.get(destination).get());
+        // assertTrue(executionException.getCause() instanceof RuntimeException);
         assertEquals(0, client.setbit(key1, 0, 1).get());
         assertEquals(1L, client.bitop(BitwiseOperation.NOT, destination, new String[] {key1}).get());
         assertEquals("\u001e", client.get(destination).get());
@@ -4487,7 +4476,7 @@ public class SharedCommandTests {
 
         // Exception thrown due to the key holding a value with the wrong type
         assertEquals(1, client.sadd(emptyKey1, new String[] {value1}).get());
-        executionException =
+        ExecutionException executionException =
                 assertThrows(
                         ExecutionException.class,
                         () -> client.bitop(BitwiseOperation.AND, destination, new String[] {emptyKey1}).get());


### PR DESCRIPTION
As discussed, the first step before introducing `GlideString` is to revert PR https://github.com/aws/glide-for-redis/pull/1526 This commit does that

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
