### PR TITLE
#1715: fix flakey test in xpending

### DIFF
--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4374,6 +4374,8 @@ public class SharedCommandTests {
         };
         assertDeepEquals(expectedResult, pending_results);
 
+        // ensure idle_time > 0
+        Thread.sleep(2000);
         Object[][] pending_results_extended =
                 client.xpending(key, groupName, InfRangeBound.MIN, InfRangeBound.MAX, 10L).get();
 

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -5654,6 +5654,8 @@ class TestCommands:
         result.remove(consumer_results)
         assert result == [5, stream_id1_0, stream_id1_4]
 
+        # to ensure an idle_time > 0
+        time.sleep(2)
         range_result = await redis_client.xpending_range(
             key, group_name, MinId(), MaxId(), 10
         )


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/glide-for-redis/issues/1715

*Description of changes:*

Add sleep for two seconds to ensure that the idle_time is at least 1 for tests. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
