### PR TITLE
Java: Add XGROUP SETID command

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -141,6 +141,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -1973,18 +1974,18 @@ public abstract class BaseClient
 
     @Override
     public CompletableFuture<String> xgroupCreate(
-            @NonNull String key, @NonNull String groupname, @NonNull String id) {
+            @NonNull String key, @NonNull String groupName, @NonNull String id) {
         return commandManager.submitNewCommand(
-                XGroupCreate, new String[] {key, groupname, id}, this::handleStringResponse);
+                XGroupCreate, new String[] {key, groupName, id}, this::handleStringResponse);
     }
 
     @Override
     public CompletableFuture<String> xgroupCreate(
             @NonNull String key,
-            @NonNull String groupname,
+            @NonNull String groupName,
             @NonNull String id,
             @NonNull StreamGroupOptions options) {
-        String[] arguments = concatenateArrays(new String[] {key, groupname, id}, options.toArgs());
+        String[] arguments = concatenateArrays(new String[] {key, groupName, id}, options.toArgs());
         return commandManager.submitNewCommand(XGroupCreate, arguments, this::handleStringResponse);
     }
 
@@ -2006,6 +2007,23 @@ public abstract class BaseClient
             @NonNull String key, @NonNull String group, @NonNull String consumer) {
         return commandManager.submitNewCommand(
                 XGroupDelConsumer, new String[] {key, group, consumer}, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> xgroupSetId(
+            @NonNull String key, @NonNull String groupName, @NonNull String id) {
+        return commandManager.submitNewCommand(
+                XGroupSetId, new String[] {key, groupName, id}, this::handleStringResponse);
+    }
+
+    @Override
+    public CompletableFuture<String> xgroupSetId(
+            @NonNull String key,
+            @NonNull String groupName,
+            @NonNull String id,
+            @NonNull String entriesRead) {
+        String[] arguments = new String[] {key, groupName, id, "ENTRIESREAD", entriesRead};
+        return commandManager.submitNewCommand(XGroupSetId, arguments, this::handleStringResponse);
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -2021,8 +2021,8 @@ public abstract class BaseClient
             @NonNull String key,
             @NonNull String groupName,
             @NonNull String id,
-            @NonNull String entriesRead) {
-        String[] arguments = new String[] {key, groupName, id, "ENTRIESREAD", entriesRead};
+            @NonNull String entriesReadId) {
+        String[] arguments = new String[] {key, groupName, id, "ENTRIESREAD", entriesReadId};
         return commandManager.submitNewCommand(XGroupSetId, arguments, this::handleStringResponse);
     }
 

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -449,14 +449,13 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
-     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
-     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
-     *     in the stream.
+     * @param id The stream entry ID that should be set as the last delivered ID for the consumer
+     *     group.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
      * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
-     * assert client.xgroupSetId("mystream", "mygroup", "$").get().equals("OK");
+     * assert client.xgroupSetId("mystream", "mygroup", "0").get().equals("OK");
      * }</pre>
      */
     CompletableFuture<String> xgroupSetId(String key, String groupName, String id);
@@ -467,10 +466,9 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
-     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
-     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
-     *     in the stream.
-     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
+     * @param id The stream entry ID that should be set as the last delivered ID for the consumer
+     *     group.
+     * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
      *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
      *     it) and the stream's last entry. This argument can only be specified if you are using Redis
      *     version 7.0.0 or above.
