### PR TITLE
GS version of ttl, pttl, expire, pexpire, expireAt, pexpireAt, expireTime, pexpireTime, exists

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -200,8 +200,6 @@ import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeys;
 import glide.api.models.commands.ZAddOptions;
-import glide.api.models.commands.bitmap.BitFieldOptions.BitFieldReadOnlySubCommands;
-import glide.api.models.commands.bitmap.BitFieldOptions.BitFieldSubCommands;
 import glide.api.models.commands.bitmap.BitmapIndexType;
 import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoAddOptions;
@@ -1009,7 +1007,8 @@ public abstract class BaseClient
     public CompletableFuture<Boolean> expire(
             @NonNull GlideString key, long seconds, @NonNull ExpireOptions expireOptions) {
         GlideString[] arguments =
-                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(seconds))}, expireOptions.toGlideStringArgs());
+                ArrayUtils.addAll(
+                        new GlideString[] {key, gs(Long.toString(seconds))}, expireOptions.toGlideStringArgs());
         return commandManager.submitNewCommand(Expire, arguments, this::handleBooleanResponse);
     }
 
@@ -1022,7 +1021,9 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Boolean> expireAt(@NonNull GlideString key, long unixSeconds) {
         return commandManager.submitNewCommand(
-                ExpireAt, new GlideString[] {key, gs(Long.toString(unixSeconds))}, this::handleBooleanResponse);
+                ExpireAt,
+                new GlideString[] {key, gs(Long.toString(unixSeconds))},
+                this::handleBooleanResponse);
     }
 
     @Override
@@ -1037,7 +1038,9 @@ public abstract class BaseClient
     public CompletableFuture<Boolean> expireAt(
             @NonNull GlideString key, long unixSeconds, @NonNull ExpireOptions expireOptions) {
         GlideString[] arguments =
-                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(unixSeconds))}, expireOptions.toGlideStringArgs());
+                ArrayUtils.addAll(
+                        new GlideString[] {key, gs(Long.toString(unixSeconds))},
+                        expireOptions.toGlideStringArgs());
         return commandManager.submitNewCommand(ExpireAt, arguments, this::handleBooleanResponse);
     }
 
@@ -1050,7 +1053,9 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Boolean> pexpire(@NonNull GlideString key, long milliseconds) {
         return commandManager.submitNewCommand(
-                PExpire, new GlideString[] {key, gs(Long.toString(milliseconds))}, this::handleBooleanResponse);
+                PExpire,
+                new GlideString[] {key, gs(Long.toString(milliseconds))},
+                this::handleBooleanResponse);
     }
 
     @Override
@@ -1065,7 +1070,9 @@ public abstract class BaseClient
     public CompletableFuture<Boolean> pexpire(
             @NonNull GlideString key, long milliseconds, @NonNull ExpireOptions expireOptions) {
         GlideString[] arguments =
-                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(milliseconds))}, expireOptions.toGlideStringArgs());
+                ArrayUtils.addAll(
+                        new GlideString[] {key, gs(Long.toString(milliseconds))},
+                        expireOptions.toGlideStringArgs());
         return commandManager.submitNewCommand(PExpire, arguments, this::handleBooleanResponse);
     }
 
@@ -1099,7 +1106,8 @@ public abstract class BaseClient
             @NonNull GlideString key, long unixMilliseconds, @NonNull ExpireOptions expireOptions) {
         GlideString[] arguments =
                 ArrayUtils.addAll(
-                        new GlideString[] {key, gs(Long.toString(unixMilliseconds))}, expireOptions.toGlideStringArgs());
+                        new GlideString[] {key, gs(Long.toString(unixMilliseconds))},
+                        expireOptions.toGlideStringArgs());
         return commandManager.submitNewCommand(PExpireAt, arguments, this::handleBooleanResponse);
     }
 

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -200,6 +200,8 @@ import glide.api.models.commands.WeightAggregateOptions.Aggregate;
 import glide.api.models.commands.WeightAggregateOptions.KeyArray;
 import glide.api.models.commands.WeightAggregateOptions.KeysOrWeightedKeys;
 import glide.api.models.commands.ZAddOptions;
