### PR TITLE
Python: add ZREVRANK command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * Python: Added BITOP command ([#1596](https://github.com/aws/glide-for-redis/pull/1596))
 * Python: Added BITPOS command ([#1604](https://github.com/aws/glide-for-redis/pull/1604))
 * Python: Added GETEX command ([#1612](https://github.com/aws/glide-for-redis/pull/1612))
+* Python: Added ZREVRANK command ([#1614](https://github.com/aws/glide-for-redis/pull/1614))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -4376,6 +4376,65 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.ZInterCard, args),
         )
 
+    async def zrevrank(self, key: str, member: str) -> Optional[int]:
+        """
+        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
+        lowest, starting from `0`.
+
+        To get the rank of `member` with its score, see `zrevrank_withscore`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Returns:
+            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Examples:
+            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
+            >>> await client.zrevrank("my_sorted_set", "member2")
+                2  # "member2" has the third-highest score in the sorted set "my_sorted_set"
+        """
+        return cast(
+            Optional[int],
+            await self._execute_command(RequestType.ZRevRank, [key, member]),
+        )
+
+    async def zrevrank_withscore(
+        self, key: str, member: str
+    ) -> Optional[List[Union[int, float]]]:
+        """
+        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
+        highest to lowest, starting from `0`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Returns:
+            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
+                in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Examples:
+            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
+            >>> await client.zrevrank("my_sorted_set", "member2")
+                [2, 8.2]  # "member2" with score 8.2 has the third-highest score in the sorted set "my_sorted_set"
+
+        Since: Redis version 7.2.0.
+        """
+        return cast(
+            Optional[List[Union[int, float]]],
+            await self._execute_command(
+                RequestType.ZRevRank, [key, member, "WITHSCORE"]
+            ),
+        )
+
     async def invoke_script(
         self,
         script: Script,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -3575,6 +3575,65 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.ZRank, [key, member, "WITHSCORE"]),
         )
 
+    async def zrevrank(self, key: str, member: str) -> Optional[int]:
+        """
+        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
+        lowest, starting from `0`.
+
+        To get the rank of `member` with its score, see `zrevrank_withscore`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Returns:
+            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Examples:
+            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
+            >>> await client.zrevrank("my_sorted_set", "member2")
+                2  # "member2" has the third-highest score in the sorted set "my_sorted_set"
+        """
+        return cast(
+            Optional[int],
+            await self._execute_command(RequestType.ZRevRank, [key, member]),
+        )
+
+    async def zrevrank_withscore(
+        self, key: str, member: str
+    ) -> Optional[List[Union[int, float]]]:
+        """
+        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
+        highest to lowest, starting from `0`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Returns:
+            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
+                in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Examples:
+            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
+            >>> await client.zrevrank("my_sorted_set", "member2")
+                [2, 8.2]  # "member2" with score 8.2 has the third-highest score in the sorted set "my_sorted_set"
+
+        Since: Redis version 7.2.0.
+        """
+        return cast(
+            Optional[List[Union[int, float]]],
+            await self._execute_command(
+                RequestType.ZRevRank, [key, member, "WITHSCORE"]
+            ),
+        )
+
     async def zrem(
         self,
         key: str,
@@ -4374,65 +4433,6 @@ class CoreCommands(Protocol):
         return cast(
             int,
             await self._execute_command(RequestType.ZInterCard, args),
-        )
-
-    async def zrevrank(self, key: str, member: str) -> Optional[int]:
-        """
-        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
-        lowest, starting from `0`.
-
-        To get the rank of `member` with its score, see `zrevrank_withscore`.
-
-        See https://valkey.io/commands/zrevrank for more details.
-
-        Args:
-            key (str): The key of the sorted set.
-            member (str): The member whose rank is to be retrieved.
-
-        Returns:
-            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
-                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
-
-        Examples:
-            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
-            >>> await client.zrevrank("my_sorted_set", "member2")
-                2  # "member2" has the third-highest score in the sorted set "my_sorted_set"
-        """
-        return cast(
-            Optional[int],
-            await self._execute_command(RequestType.ZRevRank, [key, member]),
-        )
-
-    async def zrevrank_withscore(
-        self, key: str, member: str
-    ) -> Optional[List[Union[int, float]]]:
-        """
-        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
-        highest to lowest, starting from `0`.
-
-        See https://valkey.io/commands/zrevrank for more details.
-
-        Args:
-            key (str): The key of the sorted set.
-            member (str): The member whose rank is to be retrieved.
-
-        Returns:
-            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
-                in the sorted set, where ranks are ordered from high to low based on scores.
-                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
-
-        Examples:
-            >>> await client.zadd("my_sorted_set", {"member1": 10.5, "member2": 8.2, "member3": 9.6})
-            >>> await client.zrevrank("my_sorted_set", "member2")
-                [2, 8.2]  # "member2" with score 8.2 has the third-highest score in the sorted set "my_sorted_set"
-
-        Since: Redis version 7.2.0.
-        """
-        return cast(
-            Optional[List[Union[int, float]]],
-            await self._execute_command(
-                RequestType.ZRevRank, [key, member, "WITHSCORE"]
-            ),
         )
 
     async def invoke_script(

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2986,6 +2986,45 @@ class BaseTransaction:
 
         return self.append_command(RequestType.ZInterCard, args)
 
+    def zrevrank(self: TTransaction, key: str, member: str) -> TTransaction:
+        """
+        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
+        lowest, starting from `0`.
+
+        To get the rank of `member` with its score, see `zrevrank_withscore`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Command response:
+            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+        """
+        return self.append_command(RequestType.ZRevRank, [key, member])
+
+    def zrevrank_withscore(self: TTransaction, key: str, member: str) -> TTransaction:
+        """
+        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
+        highest to lowest, starting from `0`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Command response:
+            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
+                in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Since: Redis version 7.2.0.
+        """
+        return self.append_command(RequestType.ZRevRank, [key, member, "WITHSCORE"])
+
     def dbsize(self: TTransaction) -> TTransaction:
         """
         Returns the number of keys in the currently selected database.

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2440,6 +2440,45 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.ZRank, [key, member, "WITHSCORE"])
 
+    def zrevrank(self: TTransaction, key: str, member: str) -> TTransaction:
+        """
+        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
+        lowest, starting from `0`.
+
+        To get the rank of `member` with its score, see `zrevrank_withscore`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Command response:
+            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+        """
+        return self.append_command(RequestType.ZRevRank, [key, member])
+
+    def zrevrank_withscore(self: TTransaction, key: str, member: str) -> TTransaction:
+        """
+        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
+        highest to lowest, starting from `0`.
+
+        See https://valkey.io/commands/zrevrank for more details.
+
+        Args:
+            key (str): The key of the sorted set.
+            member (str): The member whose rank is to be retrieved.
+
+        Command response:
+            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
+                in the sorted set, where ranks are ordered from high to low based on scores.
+                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
+
+        Since: Redis version 7.2.0.
+        """
+        return self.append_command(RequestType.ZRevRank, [key, member, "WITHSCORE"])
+
     def zrem(
         self: TTransaction,
         key: str,
@@ -2985,45 +3024,6 @@ class BaseTransaction:
             args.extend(["LIMIT", str(limit)])
 
         return self.append_command(RequestType.ZInterCard, args)
-
-    def zrevrank(self: TTransaction, key: str, member: str) -> TTransaction:
-        """
-        Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to
-        lowest, starting from `0`.
-
-        To get the rank of `member` with its score, see `zrevrank_withscore`.
-
-        See https://valkey.io/commands/zrevrank for more details.
-
-        Args:
-            key (str): The key of the sorted set.
-            member (str): The member whose rank is to be retrieved.
-
-        Command response:
-            Optional[int]: The rank of `member` in the sorted set, where ranks are ordered from high to low based on scores.
-                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
-        """
-        return self.append_command(RequestType.ZRevRank, [key, member])
-
-    def zrevrank_withscore(self: TTransaction, key: str, member: str) -> TTransaction:
-        """
-        Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the
-        highest to lowest, starting from `0`.
-
-        See https://valkey.io/commands/zrevrank for more details.
-
-        Args:
-            key (str): The key of the sorted set.
-            member (str): The member whose rank is to be retrieved.
-
-        Command response:
-            Optional[List[Union[int, float]]]: A list containing the rank (as `int`) and score (as `float`) of `member`
-                in the sorted set, where ranks are ordered from high to low based on scores.
-                If `key` doesn't exist, or if `member` is not present in the set, `None` will be returned.
-
-        Since: Redis version 7.2.0.
-        """
-        return self.append_command(RequestType.ZRevRank, [key, member, "WITHSCORE"])
 
     def dbsize(self: TTransaction) -> TTransaction:
         """

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -4078,6 +4078,41 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_zrevrank(self, redis_client: TRedisClient):
+        key = get_random_string(10)
+        non_existing_key = get_random_string(10)
+        string_key = get_random_string(10)
+        member_scores = {"one": 1.0, "two": 2.0, "three": 3.0}
+
+        assert await redis_client.zadd(key, member_scores) == 3
+        assert await redis_client.zrevrank(key, "three") == 0
+        assert await redis_client.zrevrank(key, "non_existing_member") is None
+        assert (
+            await redis_client.zrevrank(non_existing_key, "non_existing_member") is None
+        )
+
+        if not check_if_server_version_lt(redis_client, "7.2.0"):
+            assert await redis_client.zrevrank_withscore(key, "one") == [2, 1.0]
+            assert (
+                await redis_client.zrevrank_withscore(key, "non_existing_member")
+                is None
+            )
+            assert (
+                await redis_client.zrevrank_withscore(
+                    non_existing_key, "non_existing_member"
+                )
+                is None
+            )
+
+        # key exists, but it is not a sorted set
+        assert await redis_client.set(string_key, "foo") == OK
+        with pytest.raises(RequestError):
+            await redis_client.zrevrank(string_key, "member")
+        with pytest.raises(RequestError):
+            await redis_client.zrevrank_withscore(string_key, "member")
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_zdiff(self, redis_client: TRedisClient):
         key1 = f"{{testKey}}:1-{get_random_string(10)}"
         key2 = f"{{testKey}}:2-{get_random_string(10)}"
@@ -4342,41 +4377,6 @@ class TestCommands:
         assert await redis_client.set(string_key, "value") == OK
         with pytest.raises(RequestError):
             await redis_client.zintercard([string_key])
-
-    @pytest.mark.parametrize("cluster_mode", [True, False])
-    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
-    async def test_zrevrank(self, redis_client: TRedisClient):
-        key = get_random_string(10)
-        non_existing_key = get_random_string(10)
-        string_key = get_random_string(10)
-        member_scores = {"one": 1.0, "two": 2.0, "three": 3.0}
-
-        assert await redis_client.zadd(key, member_scores) == 3
-        assert await redis_client.zrevrank(key, "three") == 0
-        assert await redis_client.zrevrank(key, "non_existing_member") is None
-        assert (
-            await redis_client.zrevrank(non_existing_key, "non_existing_member") is None
-        )
-
-        if not check_if_server_version_lt(redis_client, "7.2.0"):
-            assert await redis_client.zrevrank_withscore(key, "one") == [2, 1.0]
-            assert (
-                await redis_client.zrevrank_withscore(key, "non_existing_member")
-                is None
-            )
-            assert (
-                await redis_client.zrevrank_withscore(
-                    non_existing_key, "non_existing_member"
-                )
-                is None
-            )
-
-        # key exists, but it is not a sorted set
-        assert await redis_client.set(string_key, "foo") == OK
-        with pytest.raises(RequestError):
-            await redis_client.zrevrank(string_key, "member")
-        with pytest.raises(RequestError):
-            await redis_client.zrevrank_withscore(string_key, "member")
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -286,9 +286,13 @@ async def transaction_test(
     args.append(4)
     transaction.zrank(key8, "one")
     args.append(0)
+    transaction.zrevrank(key8, "one")
+    args.append(3)
     if not await check_if_server_version_lt(redis_client, "7.2.0"):
         transaction.zrank_withscore(key8, "one")
         args.append([0, 1])
+        transaction.zrevrank_withscore(key8, "one")
+        args.append([3, 1])
     transaction.zadd_incr(key8, "one", 3)
     args.append(4)
     transaction.zincrby(key8, 3, "one")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/zrevrank/
- Returns the rank of `member` in the sorted set stored at `key`, where scores are ordered from the highest to lowest, starting from `0`
- Policies: none (see [here](https://github.com/valkey-io/valkey/blob/26388270f197bce84817eea0a73d687d58442654/src/commands/zrevrank.json))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