@@ -478,11 +476,11 @@ public interface StreamBaseCommands {
      * @example
      *     <pre>{@code
      * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
-     * assert client.xgroupSetId("mystream", "mygroup", "$", "$").get().equals("OK");
+     * assert client.xgroupSetId("mystream", "mygroup", "0", "1-1").get().equals("OK");
      * }</pre>
      */
     CompletableFuture<String> xgroupSetId(
-            String key, String groupName, String id, String entriesRead);
+            String key, String groupName, String id, String entriesReadId);
 
     /**
      * Reads entries from the given streams owned by a consumer group.

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -444,7 +444,7 @@ public interface StreamBaseCommands {
     CompletableFuture<Long> xgroupDelConsumer(String key, String group, String consumer);
 
     /**
-     * Set the last delivered ID for a consumer group.
+     * Sets the last delivered ID for a consumer group.
      *
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
@@ -461,8 +461,9 @@ public interface StreamBaseCommands {
     CompletableFuture<String> xgroupSetId(String key, String groupName, String id);
 
     /**
-     * Set the last delivered ID for a consumer group.
+     * Sets the last delivered ID for a consumer group.
      *
+     * @since Redis 7.0 and above
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
@@ -470,8 +471,7 @@ public interface StreamBaseCommands {
      *     group.
      * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
      *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
-     *     it) and the stream's last entry. This argument can only be specified if you are using Redis
-     *     version 7.0.0 or above.
+     *     it) and the stream's last entry.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -378,7 +378,7 @@ public interface StreamBaseCommands {
      *
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupname The newly created consumer group name.
+     * @param groupName The newly created consumer group name.
      * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
      *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
      *     in the stream.
@@ -391,7 +391,7 @@ public interface StreamBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> xgroupCreate(
-            String key, String groupname, String id, StreamGroupOptions options);
+            String key, String groupName, String id, StreamGroupOptions options);
 
     /**
      * Destroys the consumer group <code>groupname</code> for the stream stored at <code>key</code>.
@@ -442,6 +442,46 @@ public interface StreamBaseCommands {
      * }</pre>
      */
     CompletableFuture<Long> xgroupDelConsumer(String key, String group, String consumer);
+
+    /**
+     * Set the last delivered ID for a consumer group.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The newly created consumer group name.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
+     * assert client.xgroupSetId("mystream", "mygroup", "$").get().equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> xgroupSetId(String key, String groupName, String id);
+
+    /**
+     * Set the last delivered ID for a consumer group.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The newly created consumer group name.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
+     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>"0-0"</code>))
+     *     used to find out how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
+     *     This argument can only be specified if you are using Redis version 7.0.0 or above.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
+     * assert client.xgroupSetId("mystream", "mygroup", "$", "$").get().equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<String> xgroupSetId(
+            String key, String groupName, String id, String entriesRead);
 
     /**
      * Reads entries from the given streams owned by a consumer group.

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -470,9 +470,10 @@ public interface StreamBaseCommands {
      * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
      *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
      *     in the stream.
-     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>"0-0"</code>))
-     *     used to find out how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
-     *     This argument can only be specified if you are using Redis version 7.0.0 or above.
+     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
+     *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
+     *     it) and the stream's last entry. This argument can only be specified if you are using Redis
+     *     version 7.0.0 or above.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -448,13 +448,13 @@ public interface StreamBaseCommands {
      *
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupName The newly created consumer group name.
+     * @param groupName The consumer group name.
      * @param id The stream entry ID that should be set as the last delivered ID for the consumer
      *     group.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
+     * // Update consumer group "mygroup", to set the last delivered entry ID.
      * assert client.xgroupSetId("mystream", "mygroup", "0").get().equals("OK");
      * }</pre>
      */
