### PR TITLE
Python: add XGROUP CREATECONSUMER and XGROUP DELCONSUMER commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Python: Added XREVRANGE command ([#1625](https://github.com/aws/glide-for-redis/pull/1625))
 * Python: Added XREAD command ([#1644](https://github.com/aws/glide-for-redis/pull/1644))
 * Python: Added XGROUP CREATE and XGROUP DESTROY commands ([#1646](https://github.com/aws/glide-for-redis/pull/1646))
+* Python: Added XGROUP CREATECONSUMER and XGROUP DELCONSUMER commands ([#1658](https://github.com/aws/glide-for-redis/pull/1658))
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2862,6 +2862,60 @@ class CoreCommands(Protocol):
             await self._execute_command(RequestType.XGroupDestroy, [key, group_name]),
         )
 
+    async def xgroup_create_consumer(
+        self, key: str, group_name: str, consumer: str
+    ) -> bool:
+        """
+        Creates a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+
+        See https://valkey.io/commands/xgroup-createconsumer for more details.
+
+        Args:
+            key (str): The key of the stream.
+            group_name (str): The consumer group name.
+            consumer (str): The newly created consumer.
+
+        Returns:
+            bool: True if the consumer is created. Otherwise, returns False.
+
+        Examples:
+            >>> await client.xgroup_create_consumer("mystream", "mygroup", "myconsumer")
+                True  # The consumer "myconsumer" was created in consumer group "mygroup" for the stream "mystream".
+        """
+        return cast(
+            bool,
+            await self._execute_command(
+                RequestType.XGroupCreateConsumer, [key, group_name, consumer]
+            ),
+        )
+
+    async def xgroup_del_consumer(
+        self, key: str, group_name: str, consumer: str
+    ) -> int:
+        """
+        Deletes a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+
+        See https://valkey.io/commands/xgroup-delconsumer for more details.
+
+        Args:
+            key (str): The key of the stream.
+            group_name (str): The consumer group name.
+            consumer (str): The consumer to delete.
+
+        Returns:
+            int: The number of pending messages the `consumer` had before it was deleted.
+
+        Examples:
+            >>> await client.xgroup_del_consumer("mystream", "mygroup", "myconsumer")
+                5  # Consumer "myconsumer" was deleted, and had 5 pending messages unclaimed.
+        """
+        return cast(
+            int,
+            await self._execute_command(
+                RequestType.XGroupDelConsumer, [key, group_name, consumer]
+            ),
+        )
+
     async def geoadd(
         self,
         key: str,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -2863,17 +2863,17 @@ class CoreCommands(Protocol):
         )
 
     async def xgroup_create_consumer(
-        self, key: str, group_name: str, consumer: str
+        self, key: str, group_name: str, consumer_name: str
     ) -> bool:
         """
-        Creates a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+        Creates a consumer named `consumer_name` in the consumer group `group_name` for the stream stored at `key`.
 
         See https://valkey.io/commands/xgroup-createconsumer for more details.
 
         Args:
             key (str): The key of the stream.
             group_name (str): The consumer group name.
-            consumer (str): The newly created consumer.
+            consumer_name (str): The newly created consumer.
 
         Returns:
             bool: True if the consumer is created. Otherwise, returns False.
@@ -2885,22 +2885,22 @@ class CoreCommands(Protocol):
         return cast(
             bool,
             await self._execute_command(
-                RequestType.XGroupCreateConsumer, [key, group_name, consumer]
+                RequestType.XGroupCreateConsumer, [key, group_name, consumer_name]
             ),
         )
 
     async def xgroup_del_consumer(
-        self, key: str, group_name: str, consumer: str
+        self, key: str, group_name: str, consumer_name: str
     ) -> int:
         """
-        Deletes a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+        Deletes a consumer named `consumer_name` in the consumer group `group_name` for the stream stored at `key`.
 
         See https://valkey.io/commands/xgroup-delconsumer for more details.
 
         Args:
             key (str): The key of the stream.
             group_name (str): The consumer group name.
-            consumer (str): The consumer to delete.
+            consumer_name (str): The consumer to delete.
 
         Returns:
             int: The number of pending messages the `consumer` had before it was deleted.
@@ -2912,7 +2912,7 @@ class CoreCommands(Protocol):
         return cast(
             int,
             await self._execute_command(
-                RequestType.XGroupDelConsumer, [key, group_name, consumer]
+                RequestType.XGroupDelConsumer, [key, group_name, consumer_name]
             ),
         )
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2000,43 +2000,43 @@ class BaseTransaction:
         return self.append_command(RequestType.XGroupDestroy, [key, group_name])
 
     def xgroup_create_consumer(
-        self: TTransaction, key: str, group_name: str, consumer: str
+        self: TTransaction, key: str, group_name: str, consumer_name: str
     ) -> TTransaction:
         """
-        Creates a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+        Creates a consumer named `consumer_name` in the consumer group `group_name` for the stream stored at `key`.
 
         See https://valkey.io/commands/xgroup-createconsumer for more details.
 
         Args:
             key (str): The key of the stream.
             group_name (str): The consumer group name.
-            consumer (str): The newly created consumer.
+            consumer_name (str): The newly created consumer.
 
         Command response:
             bool: True if the consumer is created. Otherwise, returns False.
         """
         return self.append_command(
-            RequestType.XGroupCreateConsumer, [key, group_name, consumer]
+            RequestType.XGroupCreateConsumer, [key, group_name, consumer_name]
         )
 
     def xgroup_del_consumer(
-        self: TTransaction, key: str, group_name: str, consumer: str
+        self: TTransaction, key: str, group_name: str, consumer_name: str
     ) -> TTransaction:
         """
-        Deletes a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+        Deletes a consumer named `consumer_name` in the consumer group `group_name` for the stream stored at `key`.
 
         See https://valkey.io/commands/xgroup-delconsumer for more details.
 
         Args:
             key (str): The key of the stream.
             group_name (str): The consumer group name.
-            consumer (str): The consumer to delete.
+            consumer_name (str): The consumer to delete.
 
         Command response:
             int: The number of pending messages the `consumer` had before it was deleted.
         """
         return self.append_command(
-            RequestType.XGroupDelConsumer, [key, group_name, consumer]
+            RequestType.XGroupDelConsumer, [key, group_name, consumer_name]
         )
 
     def geoadd(

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1999,6 +1999,46 @@ class BaseTransaction:
         """
         return self.append_command(RequestType.XGroupDestroy, [key, group_name])
 
+    def xgroup_create_consumer(
+        self: TTransaction, key: str, group_name: str, consumer: str
+    ) -> TTransaction:
+        """
+        Creates a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+
+        See https://valkey.io/commands/xgroup-createconsumer for more details.
+
+        Args:
+            key (str): The key of the stream.
+            group_name (str): The consumer group name.
+            consumer (str): The newly created consumer.
+
+        Command response:
+            bool: True if the consumer is created. Otherwise, returns False.
+        """
+        return self.append_command(
+            RequestType.XGroupCreateConsumer, [key, group_name, consumer]
+        )
+
+    def xgroup_del_consumer(
+        self: TTransaction, key: str, group_name: str, consumer: str
+    ) -> TTransaction:
+        """
+        Deletes a consumer named `consumer` in the consumer group `group_name` for the stream stored at `key`.
+
+        See https://valkey.io/commands/xgroup-delconsumer for more details.
+
+        Args:
+            key (str): The key of the stream.
+            group_name (str): The consumer group name.
+            consumer (str): The consumer to delete.
+
+        Command response:
+            int: The number of pending messages the `consumer` had before it was deleted.
+        """
+        return self.append_command(
+            RequestType.XGroupDelConsumer, [key, group_name, consumer]
+        )
+
     def geoadd(
         self: TTransaction,
         key: str,

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -490,12 +490,17 @@ async def transaction_test(
 
     group_name1 = get_random_string(10)
     group_name2 = get_random_string(10)
+    consumer = get_random_string(10)
     transaction.xgroup_create(key11, group_name1, "0-0")
     args.append(OK)
     transaction.xgroup_create(
         key11, group_name2, "0-0", StreamGroupOptions(make_stream=True)
     )
     args.append(OK)
+    transaction.xgroup_create_consumer(key11, group_name1, consumer)
+    args.append(True)
+    transaction.xgroup_del_consumer(key11, group_name1, consumer)
+    args.append(0)
     transaction.xgroup_destroy(key11, group_name1)
     args.append(True)
     transaction.xgroup_destroy(key11, group_name2)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/xgroup-createconsumer/
https://redis.io/docs/latest/commands/xgroup-delconsumer/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
