### PR TITLE
Python: add missing classes to __all__ section in __init__.py

### DIFF
--- a/python/python/glide/__init__.py
+++ b/python/python/glide/__init__.py
@@ -87,6 +87,8 @@ __all__ = [
     # Response
     "OK",
     # Commands
+    "BitmapIndexType",
+    "BitwiseOperation",
     "Script",
     "ScoreBoundary",
     "ConditionalChange",
@@ -106,6 +108,7 @@ __all__ = [
     "LexBoundary",
     "Limit",
     "ListDirection",
+    "OffsetOptions",
     "RangeByIndex",
     "RangeByLex",
     "RangeByScore",

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4557,7 +4557,7 @@ class CoreCommands(Protocol):
                 value of the string held at `key`.
 
         Examples:
-            >>> await client.set("key1", "A12")  # "A1" has binary value 01000001 00110001 00110010
+            >>> await client.set("key1", "A12")  # "A12" has binary value 01000001 00110001 00110010
             >>> await client.bitpos_interval("key1", 1, 1, -1)
                 10  # The first occurrence of bit value 1 in the second byte to the last byte of the string stored at "key1" is at the eleventh position.
             >>> await client.bitpos_interval("key1", 1, 2, 9, BitmapIndexType.BIT)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- some classes were missing from the \_\_all__ section of the \_\_init__.py file. This PR adds the missing classes.
- also fixed small error in the bitpos example documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