@@ -466,7 +466,7 @@ public interface StreamBaseCommands {
      * @since Redis 7.0 and above
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupName The newly created consumer group name.
+     * @param groupName The consumer group name.
      * @param id The stream entry ID that should be set as the last delivered ID for the consumer
      *     group.
      * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
@@ -475,7 +475,7 @@ public interface StreamBaseCommands {
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * // Create the consumer group "mygroup", and the stream if it does not exist, after the last ID
+     * // Update consumer group "mygroup", to set the last delivered entry ID.
      * assert client.xgroupSetId("mystream", "mygroup", "0", "1-1").get().equals("OK");
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3120,7 +3120,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @return Command Response - <code>OK</code>.
      */
     public T xgroupSetId(@NonNull String key, @NonNull String groupName, @NonNull String id) {
-        protobufTransaction.addCommands(buildCommand(XGroupCreate, buildArgs(key, groupName, id)));
+        protobufTransaction.addCommands(buildCommand(XGroupSetId, buildArgs(key, groupName, id)));
         return getThis();
     }
 
@@ -3133,9 +3133,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
      *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
      *     in the stream.
-     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>"0-0"</code>))
-     *     used to find out how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
-     *     This argument can only be specified if you are using Redis version 7.0.0 or above.
+     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
+     *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
+     *     it) and the stream's last entry. This argument can only be specified if you are using Redis
+     *     version 7.0.0 or above.
      * @return Command Response - <code>OK</code>.
      */
     public T xgroupSetId(

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3109,7 +3109,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Set the last delivered ID for a consumer group.
+     * Sets the last delivered ID for a consumer group.
      *
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
@@ -3124,8 +3124,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     }
 
     /**
-     * Set the last delivered ID for a consumer group.
+     * Sets the last delivered ID for a consumer group.
      *
+     * @since Redis 7.0 and above
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
@@ -3133,8 +3134,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     group.
      * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
      *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
-     *     it) and the stream's last entry. This argument can only be specified if you are using Redis
-     *     version 7.0.0 or above.
+     *     it) and the stream's last entry.
      * @return Command Response - <code>OK</code>.
      */
     public T xgroupSetId(

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3113,7 +3113,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupName The newly created consumer group name.
+     * @param groupName The consumer group name.
      * @param id The stream entry ID that should be set as the last delivered ID for the consumer
      *     group.
      * @return Command Response - <code>OK</code>.
@@ -3129,7 +3129,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @since Redis 7.0 and above
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupName The newly created consumer group name.
+     * @param groupName The consumer group name.
      * @param id The stream entry ID that should be set as the last delivered ID for the consumer
      *     group.
      * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -167,6 +167,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -3024,14 +3025,14 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupname The newly created consumer group name.
+     * @param groupName The newly created consumer group name.
      * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
      *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
      *     in the stream.
      * @return Command Response - <code>OK</code>.
      */
-    public T xgroupCreate(@NonNull String key, @NonNull String groupname, @NonNull String id) {
-        protobufTransaction.addCommands(buildCommand(XGroupCreate, buildArgs(key, groupname, id)));
+    public T xgroupCreate(@NonNull String key, @NonNull String groupName, @NonNull String id) {
+        protobufTransaction.addCommands(buildCommand(XGroupCreate, buildArgs(key, groupName, id)));
         return getThis();
     }
 
@@ -3041,7 +3042,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://valkey.io/commands/xgroup-create/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @param groupname The newly created consumer group name.
+     * @param groupName The newly created consumer group name.
      * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
      *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
      *     in the stream.
@@ -3050,11 +3051,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      */
     public T xgroupCreate(
             @NonNull String key,
-            @NonNull String groupname,
+            @NonNull String groupName,
             @NonNull String id,
             @NonNull StreamGroupOptions options) {
         String[] commandArgs =
-                buildArgs(concatenateArrays(new String[] {key, groupname, id}, options.toArgs()));
+                buildArgs(concatenateArrays(new String[] {key, groupName, id}, options.toArgs()));
         protobufTransaction.addCommands(buildCommand(XGroupCreate, commandArgs));
         return getThis();
     }
@@ -3104,6 +3105,46 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
     public T xgroupDelConsumer(@NonNull String key, @NonNull String group, @NonNull String consumer) {
         protobufTransaction.addCommands(
                 buildCommand(XGroupDelConsumer, buildArgs(key, group, consumer)));
+        return getThis();
+    }
+
+    /**
+     * Set the last delivered ID for a consumer group.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The newly created consumer group name.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
+     * @return Command Response - <code>OK</code>.
+     */
+    public T xgroupSetId(@NonNull String key, @NonNull String groupName, @NonNull String id) {
+        protobufTransaction.addCommands(buildCommand(XGroupCreate, buildArgs(key, groupName, id)));
+        return getThis();
+    }
+
+    /**
+     * Set the last delivered ID for a consumer group.
+     *
+     * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The newly created consumer group name.
+     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
+     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
+     *     in the stream.
+     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>"0-0"</code>))
+     *     used to find out how many entries are between the arbitrary ID (excluding it) and the stream's last entry.
+     *     This argument can only be specified if you are using Redis version 7.0.0 or above.
+     * @return Command Response - <code>OK</code>.
+     */
+    public T xgroupSetId(
+            @NonNull String key,
+            @NonNull String groupName,
+            @NonNull String id,
+            @NonNull String entriesRead) {
+        String[] commandArgs = buildArgs(key, groupName, id, "ENTRIESREAD", entriesRead);
+        protobufTransaction.addCommands(buildCommand(XGroupSetId, commandArgs));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -3114,9 +3114,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
-     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
-     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
-     *     in the stream.
+     * @param id The stream entry ID that should be set as the last delivered ID for the consumer
+     *     group.
      * @return Command Response - <code>OK</code>.
      */
     public T xgroupSetId(@NonNull String key, @NonNull String groupName, @NonNull String id) {
@@ -3130,10 +3129,9 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xgroup-setid/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The newly created consumer group name.
-     * @param id Stream entry ID that specifies the last delivered entry in the stream from the new
-     *     group’s perspective. The special ID <code>"$"</code> can be used to specify the last entry
-     *     in the stream.
-     * @param entriesRead An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
+     * @param id The stream entry ID that should be set as the last delivered ID for the consumer
+     *     group.
+     * @param entriesReadId An arbitrary ID (that isn't the first ID, last ID, or the zero ID (<code>
      *     "0-0"</code>)) used to find out how many entries are between the arbitrary ID (excluding
      *     it) and the stream's last entry. This argument can only be specified if you are using Redis
      *     version 7.0.0 or above.
@@ -3143,8 +3141,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
             @NonNull String key,
             @NonNull String groupName,
             @NonNull String id,
-            @NonNull String entriesRead) {
-        String[] commandArgs = buildArgs(key, groupName, id, "ENTRIESREAD", entriesRead);
+            @NonNull String entriesReadId) {
+        String[] commandArgs = buildArgs(key, groupName, id, "ENTRIESREAD", entriesReadId);
         protobufTransaction.addCommands(buildCommand(XGroupSetId, commandArgs));
         return getThis();
     }

--- a/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/stream/StreamGroupOptions.java
@@ -15,11 +15,11 @@ import lombok.Builder;
 @Builder
 public final class StreamGroupOptions {
 
-    // Redis API String argument for makeStream
-    public static final String MAKE_STREAM_REDIS_API = "MKSTREAM";
+    // Valkey API String argument for makeStream
+    public static final String MAKE_STREAM_VALKEY_API = "MKSTREAM";
 
-    // Redis API String argument for entriesRead
-    public static final String ENTRIES_READ_REDIS_API = "ENTRIESREAD";
+    // Valkey API String argument for entriesRead
+    public static final String ENTRIES_READ_VALKEY_API = "ENTRIESREAD";
 
     /**
      * If <code>true</code> and the stream doesn't exist, creates a new stream with a length of <code>
@@ -54,11 +54,11 @@ public final class StreamGroupOptions {
         List<String> optionArgs = new ArrayList<>();
 
         if (this.mkStream) {
-            optionArgs.add(MAKE_STREAM_REDIS_API);
+            optionArgs.add(MAKE_STREAM_VALKEY_API);
         }
 
         if (this.entriesRead != null) {
-            optionArgs.add(ENTRIES_READ_REDIS_API);
+            optionArgs.add(ENTRIES_READ_VALKEY_API);
             optionArgs.add(this.entriesRead);
         }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -225,6 +225,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -5879,6 +5880,57 @@ public class RedisClientTest {
         // verify
         assertEquals(testResponse, response);
         assertEquals(result, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xgroupSetid() {
+        // setup
+        String key = "testKey";
+        String groupName = "testGroupName";
+        String id = "testId";
+        String[] arguments = new String[] {key, groupName, id};
+
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(XGroupSetId), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.xgroupSetId(key, groupName, id);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xgroupSetidWithEntriesRead() {
+        // setup
+        String key = "testKey";
+        String groupName = "testGroupName";
+        String id = "testId";
+        String entriesRead = "1-1";
+        String[] arguments = new String[] {key, groupName, id, "ENTRIESREAD", entriesRead};
+
+        CompletableFuture<String> testResponse = new CompletableFuture<>();
+        testResponse.complete(OK);
+
+        // match on protobuf request
+        when(commandManager.<String>submitNewCommand(eq(XGroupSetId), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<String> response = service.xgroupSetId(key, groupName, id, entriesRead);
+        String payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(OK, payload);
     }
 
     @SneakyThrows

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -43,8 +43,8 @@ import static glide.api.models.commands.geospatial.GeoSearchOrigin.FROMMEMBER_VA
 import static glide.api.models.commands.scan.BaseScanOptions.COUNT_OPTION_STRING;
 import static glide.api.models.commands.scan.BaseScanOptions.MATCH_OPTION_STRING;
 import static glide.api.models.commands.stream.StreamAddOptions.NO_MAKE_STREAM_REDIS_API;
-import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_REDIS_API;
-import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_VALKEY_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_VALKEY_API;
 import static glide.api.models.commands.stream.StreamPendingOptions.IDLE_TIME_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.EXCLUSIVE_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
@@ -5785,7 +5785,9 @@ public class RedisClientTest {
         StreamGroupOptions options =
                 StreamGroupOptions.builder().makeStream().entriesRead(testEntry).build();
         String[] arguments =
-                new String[] {key, groupName, id, MAKE_STREAM_REDIS_API, ENTRIES_READ_REDIS_API, testEntry};
+                new String[] {
+                    key, groupName, id, MAKE_STREAM_VALKEY_API, ENTRIES_READ_VALKEY_API, testEntry
+                };
 
         CompletableFuture<String> testResponse = new CompletableFuture<>();
         testResponse.complete(OK);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -32,7 +32,6 @@ import static glide.api.models.commands.geospatial.GeoAddOptions.CHANGED_REDIS_A
 import static glide.api.models.commands.geospatial.GeoSearchOrigin.FROMLONLAT_VALKEY_API;
 import static glide.api.models.commands.geospatial.GeoSearchOrigin.FROMMEMBER_VALKEY_API;
 import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_VALKEY_API;
-import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_REDIS_API;
 import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_VALKEY_API;
 import static glide.api.models.commands.stream.StreamPendingOptions.IDLE_TIME_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.EXCLUSIVE_RANGE_REDIS_API;
@@ -189,6 +188,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreate;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
+import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -267,7 +267,7 @@ import glide.api.models.commands.scan.HScanOptions;
 import glide.api.models.commands.scan.SScanOptions;
 import glide.api.models.commands.scan.ZScanOptions;
 import glide.api.models.commands.stream.StreamAddOptions;
-import glide.api.models.commands.stream.StreamGroupCreateOptions;
+import glide.api.models.commands.stream.StreamGroupOptions;
 import glide.api.models.commands.stream.StreamPendingOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
@@ -835,6 +835,12 @@ public class TransactionTests {
                         XReadGroup,
                         buildArgs(
                                 READ_GROUP_REDIS_API, "group", "consumer", READ_STREAMS_REDIS_API, "key", "id")));
+
+        transaction.xgroupSetId("key", "group", "id");
+        results.add(Pair.of(XGroupSetId, buildArgs("key", "group", "id")));
+
+        transaction.xgroupSetId("key", "group", "id", "1-1");
+        results.add(Pair.of(XGroupSetId, buildArgs("key", "group", "id", "ENTRIESREAD", "1-1")));
 
         transaction.xreadgroup(
                 Map.of("key", "id"),

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -31,8 +31,9 @@ import static glide.api.models.commands.function.FunctionListOptions.WITH_CODE_R
 import static glide.api.models.commands.geospatial.GeoAddOptions.CHANGED_REDIS_API;
 import static glide.api.models.commands.geospatial.GeoSearchOrigin.FROMLONLAT_VALKEY_API;
 import static glide.api.models.commands.geospatial.GeoSearchOrigin.FROMMEMBER_VALKEY_API;
-import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.ENTRIES_READ_VALKEY_API;
 import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_REDIS_API;
+import static glide.api.models.commands.stream.StreamGroupOptions.MAKE_STREAM_VALKEY_API;
 import static glide.api.models.commands.stream.StreamPendingOptions.IDLE_TIME_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.EXCLUSIVE_RANGE_REDIS_API;
 import static glide.api.models.commands.stream.StreamRange.MAXIMUM_RANGE_REDIS_API;
@@ -266,7 +267,7 @@ import glide.api.models.commands.scan.HScanOptions;
 import glide.api.models.commands.scan.SScanOptions;
 import glide.api.models.commands.scan.ZScanOptions;
 import glide.api.models.commands.stream.StreamAddOptions;
-import glide.api.models.commands.stream.StreamGroupOptions;
+import glide.api.models.commands.stream.StreamGroupCreateOptions;
 import glide.api.models.commands.stream.StreamPendingOptions;
 import glide.api.models.commands.stream.StreamRange;
 import glide.api.models.commands.stream.StreamRange.InfRangeBound;
@@ -817,7 +818,7 @@ public class TransactionTests {
                 Pair.of(
                         XGroupCreate,
                         buildArgs(
-                                "key", "group", "id", MAKE_STREAM_REDIS_API, ENTRIES_READ_REDIS_API, "entry")));
+                                "key", "group", "id", MAKE_STREAM_VALKEY_API, ENTRIES_READ_VALKEY_API, "entry")));
 
         transaction.xgroupDestroy("key", "group");
         results.add(Pair.of(XGroupDestroy, buildArgs("key", "group")));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4222,7 +4222,8 @@ public class SharedCommandTests {
         assertEquals(false, client.xgroupDestroy(key, groupName).get());
 
         // ENTRIESREAD option was added in redis 7.0.0
-        StreamGroupOptions entriesReadOption = StreamGroupOptions.builder().entriesRead("10").build();
+        StreamGroupOptions entriesReadOption =
+                StreamGroupOptions.builder().entriesRead("10").build();
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             assertEquals(OK, client.xgroupCreate(key, groupName, streamId, entriesReadOption).get());
         } else {
@@ -4269,7 +4270,10 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                                key,
+                                groupName,
+                                zeroStreamId,
+                                StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4374,7 +4378,10 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                                key,
+                                groupName,
+                                zeroStreamId,
+                                StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4502,7 +4509,10 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                                key,
+                                groupName,
+                                zeroStreamId,
+                                StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4537,7 +4547,10 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                                key,
+                                groupName,
+                                zeroStreamId,
+                                StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer1).get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer2).get());
@@ -4666,7 +4679,10 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
+                                key,
+                                groupName,
+                                zeroStreamId,
+                                StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer1).get());
 

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4369,8 +4369,7 @@ public class SharedCommandTests {
         String streamId1_2 = "1-2";
 
         // Setup: Create stream with 3 entries, create consumer group, read entries to add them to the
-        // Pending Entries
-        // List.
+        // Pending Entries List.
         assertEquals(
                 streamId1_0,
                 client
@@ -4404,15 +4403,14 @@ public class SharedCommandTests {
         assertNull(client.xreadgroup(Map.of(key, ">"), groupName, consumerName).get());
 
         // Reset the last delivered ID for the consumer group to "1-1".
-        // ENRIESREAD is only supported in Redis version 7.0.0
+        // ENTRIESREAD is only supported in Redis version 7.0.0 and higher.
         if (REDIS_VERSION.isLowerThan("7.0.0")) {
             assertEquals(OK, client.xgroupSetId(key, groupName, streamId1_1).get());
         } else {
             assertEquals(OK, client.xgroupSetId(key, groupName, streamId1_1, streamId0).get());
 
             // The entriesReadId cannot be the first, last, or zero ID. Here we pass the first ID and
-            // assert
-            // that an error is raised.
+            // assert that an error is raised.
             ExecutionException executionException =
                     assertThrows(
                             ExecutionException.class,

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -4222,8 +4222,7 @@ public class SharedCommandTests {
         assertEquals(false, client.xgroupDestroy(key, groupName).get());
 
         // ENTRIESREAD option was added in redis 7.0.0
-        StreamGroupOptions entriesReadOption =
-                StreamGroupOptions.builder().entriesRead("10").build();
+        StreamGroupOptions entriesReadOption = StreamGroupOptions.builder().entriesRead("10").build();
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             assertEquals(OK, client.xgroupCreate(key, groupName, streamId, entriesReadOption).get());
         } else {
@@ -4270,10 +4269,7 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key,
-                                groupName,
-                                zeroStreamId,
-                                StreamGroupOptions.builder().makeStream().build())
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4378,10 +4374,7 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key,
-                                groupName,
-                                zeroStreamId,
-                                StreamGroupOptions.builder().makeStream().build())
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4509,10 +4502,7 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key,
-                                groupName,
-                                zeroStreamId,
-                                StreamGroupOptions.builder().makeStream().build())
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumerName).get());
 
@@ -4547,10 +4537,7 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key,
-                                groupName,
-                                zeroStreamId,
-                                StreamGroupOptions.builder().makeStream().build())
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer1).get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer2).get());
@@ -4679,10 +4666,7 @@ public class SharedCommandTests {
                 OK,
                 client
                         .xgroupCreate(
-                                key,
-                                groupName,
-                                zeroStreamId,
-                                StreamGroupOptions.builder().makeStream().build())
+                                key, groupName, zeroStreamId, StreamGroupOptions.builder().makeStream().build())
                         .get());
         assertTrue(client.xgroupCreateConsumer(key, groupName, consumer1).get());
 

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -830,6 +830,7 @@ public class TransactionTestUtilities {
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupCreateConsumer(streamKey1, groupName1, consumer1)
+                .xgroupSetId(streamKey1, groupName1, "0-2")
                 .xreadgroup(Map.of(streamKey1, ">"), groupName1, consumer1)
                 .xreadgroup(
                         Map.of(streamKey1, "0-3"),
@@ -871,6 +872,7 @@ public class TransactionTestUtilities {
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
+            OK, // xgroupSetId(streamKey1, groupName1, "0-2")
             Map.of(
                     streamKey1,
                     Map.of(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add support for the XGROUP SETID command.
This is a port of #1683 for Java.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