+import glide.api.models.commands.bitmap.BitFieldOptions.BitFieldReadOnlySubCommands;
+import glide.api.models.commands.bitmap.BitFieldOptions.BitFieldSubCommands;
 import glide.api.models.commands.bitmap.BitmapIndexType;
 import glide.api.models.commands.bitmap.BitwiseOperation;
 import glide.api.models.commands.geospatial.GeoAddOptions;
@@ -974,6 +976,11 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Long> exists(@NonNull GlideString[] keys) {
+        return commandManager.submitNewCommand(Exists, keys, this::handleLongResponse);
+    }
+
+    @Override
     public CompletableFuture<Long> unlink(@NonNull String[] keys) {
         return commandManager.submitNewCommand(Unlink, keys, this::handleLongResponse);
     }
@@ -985,6 +992,12 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Boolean> expire(@NonNull GlideString key, long seconds) {
+        return commandManager.submitNewCommand(
+                Expire, new GlideString[] {key, gs(Long.toString(seconds))}, this::handleBooleanResponse);
+    }
+
+    @Override
     public CompletableFuture<Boolean> expire(
             @NonNull String key, long seconds, @NonNull ExpireOptions expireOptions) {
         String[] arguments =
@@ -993,9 +1006,23 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Boolean> expire(
+            @NonNull GlideString key, long seconds, @NonNull ExpireOptions expireOptions) {
+        GlideString[] arguments =
+                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(seconds))}, expireOptions.toGlideStringArgs());
+        return commandManager.submitNewCommand(Expire, arguments, this::handleBooleanResponse);
+    }
+
+    @Override
     public CompletableFuture<Boolean> expireAt(@NonNull String key, long unixSeconds) {
         return commandManager.submitNewCommand(
                 ExpireAt, new String[] {key, Long.toString(unixSeconds)}, this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> expireAt(@NonNull GlideString key, long unixSeconds) {
+        return commandManager.submitNewCommand(
+                ExpireAt, new GlideString[] {key, gs(Long.toString(unixSeconds))}, this::handleBooleanResponse);
     }
 
     @Override
@@ -1007,9 +1034,23 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Boolean> expireAt(
+            @NonNull GlideString key, long unixSeconds, @NonNull ExpireOptions expireOptions) {
+        GlideString[] arguments =
+                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(unixSeconds))}, expireOptions.toGlideStringArgs());
+        return commandManager.submitNewCommand(ExpireAt, arguments, this::handleBooleanResponse);
+    }
+
+    @Override
     public CompletableFuture<Boolean> pexpire(@NonNull String key, long milliseconds) {
         return commandManager.submitNewCommand(
                 PExpire, new String[] {key, Long.toString(milliseconds)}, this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> pexpire(@NonNull GlideString key, long milliseconds) {
+        return commandManager.submitNewCommand(
+                PExpire, new GlideString[] {key, gs(Long.toString(milliseconds))}, this::handleBooleanResponse);
     }
 
     @Override
@@ -1021,10 +1062,26 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Boolean> pexpire(
+            @NonNull GlideString key, long milliseconds, @NonNull ExpireOptions expireOptions) {
+        GlideString[] arguments =
+                ArrayUtils.addAll(new GlideString[] {key, gs(Long.toString(milliseconds))}, expireOptions.toGlideStringArgs());
+        return commandManager.submitNewCommand(PExpire, arguments, this::handleBooleanResponse);
+    }
+
+    @Override
     public CompletableFuture<Boolean> pexpireAt(@NonNull String key, long unixMilliseconds) {
         return commandManager.submitNewCommand(
                 PExpireAt,
                 new String[] {key, Long.toString(unixMilliseconds)},
+                this::handleBooleanResponse);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> pexpireAt(@NonNull GlideString key, long unixMilliseconds) {
+        return commandManager.submitNewCommand(
+                PExpireAt,
+                new GlideString[] {key, gs(Long.toString(unixMilliseconds))},
                 this::handleBooleanResponse);
     }
 
@@ -1038,8 +1095,22 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Boolean> pexpireAt(
+            @NonNull GlideString key, long unixMilliseconds, @NonNull ExpireOptions expireOptions) {
+        GlideString[] arguments =
+                ArrayUtils.addAll(
+                        new GlideString[] {key, gs(Long.toString(unixMilliseconds))}, expireOptions.toGlideStringArgs());
+        return commandManager.submitNewCommand(PExpireAt, arguments, this::handleBooleanResponse);
+    }
+
+    @Override
     public CompletableFuture<Long> ttl(@NonNull String key) {
         return commandManager.submitNewCommand(TTL, new String[] {key}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> ttl(@NonNull GlideString key) {
+        return commandManager.submitNewCommand(TTL, new GlideString[] {key}, this::handleLongResponse);
     }
 
     @Override
@@ -1049,9 +1120,21 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Long> expiretime(@NonNull GlideString key) {
+        return commandManager.submitNewCommand(
+                ExpireTime, new GlideString[] {key}, this::handleLongResponse);
+    }
+
+    @Override
     public CompletableFuture<Long> pexpiretime(@NonNull String key) {
         return commandManager.submitNewCommand(
                 PExpireTime, new String[] {key}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> pexpiretime(@NonNull GlideString key) {
+        return commandManager.submitNewCommand(
+                PExpireTime, new GlideString[] {key}, this::handleLongResponse);
     }
 
     @Override
@@ -1562,6 +1645,11 @@ public abstract class BaseClient
     @Override
     public CompletableFuture<Long> pttl(@NonNull String key) {
         return commandManager.submitNewCommand(PTTL, new String[] {key}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Long> pttl(@NonNull GlideString key) {
+        return commandManager.submitNewCommand(PTTL, new GlideString[] {key}, this::handleLongResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -279,7 +279,8 @@ public interface GenericBaseCommands {
      * assert isSet;
      * }</pre>
      */
-    CompletableFuture<Boolean> expireAt(GlideString key, long unixSeconds, ExpireOptions expireOptions);
+    CompletableFuture<Boolean> expireAt(
+            GlideString key, long unixSeconds, ExpireOptions expireOptions);
 
     /**
      * Sets a timeout on <code>key</code> in milliseconds. After the timeout has expired, the <code>
@@ -375,7 +376,8 @@ public interface GenericBaseCommands {
      * assert isSet;
      * }</pre>
      */
-    CompletableFuture<Boolean> pexpire(GlideString key, long milliseconds, ExpireOptions expireOptions);
+    CompletableFuture<Boolean> pexpire(
+            GlideString key, long milliseconds, ExpireOptions expireOptions);
 
     /**
      * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (milliseconds since
@@ -473,7 +475,7 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Boolean> pexpireAt(
-        GlideString key, long unixMilliseconds, ExpireOptions expireOptions);
+            GlideString key, long unixMilliseconds, ExpireOptions expireOptions);
 
     /**
      * Returns the remaining time to live of <code>key</code> that has a timeout, in seconds.

--- a/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericBaseCommands.java
@@ -54,6 +54,23 @@ public interface GenericBaseCommands {
     CompletableFuture<Long> exists(String[] keys);
 
     /**
+     * Returns the number of keys in <code>keys</code> that exist in the database.
+     *
+     * @apiNote When in cluster mode, the command may route to multiple nodes when <code>keys</code>
+     *     map to different hash slots.
+     * @see <a href="https://redis.io/commands/exists/">redis.io</a> for details.
+     * @param keys The keys list to check.
+     * @return The number of keys that exist. If the same existing key is mentioned in <code>keys
+     *     </code> multiple times, it will be counted multiple times.
+     * @example
+     *     <pre>{@code
+     * Long result = client.exists(new GlideString[] {gs("my_key"), gs("invalid_key")}).get();
+     * assert result == 1L;
+     * }</pre>
+     */
+    CompletableFuture<Long> exists(GlideString[] keys);
+
+    /**
      * Unlink (delete) multiple <code>keys</code> from the database. A key is ignored if it does not
      * exist. This command, similar to <a href="https://redis.io/commands/del/">DEL</a>, removes
      * specified keys and ignores non-existent ones. However, this command does not block the server,
@@ -108,6 +125,29 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param seconds The timeout in seconds.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.expire(gs("my_key"), 60).get();
+     * assert isSet; //Indicates that a timeout of 60 seconds has been set for gs("my_key").
+     * }</pre>
+     */
+    CompletableFuture<Boolean> expire(GlideString key, long seconds);
+
+    /**
+     * Sets a timeout on <code>key</code> in seconds. After the timeout has expired, the <code>key
+     * </code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire
+     * </code> set, the time to live is updated to the new value.<br>
+     * If <code>seconds</code> is a non-positive number, the <code>key</code> will be deleted rather
+     * than expired.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param seconds The timeout in seconds.
      * @param expireOptions The expire options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
@@ -115,10 +155,35 @@ public interface GenericBaseCommands {
      * @example
      *     <pre>{@code
      * Boolean isSet = client.expire("my_key", 60, ExpireOptions.HAS_NO_EXPIRY).get();
-     * assert isSet; //Indicates that a timeout of 60 seconds has been set for "my_key."
+     * assert isSet; //Indicates that a timeout of 60 seconds has been set for "my_key".
      * }</pre>
      */
     CompletableFuture<Boolean> expire(String key, long seconds, ExpireOptions expireOptions);
+
+    /**
+     * Sets a timeout on <code>key</code> in seconds. After the timeout has expired, the <code>key
+     * </code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire
+     * </code> set, the time to live is updated to the new value.<br>
+     * If <code>seconds</code> is a non-positive number, the <code>key</code> will be deleted rather
+     * than expired.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/expire/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param seconds The timeout in seconds.
+     * @param expireOptions The expire options.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
+     *     arguments.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.expire(gs("my_key"), 60, ExpireOptions.HAS_NO_EXPIRY).get();
+     * assert isSet; //Indicates that a timeout of 60 seconds has been set for gs("my_key").
+     * }</pre>
+     */
+    CompletableFuture<Boolean> expire(GlideString key, long seconds, ExpireOptions expireOptions);
 
     /**
      * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (seconds since January
@@ -156,6 +221,29 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
      * @param key The key to set timeout on it.
      * @param unixSeconds The timeout in an absolute Unix timestamp.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.expireAt(gs("my_key"), Instant.now().getEpochSecond() + 10).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> expireAt(GlideString key, long unixSeconds);
+
+    /**
+     * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (seconds since January
+     * 1, 1970) instead of specifying the number of seconds.<br>
+     * A timestamp in the past will delete the <code>key</code> immediately. After the timeout has
+     * expired, the <code>key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire</code> set, the time to live is
+     * updated to the new value.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param unixSeconds The timeout in an absolute Unix timestamp.
      * @param expireOptions The expire options.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
@@ -167,6 +255,31 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Boolean> expireAt(String key, long unixSeconds, ExpireOptions expireOptions);
+
+    /**
+     * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (seconds since January
+     * 1, 1970) instead of specifying the number of seconds.<br>
+     * A timestamp in the past will delete the <code>key</code> immediately. After the timeout has
+     * expired, the <code>key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire</code> set, the time to live is
+     * updated to the new value.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/expireat/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param unixSeconds The timeout in an absolute Unix timestamp.
+     * @param expireOptions The expire options.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
+     *     arguments.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.expireAt(gs("my_key"), Instant.now().getEpochSecond() + 10, ExpireOptions.HasNoExpiry).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> expireAt(GlideString key, long unixSeconds, ExpireOptions expireOptions);
 
     /**
      * Sets a timeout on <code>key</code> in milliseconds. After the timeout has expired, the <code>
@@ -194,6 +307,29 @@ public interface GenericBaseCommands {
     /**
      * Sets a timeout on <code>key</code> in milliseconds. After the timeout has expired, the <code>
      * key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>
+     * expire</code> set, the time to live is updated to the new value.<br>
+     * If <code>milliseconds</code> is a non-positive number, the <code>key</code> will be deleted
+     * rather than expired.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param milliseconds The timeout in milliseconds.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.pexpire(gs("my_key"), 60000).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> pexpire(GlideString key, long milliseconds);
+
+    /**
+     * Sets a timeout on <code>key</code> in milliseconds. After the timeout has expired, the <code>
+     * key</code> will automatically be deleted.<br>
      * If <code>key</code> already has an existing expire set, the time to live is updated to the new
      * value.<br>
      * If <code>milliseconds</code> is a non-positive number, the <code>key</code> will be deleted
@@ -215,6 +351,31 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Boolean> pexpire(String key, long milliseconds, ExpireOptions expireOptions);
+
+    /**
+     * Sets a timeout on <code>key</code> in milliseconds. After the timeout has expired, the <code>
+     * key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing expire set, the time to live is updated to the new
+     * value.<br>
+     * If <code>milliseconds</code> is a non-positive number, the <code>key</code> will be deleted
+     * rather than expired.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/pexpire/">redis.io</a> for details.
+     * @param key The key to set timeout on it.
+     * @param milliseconds The timeout in milliseconds.
+     * @param expireOptions The expire options.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
+     *     arguments.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.pexpire(gs("my_key"), 60000, ExpireOptions.HasNoExpiry).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> pexpire(GlideString key, long milliseconds, ExpireOptions expireOptions);
 
     /**
      * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (milliseconds since
@@ -252,6 +413,29 @@ public interface GenericBaseCommands {
      * @see <a href="https://redis.io/commands/pexpireat/">redis.io</a> for details.
      * @param key The <code>key</code> to set timeout on it.
      * @param unixMilliseconds The timeout in an absolute Unix timestamp.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.pexpireAt(gs("my_key"), Instant.now().toEpochMilli() + 10).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> pexpireAt(GlideString key, long unixMilliseconds);
+
+    /**
+     * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (milliseconds since
+     * January 1, 1970) instead of specifying the number of milliseconds.<br>
+     * A timestamp in the past will delete the <code>key</code> immediately. After the timeout has
+     * expired, the <code>key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire</code> set, the time to live is
+     * updated to the new value.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/pexpireat/">redis.io</a> for details.
+     * @param key The <code>key</code> to set timeout on it.
+     * @param unixMilliseconds The timeout in an absolute Unix timestamp.
      * @param expireOptions The expire option.
      * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
      *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
@@ -264,6 +448,32 @@ public interface GenericBaseCommands {
      */
     CompletableFuture<Boolean> pexpireAt(
             String key, long unixMilliseconds, ExpireOptions expireOptions);
+
+    /**
+     * Sets a timeout on <code>key</code>. It takes an absolute Unix timestamp (milliseconds since
+     * January 1, 1970) instead of specifying the number of milliseconds.<br>
+     * A timestamp in the past will delete the <code>key</code> immediately. After the timeout has
+     * expired, the <code>key</code> will automatically be deleted.<br>
+     * If <code>key</code> already has an existing <code>expire</code> set, the time to live is
+     * updated to the new value.<br>
+     * The timeout will only be cleared by commands that delete or overwrite the contents of <code>key
+     * </code>.
+     *
+     * @see <a href="https://redis.io/commands/pexpireat/">redis.io</a> for details.
+     * @param key The <code>key</code> to set timeout on it.
+     * @param unixMilliseconds The timeout in an absolute Unix timestamp.
+     * @param expireOptions The expire option.
+     * @return <code>true</code> if the timeout was set. <code>false</code> if the timeout was not
+     *     set. e.g. <code>key</code> doesn't exist, or operation skipped due to the provided
+     *     arguments.
+     * @example
+     *     <pre>{@code
+     * Boolean isSet = client.pexpireAt(gs("my_key"), Instant.now().toEpochMilli() + 10, ExpireOptions.HasNoExpiry).get();
+     * assert isSet;
+     * }</pre>
+     */
+    CompletableFuture<Boolean> pexpireAt(
+        GlideString key, long unixMilliseconds, ExpireOptions expireOptions);
 
     /**
      * Returns the remaining time to live of <code>key</code> that has a timeout, in seconds.
@@ -282,6 +492,24 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> ttl(String key);
+
+    /**
+     * Returns the remaining time to live of <code>key</code> that has a timeout, in seconds.
+     *
+     * @see <a href="https://redis.io/commands/ttl/">redis.io</a> for details.
+     * @param key The <code>key</code> to return its timeout.
+     * @return TTL in seconds, <code>-2</code> if <code>key</code> does not exist, or <code>-1</code>
+     *     if <code>key</code> exists but has no associated expiration.
+     * @example
+     *     <pre>{@code
+     * Long timeRemaining = client.ttl(gs("my_key")).get();
+     * assert timeRemaining == 3600L; //Indicates that gs("my_key") has a remaining time to live of 3600 seconds.
+     *
+     * Long timeRemaining = client.ttl(gs("nonexistent_key")).get();
+     * assert timeRemaining == -2L; //Returns -2 for a non-existing key.
+     * }</pre>
+     */
+    CompletableFuture<Long> ttl(GlideString key);
 
     /**
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given <code>key</code>
@@ -303,6 +531,24 @@ public interface GenericBaseCommands {
 
     /**
      * Returns the absolute Unix timestamp (since January 1, 1970) at which the given <code>key</code>
+     * will expire, in seconds.<br>
+     * To get the expiration with millisecond precision, use {@link #pexpiretime(String)}.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/commands/expiretime/">redis.io</a> for details.
+     * @param key The <code>key</code> to determine the expiration value of.
+     * @return The expiration Unix timestamp in seconds. <code>-2</code> if <code>key</code> does not
+     *     exist, or <code>-1</code> if <code>key</code> exists but has no associated expiration.
+     * @example
+     *     <pre>{@code
+     * Long expiration = client.expiretime(gs("my_key")).get();
+     * System.out.printf("The key expires at %d epoch time", expiration);
+     * }</pre>
+     */
+    CompletableFuture<Long> expiretime(GlideString key);
+
+    /**
+     * Returns the absolute Unix timestamp (since January 1, 1970) at which the given <code>key</code>
      * will expire, in milliseconds.
      *
      * @since Redis 7.0 and above.
@@ -317,6 +563,23 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> pexpiretime(String key);
+
+    /**
+     * Returns the absolute Unix timestamp (since January 1, 1970) at which the given <code>key</code>
+     * will expire, in milliseconds.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://redis.io/commands/pexpiretime/">redis.io</a> for details.
+     * @param key The <code>key</code> to determine the expiration value of.
+     * @return The expiration Unix timestamp in milliseconds. <code>-2</code> if <code>key</code> does
+     *     not exist, or <code>-1</code> if <code>key</code> exists but has no associated expiration.
+     * @example
+     *     <pre>{@code
+     * Long expiration = client.pexpiretime(gs("my_key")).get();
+     * System.out.printf("The key expires at %d epoch time (ms)", expiration);
+     * }</pre>
+     */
+    CompletableFuture<Long> pexpiretime(GlideString key);
 
     // TODO move invokeScript to ScriptingAndFunctionsBaseCommands
     // TODO add note to invokeScript about routing on cluster client
@@ -384,6 +647,24 @@ public interface GenericBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> pttl(String key);
+
+    /**
+     * Returns the remaining time to live of <code>key</code> that has a timeout, in milliseconds.
+     *
+     * @see <a href="https://redis.io/commands/pttl/">redis.io</a> for details.
+     * @param key The key to return its timeout.
+     * @return TTL in milliseconds. <code>-2</code> if <code>key</code> does not exist, <code>-1
+     *     </code> if <code>key</code> exists but has no associated expire.
+     * @example
+     *     <pre>{@code
+     * Long timeRemainingMS = client.pttl(gs("my_key")).get()
+     * assert timeRemainingMS == 5000L // Indicates that gs("my_key") has a remaining time to live of 5000 milliseconds.
+     *
+     * Long timeRemainingMS = client.pttl(gs("nonexistent_key")).get();
+     * assert timeRemainingMS == -2L; // Returns -2 for a non-existing key.
+     * }</pre>
+     */
+    CompletableFuture<Long> pttl(GlideString key);
 
     /**
      * Removes the existing timeout on <code>key</code>, turning the <code>key</code> from volatile (a

--- a/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
@@ -3,6 +3,7 @@ package glide.api.models.commands;
 
 import glide.api.commands.GenericBaseCommands;
 import lombok.RequiredArgsConstructor;
+import glide.api.models.GlideString;
 
 /**
  * Optional arguments for {@link GenericBaseCommands#expire(String, long, ExpireOptions)}, and
@@ -42,4 +43,14 @@ public enum ExpireOptions {
     public String[] toArgs() {
         return new String[] {this.redisApi};
     }
+
+        /**
+     * Converts SetOptions into a GlideString[] to add to a {@link Command} arguments.
+     *
+     * @return GlideString[]
+     */
+    public GlideString[] toGlideStringArgs() {
+        return new GlideString[] {GlideString.gs(redisApi)};
+    }
+
 }

--- a/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
@@ -2,8 +2,8 @@
 package glide.api.models.commands;
 
 import glide.api.commands.GenericBaseCommands;
-import lombok.RequiredArgsConstructor;
 import glide.api.models.GlideString;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Optional arguments for {@link GenericBaseCommands#expire(String, long, ExpireOptions)}, and

--- a/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/ExpireOptions.java
@@ -44,7 +44,7 @@ public enum ExpireOptions {
         return new String[] {this.redisApi};
     }
 
-        /**
+    /**
      * Converts SetOptions into a GlideString[] to add to a {@link Command} arguments.
      *
      * @return GlideString[]
@@ -52,5 +52,4 @@ public enum ExpireOptions {
     public GlideString[] toGlideStringArgs() {
         return new GlideString[] {GlideString.gs(redisApi)};
     }
-
 }

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -1068,7 +1068,8 @@ public class RedisClientTest {
         // setup
         GlideString key = gs("testKey");
         long unixMilliseconds = 999999L;
-        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(unixMilliseconds)), gs("GT")};
+        GlideString[] arguments =
+                new GlideString[] {key, gs(Long.toString(unixMilliseconds)), gs("GT")};
 
         CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
         testResponse.complete(Boolean.FALSE);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -694,11 +694,54 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void exists_binary_returns_long_success() {
+        // setup
+        GlideString[] keys = new GlideString[] {gs("testKey1"), gs("testKey2")};
+        Long numberExisting = 1L;
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(numberExisting);
+        when(commandManager.<Long>submitNewCommand(eq(Exists), eq(keys), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.exists(keys);
+        Long result = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(numberExisting, result);
+    }
+
+    @SneakyThrows
+    @Test
     public void expire_returns_success() {
         // setup
         String key = "testKey";
         long seconds = 10L;
         String[] arguments = new String[] {key, Long.toString(seconds)};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(Expire), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.expire(key, seconds);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(true, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void expire_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long seconds = 10L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(seconds))};
 
         CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
         testResponse.complete(Boolean.TRUE);
@@ -740,11 +783,57 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void expire_with_expireOptions_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long seconds = 10L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(seconds)), gs("NX")};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(Expire), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.expire(key, seconds, ExpireOptions.HAS_NO_EXPIRY);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(false, response.get());
+    }
+
+    @SneakyThrows
+    @Test
     public void expireAt_returns_success() {
         // setup
         String key = "testKey";
         long unixSeconds = 100000L;
         String[] arguments = new String[] {key, Long.toString(unixSeconds)};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(ExpireAt), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.expireAt(key, unixSeconds);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(true, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void expireAt_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long unixSeconds = 100000L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(unixSeconds))};
 
         CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
         testResponse.complete(Boolean.TRUE);
@@ -787,11 +876,58 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void expireAt_with_expireOptions_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long unixSeconds = 100000L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(unixSeconds)), gs("XX")};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(ExpireAt), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response =
+                service.expireAt(key, unixSeconds, ExpireOptions.HAS_EXISTING_EXPIRY);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(false, response.get());
+    }
+
+    @SneakyThrows
+    @Test
     public void pexpire_returns_success() {
         // setup
         String key = "testKey";
         long milliseconds = 50000L;
         String[] arguments = new String[] {key, Long.toString(milliseconds)};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(PExpire), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.pexpire(key, milliseconds);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(true, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void pexpire_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long milliseconds = 50000L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(milliseconds))};
 
         CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
         testResponse.complete(Boolean.TRUE);
@@ -834,11 +970,58 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void pexpire_with_expireOptions_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long milliseconds = 50000L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(milliseconds)), gs("LT")};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(PExpire), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response =
+                service.pexpire(key, milliseconds, ExpireOptions.NEW_EXPIRY_LESS_THAN_CURRENT);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(false, response.get());
+    }
+
+    @SneakyThrows
+    @Test
     public void pexpireAt_returns_success() {
         // setup
         String key = "testKey";
         long unixMilliseconds = 999999L;
         String[] arguments = new String[] {key, Long.toString(unixMilliseconds)};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.TRUE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(PExpireAt), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response = service.pexpireAt(key, unixMilliseconds);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(true, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void pexpireAt_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long unixMilliseconds = 999999L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(unixMilliseconds))};
 
         CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
         testResponse.complete(Boolean.TRUE);
@@ -881,6 +1064,30 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void pexpireAt_with_expireOptions_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long unixMilliseconds = 999999L;
+        GlideString[] arguments = new GlideString[] {key, gs(Long.toString(unixMilliseconds)), gs("GT")};
+
+        CompletableFuture<Boolean> testResponse = new CompletableFuture<>();
+        testResponse.complete(Boolean.FALSE);
+
+        // match on protobuf request
+        when(commandManager.<Boolean>submitNewCommand(eq(PExpireAt), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Boolean> response =
+                service.pexpireAt(key, unixMilliseconds, ExpireOptions.NEW_EXPIRY_GREATER_THAN_CURRENT);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(false, response.get());
+    }
+
+    @SneakyThrows
+    @Test
     public void ttl_returns_success() {
         // setup
         String key = "testKey";
@@ -890,6 +1097,27 @@ public class RedisClientTest {
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(TTL), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.ttl(key);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(ttl, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void ttl_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long ttl = 999L;
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(ttl);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(TTL), eq(new GlideString[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -923,6 +1151,27 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void expiretime_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long value = 999L;
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(ExpireTime), eq(new GlideString[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.expiretime(key);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, response.get());
+    }
+
+    @SneakyThrows
+    @Test
     public void pexpiretime_returns_success() {
         // setup
         String key = "testKey";
@@ -932,6 +1181,27 @@ public class RedisClientTest {
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(PExpireTime), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.pexpiretime(key);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void pexpiretime_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long value = 999L;
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(PExpireTime), eq(new GlideString[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise
@@ -1006,6 +1276,28 @@ public class RedisClientTest {
 
         // match on protobuf request
         when(commandManager.<Long>submitNewCommand(eq(PTTL), eq(new String[] {key}), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Long> response = service.pttl(key);
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(pttl, response.get());
+    }
+
+    @SneakyThrows
+    @Test
+    public void pttl_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        long pttl = 999000L;
+
+        CompletableFuture<Long> testResponse = new CompletableFuture<>();
+        testResponse.complete(pttl);
+
+        // match on protobuf request
+        when(commandManager.<Long>submitNewCommand(eq(PTTL), eq(new GlideString[] {key}), any()))
                 .thenReturn(testResponse);
 
         // exercise

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -1656,7 +1656,7 @@ public class SharedCommandTests {
         GlideString key2 = gs("{key}" + UUID.randomUUID());
         GlideString value = gs(UUID.randomUUID().toString());
 
-        GlideString setResult = client.set(key1, value).get();
+        String setResult = client.set(key1, value).get();
         assertEquals(OK, setResult);
         setResult = client.set(key2, value).get();
         assertEquals(OK, setResult);
@@ -1822,8 +1822,9 @@ public class SharedCommandTests {
     @SneakyThrows
     @ParameterizedTest(autoCloseArguments = false)
     @MethodSource("getClients")
-    public void expire_pexpire_ttl_and_expiretime_binary_with_timestamp_in_the_past_or_negative_timeout(
-            BaseClient client) {
+    public void
+            expire_pexpire_ttl_and_expiretime_binary_with_timestamp_in_the_past_or_negative_timeout(
+                    BaseClient client) {
         GlideString key = gs(UUID.randomUUID().toString());
 
         assertEquals(OK, client.set(key, gs("expire_with_past_timestamp")).get());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GS version of ttl, pttl, expire, pexpire, expireAt, pexpireAt, expireTime, pexpireTime, exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
