### PR TITLE
Java: Add SCAN command for standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@
 * Python: Added LPOS command ([#1740](https://github.com/aws/glide-for-redis/pull/1740))
 * Python: Added SCAN command ([#1623](https://github.com/aws/glide-for-redis/pull/1623))
 * Python: Added DUMP and Restore commands ([#1733](https://github.com/aws/glide-for-redis/pull/1733))
+* Java: Added SCAN command ([#TODO](TODO))
+
 
 ### Breaking Changes
 * Node: Update XREAD to return a Map of Map ([#1494](https://github.com/aws/glide-for-redis/pull/1494))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 * Python: Added LPOS command ([#1740](https://github.com/aws/glide-for-redis/pull/1740))
 * Python: Added SCAN command ([#1623](https://github.com/aws/glide-for-redis/pull/1623))
 * Python: Added DUMP and Restore commands ([#1733](https://github.com/aws/glide-for-redis/pull/1733))
-* Java: Added SCAN command ([#TODO](TODO))
+* Java: Added SCAN command ([#1751](https://github.com/aws/glide-for-redis/pull/1751))
 
 
 ### Breaking Changes

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -244,9 +244,9 @@ enum RequestType {
     XAutoClaim = 203;
     XInfoGroups = 204;
     XInfoConsumers = 205;
+    Scan = 206;
     Wait = 208;
     XClaim = 209;
-    Scan = 210;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -214,9 +214,9 @@ pub enum RequestType {
     XAutoClaim = 203,
     XInfoGroups = 204,
     XInfoConsumers = 205,
+    Scan = 206,
     Wait = 208,
     XClaim = 209,
-    Scan = 210,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -36,6 +36,7 @@ import static redis_request.RedisRequestOuterClass.RequestType.Lolwut;
 import static redis_request.RedisRequestOuterClass.RequestType.Move;
 import static redis_request.RedisRequestOuterClass.RequestType.Ping;
 import static redis_request.RedisRequestOuterClass.RequestType.RandomKey;
+import static redis_request.RedisRequestOuterClass.RequestType.Scan;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.Sort;
 import static redis_request.RedisRequestOuterClass.RequestType.SortReadOnly;
@@ -54,6 +55,7 @@ import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SortOptions;
 import glide.api.models.commands.SortOptionsBinary;
 import glide.api.models.commands.function.FunctionRestorePolicy;
+import glide.api.models.commands.scan.ScanOptions;
 import glide.api.models.configuration.RedisClientConfiguration;
 import java.util.Arrays;
 import java.util.Map;
@@ -485,5 +487,16 @@ public class RedisClient extends BaseClient
         GlideString[] arguments =
                 concatenateArrays(new GlideString[] {key}, sortOptions.toGlideStringArgs(), storeArguments);
         return commandManager.submitNewCommand(Sort, arguments, this::handleLongResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object[]> scan(@NonNull String cursor) {
+        return commandManager.submitNewCommand(Scan, new String[] {cursor}, this::handleArrayResponse);
+    }
+
+    @Override
+    public CompletableFuture<Object[]> scan(@NonNull String cursor, @NonNull ScanOptions options) {
+        String[] arguments = ArrayUtils.addFirst(options.toArgs(), cursor);
+        return commandManager.submitNewCommand(Scan, arguments, this::handleArrayResponse);
     }
 }

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -347,7 +347,7 @@ public interface GenericCommands {
     /**
      * Iterates incrementally over a database for matching keys.
      *
-     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @see <a href="https://valkey.io/commands/scan/">valkey.io</a> for details.
      * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
      *     </code> indicates the start of the search.
      * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
@@ -375,7 +375,7 @@ public interface GenericCommands {
     /**
      * Iterates incrementally over a database for matching keys.
      *
-     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @see <a href="https://valkey.io/commands/scan/">valkey.io</a> for details.
      * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
      *     </code> indicates the start of the search.
      * @param options The {@link ScanOptions}.

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -352,7 +352,7 @@ public interface GenericCommands {
      *     </code> indicates the start of the search.
      * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the sorted set. <br>
+     *     </code> returned on the last iteration of the scan. <br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      * @example
      *     <pre>{@code
@@ -381,7 +381,7 @@ public interface GenericCommands {
      * @param options The {@link ScanOptions}.
      * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the sorted set. <br>
+     *     </code> returned on the last iteration of the scan. <br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -352,7 +352,7 @@ public interface GenericCommands {
      *     </code> indicates the start of the search.
      * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the scan. <br>
+     *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      * @example
      *     <pre>{@code
@@ -381,7 +381,7 @@ public interface GenericCommands {
      * @param options The {@link ScanOptions}.
      * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the scan. <br>
+     *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/GenericCommands.java
+++ b/java/client/src/main/java/glide/api/commands/GenericCommands.java
@@ -5,6 +5,7 @@ import glide.api.models.GlideString;
 import glide.api.models.Transaction;
 import glide.api.models.commands.SortOptions;
 import glide.api.models.commands.SortOptionsBinary;
+import glide.api.models.commands.scan.ScanOptions;
 import glide.api.models.configuration.ReadFrom;
 import java.util.concurrent.CompletableFuture;
 
@@ -342,4 +343,63 @@ public interface GenericCommands {
      */
     CompletableFuture<Long> sortStore(
             GlideString key, GlideString destination, SortOptionsBinary sortOptions);
+
+    /**
+     * Iterates incrementally over a database for matching keys.
+     *
+     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
+     *     </code> indicates the start of the search.
+     * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
+     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the sorted set. <br>
+     *     The second element is always an <code>Array</code> of matched keys from the database.
+     * @example
+     *     <pre>{@code
+     * // Assume database contains a set with 200 keys
+     * String cursor = "0";
+     * Object[] result;
+     * do {
+     *     result = client.scan(cursor, options).get();
+     *     cursor = result[0].toString();
+     *     Object[] stringResults = (Object[]) result[1];
+     *     String keyList = Arrays.stream(stringResults)
+     *         .map(obj -> (String)obj)
+     *         .collect(Collectors.joining(", "));
+     *     System.out.println("\nSCAN iteration: " + keyList);
+     * } while (!cursor.equals("0"));
+     * </pre>
+     */
+    CompletableFuture<Object[]> scan(String cursor);
+
+    /**
+     * Iterates incrementally over a database for matching keys.
+     *
+     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
+     *     </code> indicates the start of the search.
+     * @param options The {@link ScanOptions}.
+     * @return An <code>Array</code> of <code>Objects</code>. The first element is always the <code>
+     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the sorted set. <br>
+     *     The second element is always an <code>Array</code> of matched keys from the database.
+     * @example
+     *     <pre>{@code
+     * // Assume database contains a set with 200 keys
+     * String cursor = "0";
+     * Object[] result;
+     * // match keys on pattern *11*
+     * ScanOptions options = ScanOptions.builder().matchPattern("*11*").build();
+     * do {
+     *     result = client.scan(cursor, options).get();
+     *     cursor = result[0].toString();
+     *     Object[] stringResults = (Object[]) result[1];
+     *     String keyList = Arrays.stream(stringResults)
+     *         .map(obj -> (String)obj)
+     *         .collect(Collectors.joining(", "));
+     *     System.out.println("\nSCAN iteration: " + keyList);
+     * } while (!cursor.equals("0"));
+     * </pre>
+     */
+    CompletableFuture<Object[]> scan(String cursor, ScanOptions options);
 }

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -179,7 +179,8 @@ public class Transaction extends BaseTransaction<Transaction> {
      * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
      *     </code> indicates the start of the search.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
-     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
+     *     the <code>cursor
      *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
@@ -196,7 +197,8 @@ public class Transaction extends BaseTransaction<Transaction> {
      *     </code> indicates the start of the search.
      * @param options The {@link ScanOptions}.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
-     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
+     *     the <code>cursor
      *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -6,11 +6,13 @@ import static glide.api.commands.GenericCommands.DB_REDIS_API;
 import static glide.api.models.commands.SortBaseOptions.STORE_COMMAND_STRING;
 import static redis_request.RedisRequestOuterClass.RequestType.Copy;
 import static redis_request.RedisRequestOuterClass.RequestType.Move;
+import static redis_request.RedisRequestOuterClass.RequestType.Scan;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.Sort;
 import static redis_request.RedisRequestOuterClass.RequestType.SortReadOnly;
 
 import glide.api.models.commands.SortOptions;
+import glide.api.models.commands.scan.ScanOptions;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.apache.commons.lang3.ArrayUtils;
@@ -167,6 +169,42 @@ public class Transaction extends BaseTransaction<Transaction> {
                                 .add(sortOptions.toArgs())
                                 .add(STORE_COMMAND_STRING)
                                 .add(destination)));
+        return this;
+    }
+
+    /**
+     * Iterates incrementally over a database for matching keys.
+     *
+     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
+     *     </code> indicates the start of the search.
+     * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
+     *     always the <code>
+     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the sorted set. <br>
+     *     The second element is always an <code>Array</code> of matched keys from the database.
+     */
+    public Transaction scan(@NonNull String cursor) {
+        protobufTransaction.addCommands(buildCommand(Scan, newArgsBuilder().add(cursor)));
+        return this;
+    }
+
+    /**
+     * Iterates incrementally over a database for matching keys.
+     *
+     * @see <a href="https://valkey.io/commands/zscan">valkey.io</a> for details.
+     * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
+     *     </code> indicates the start of the search.
+     * @param options The {@link ScanOptions}.
+     * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
+     *     always the <code>
+     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the sorted set. <br>
+     *     The second element is always an <code>Array</code> of matched keys from the database.
+     */
+    public Transaction scan(@NonNull String cursor, @NonNull ScanOptions options) {
+        protobufTransaction.addCommands(
+                buildCommand(Scan, newArgsBuilder().add(cursor).add(options.toArgs())));
         return this;
     }
 }

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -179,9 +179,8 @@ public class Transaction extends BaseTransaction<Transaction> {
      * @param cursor The cursor that points to the next iteration of results. A value of <code>"0"
      *     </code> indicates the start of the search.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
-     *     always the <code>
-     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the scan. <br>
+     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor) {
@@ -197,9 +196,8 @@ public class Transaction extends BaseTransaction<Transaction> {
      *     </code> indicates the start of the search.
      * @param options The {@link ScanOptions}.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
-     *     always the <code>
-     *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the scan. <br>
+     *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
+     *     </code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor, @NonNull ScanOptions options) {

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -180,8 +180,7 @@ public class Transaction extends BaseTransaction<Transaction> {
      *     </code> indicates the start of the search.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
      *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
-     *     the <code>cursor
-     *     </code> returned on the last iteration of the scan.<br>
+     *     the <code>cursor</code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor) {
@@ -198,8 +197,7 @@ public class Transaction extends BaseTransaction<Transaction> {
      * @param options The {@link ScanOptions}.
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
      *     always the <code>cursor</code> for the next iteration of results. <code>"0"</code> will be
-     *     the <code>cursor
-     *     </code> returned on the last iteration of the scan.<br>
+     *     the <code>cursor</code> returned on the last iteration of the scan.<br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor, @NonNull ScanOptions options) {

--- a/java/client/src/main/java/glide/api/models/Transaction.java
+++ b/java/client/src/main/java/glide/api/models/Transaction.java
@@ -181,7 +181,7 @@ public class Transaction extends BaseTransaction<Transaction> {
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
      *     always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the sorted set. <br>
+     *     </code> returned on the last iteration of the scan. <br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor) {
@@ -199,7 +199,7 @@ public class Transaction extends BaseTransaction<Transaction> {
      * @return Command Response - An <code>Array</code> of <code>Objects</code>. The first element is
      *     always the <code>
      *     cursor</code> for the next iteration of results. <code>"0"</code> will be the <code>cursor
-     *     </code> returned on the last iteration of the sorted set. <br>
+     *     </code> returned on the last iteration of the scan. <br>
      *     The second element is always an <code>Array</code> of matched keys from the database.
      */
     public Transaction scan(@NonNull String cursor, @NonNull ScanOptions options) {

--- a/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
@@ -25,7 +25,7 @@ public class ScanOptions extends BaseScanOptions {
      */
     private final ObjectType type;
 
-    // Defines the complex data types available for a <code>SCAN</code> request.
+    /** Defines the complex data types available for a <code>SCAN</code> request. */
     public enum ObjectType {
         STRING(ObjectTypeResolver.OBJECT_TYPE_STRING_NATIVE_NAME),
         LIST(ObjectTypeResolver.OBJECT_TYPE_LIST_NATIVE_NAME),

--- a/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
+++ b/java/client/src/main/java/glide/api/models/commands/scan/ScanOptions.java
@@ -25,6 +25,7 @@ public class ScanOptions extends BaseScanOptions {
      */
     private final ObjectType type;
 
+    // Defines the complex data types available for a <code>SCAN</code> request.
     public enum ObjectType {
         STRING(ObjectTypeResolver.OBJECT_TYPE_STRING_NATIVE_NAME),
         LIST(ObjectTypeResolver.OBJECT_TYPE_LIST_NATIVE_NAME),

--- a/java/client/src/test/java/glide/api/models/StandaloneTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/StandaloneTransactionTests.java
@@ -11,14 +11,20 @@ import static glide.api.models.commands.SortBaseOptions.OrderBy.DESC;
 import static glide.api.models.commands.SortBaseOptions.STORE_COMMAND_STRING;
 import static glide.api.models.commands.SortOptions.BY_COMMAND_STRING;
 import static glide.api.models.commands.SortOptions.GET_COMMAND_STRING;
+import static glide.api.models.commands.scan.BaseScanOptions.COUNT_OPTION_STRING;
+import static glide.api.models.commands.scan.BaseScanOptions.MATCH_OPTION_STRING;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.ZSET;
+import static glide.api.models.commands.scan.ScanOptions.TYPE_OPTION_STRING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static redis_request.RedisRequestOuterClass.RequestType.Copy;
 import static redis_request.RedisRequestOuterClass.RequestType.Move;
+import static redis_request.RedisRequestOuterClass.RequestType.Scan;
 import static redis_request.RedisRequestOuterClass.RequestType.Select;
 import static redis_request.RedisRequestOuterClass.RequestType.Sort;
 import static redis_request.RedisRequestOuterClass.RequestType.SortReadOnly;
 
 import glide.api.models.commands.SortOptions;
+import glide.api.models.commands.scan.ScanOptions;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.commons.lang3.tuple.Pair;
@@ -171,6 +177,23 @@ public class StandaloneTransactionTests {
                                 "getPattern2",
                                 STORE_COMMAND_STRING,
                                 "key2")));
+
+        transaction.scan("cursor");
+        results.add(Pair.of(Scan, buildArgs("cursor")));
+
+        transaction.scan(
+                "cursor", ScanOptions.builder().matchPattern("pattern").count(99L).type(ZSET).build());
+        results.add(
+                Pair.of(
+                        Scan,
+                        buildArgs(
+                                "cursor",
+                                MATCH_OPTION_STRING,
+                                "pattern",
+                                COUNT_OPTION_STRING,
+                                "99",
+                                TYPE_OPTION_STRING,
+                                ZSET.toString())));
 
         var protobufTransaction = transaction.getProtobufTransaction().build();
 

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -27,6 +27,9 @@ import static glide.api.models.commands.SortBaseOptions.OrderBy.DESC;
 import static glide.api.models.commands.function.FunctionRestorePolicy.APPEND;
 import static glide.api.models.commands.function.FunctionRestorePolicy.FLUSH;
 import static glide.api.models.commands.function.FunctionRestorePolicy.REPLACE;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.HASH;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.SET;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.STRING;
 import static glide.cluster.CommandTests.DEFAULT_INFO_SECTIONS;
 import static glide.cluster.CommandTests.EVERYTHING_INFO_SECTIONS;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -34,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,9 +48,11 @@ import glide.api.models.GlideString;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SortOptions;
 import glide.api.models.commands.SortOptionsBinary;
+import glide.api.models.commands.scan.ScanOptions;
 import glide.api.models.exceptions.RequestException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +61,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1351,5 +1358,139 @@ public class CommandTests {
                                 SortOptionsBinary.builder().byPattern(agePattern).getPattern(namePattern).build())
                         .get());
         assertArrayEquals(namesSortedByAge, regularClient.lrange(storeKey.toString(), 0, -1).get());
+    }
+
+    @Test
+    @SneakyThrows
+    public void scan() {
+        String initialCursor = "0";
+
+        int numberKeys = 500;
+        Map<String, String> keys = new HashMap<>();
+        for (int i = 0; i < numberKeys; i++) {
+            keys.put("{key}-" + i + "-" + UUID.randomUUID(), "{value}-" + i + "-" + UUID.randomUUID());
+        }
+
+        int resultCursorIndex = 0;
+        int resultCollectionIndex = 1;
+
+        // empty the database
+        assertEquals(OK, regularClient.flushdb().get());
+
+        // Empty return
+        Object[] emptyResult = regularClient.scan(initialCursor).get();
+        assertEquals(initialCursor, emptyResult[resultCursorIndex]);
+        assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
+
+        // Negative cursor
+        Object[] negativeResult = regularClient.scan("-1").get();
+        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+
+        // Add keys to the database using mset
+        regularClient.mset(keys).get();
+
+        Object[] result;
+        Object[] keysFound = new String[0];
+        String resultCursor = "0";
+        boolean isFirstLoop = true;
+        do {
+            result = regularClient.scan(resultCursor).get();
+            resultCursor = result[resultCursorIndex].toString();
+            Object[] resultKeys = (Object[]) result[resultCollectionIndex];
+            keysFound = ArrayUtils.addAll(keysFound, resultKeys);
+
+            if (isFirstLoop) {
+                assertNotEquals("0", resultCursor);
+                isFirstLoop = false;
+            } else if (resultCursor.equals("0")) {
+                break;
+            }
+        } while (!resultCursor.equals("0")); // 0 is returned for the cursor of the last iteration.
+
+        // check that each key added to the database is found through the cursor
+        Object[] finalKeysFound = keysFound;
+        keys.entrySet().forEach(e -> assertTrue(ArrayUtils.contains(finalKeysFound, e.getKey())));
+    }
+
+    @Test
+    @SneakyThrows
+    public void scan_with_options() {
+        String initialCursor = "0";
+        String matchPattern = UUID.randomUUID().toString();
+
+        int resultCursorIndex = 0;
+        int resultCollectionIndex = 1;
+
+        // Add string keys to the database using mset
+        Map<String, String> stringKeys = new HashMap<>();
+        for (int i = 0; i < 10; i++) {
+            stringKeys.put("{key}-" + i + "-" + matchPattern, "{value}-" + i + "-" + matchPattern);
+        }
+        regularClient.mset(stringKeys).get();
+
+        // Add set keys to the database using sadd
+        List<String> setKeys = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String key = "{key}-set-" + i + "-" + matchPattern;
+            regularClient.sadd(
+                gs(key),
+                new GlideString[] {gs(UUID.randomUUID().toString()), gs(UUID.randomUUID().toString())});
+            setKeys.add(key);
+        }
+
+        // Empty return - match a random UUID
+        ScanOptions options = ScanOptions.builder().matchPattern("*" + UUID.randomUUID()).build();
+        Object[] emptyResult = regularClient.scan(initialCursor, options).get();
+        assertNotEquals(initialCursor, emptyResult[resultCursorIndex]);
+        assertDeepEquals(new String[] {}, emptyResult[resultCollectionIndex]);
+
+        // Negative cursor
+        Object[] negativeResult = regularClient.scan("-1", options).get();
+        assertEquals(initialCursor, negativeResult[resultCursorIndex]);
+        assertDeepEquals(new String[] {}, negativeResult[resultCollectionIndex]);
+
+        // scan for strings by match pattern:
+        options =
+            ScanOptions.builder().matchPattern("*" + matchPattern).count(100L).type(STRING).build();
+        Object[] result;
+        Object[] keysFound = new String[0];
+        String resultCursor = "0";
+        do {
+            result = regularClient.scan(resultCursor, options).get();
+            resultCursor = result[resultCursorIndex].toString();
+            Object[] resultKeys = (Object[]) result[resultCollectionIndex];
+            keysFound = ArrayUtils.addAll(keysFound, resultKeys);
+        } while (!resultCursor.equals("0")); // 0 is returned for the cursor of the last iteration.
+
+        // check that each key added to the database is found through the cursor
+        Object[] finalKeysFound = keysFound;
+        stringKeys.entrySet().forEach(e -> assertTrue(ArrayUtils.contains(finalKeysFound, e.getKey())));
+
+        // scan for sets by match pattern:
+        options = ScanOptions.builder().matchPattern("*" + matchPattern).count(100L).type(SET).build();
+        Object[] setResult;
+        Object[] setsFound = new String[0];
+        String setCursor = "0";
+        do {
+            setResult = regularClient.scan(setCursor, options).get();
+            setCursor = setResult[resultCursorIndex].toString();
+            Object[] resultKeys = (Object[]) setResult[resultCollectionIndex];
+            setsFound = ArrayUtils.addAll(setsFound, resultKeys);
+        } while (!setCursor.equals("0")); // 0 is returned for the cursor of the last iteration.
+
+        // check that each key added to the database is found through the cursor
+        Object[] finalSetsFound = setsFound;
+        setKeys.forEach(k -> assertTrue(ArrayUtils.contains(finalSetsFound, k)));
+
+        // scan for hashes by match pattern:
+        // except in this case, we should never find anything
+        options = ScanOptions.builder().matchPattern("*" + matchPattern).count(100L).type(HASH).build();
+        String hashCursor = "0";
+        do {
+            Object[] hashResult = regularClient.scan(hashCursor, options).get();
+            hashCursor = hashResult[resultCursorIndex].toString();
+            assertTrue(((Object[]) hashResult[resultCollectionIndex]).length == 0);
+        } while (!hashCursor.equals("0")); // 0 is returned for the cursor of the last iteration.
     }
 }

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -1434,8 +1434,8 @@ public class CommandTests {
         for (int i = 0; i < 10; i++) {
             String key = "{key}-set-" + i + "-" + matchPattern;
             regularClient.sadd(
-                gs(key),
-                new GlideString[] {gs(UUID.randomUUID().toString()), gs(UUID.randomUUID().toString())});
+                    gs(key),
+                    new GlideString[] {gs(UUID.randomUUID().toString()), gs(UUID.randomUUID().toString())});
             setKeys.add(key);
         }
 
@@ -1452,7 +1452,7 @@ public class CommandTests {
 
         // scan for strings by match pattern:
         options =
-            ScanOptions.builder().matchPattern("*" + matchPattern).count(100L).type(STRING).build();
+                ScanOptions.builder().matchPattern("*" + matchPattern).count(100L).type(STRING).build();
         Object[] result;
         Object[] keysFound = new String[0];
         String resultCursor = "0";

--- a/java/integTest/src/test/java/glide/standalone/TransactionTests.java
+++ b/java/integTest/src/test/java/glide/standalone/TransactionTests.java
@@ -7,10 +7,17 @@ import static glide.TestUtilities.commonClientConfig;
 import static glide.api.BaseClient.OK;
 import static glide.api.models.GlideString.gs;
 import static glide.api.models.commands.SortBaseOptions.OrderBy.DESC;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.HASH;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.LIST;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.SET;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.STREAM;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.STRING;
+import static glide.api.models.commands.scan.ScanOptions.ObjectType.ZSET;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,6 +29,7 @@ import glide.api.models.GlideString;
 import glide.api.models.Transaction;
 import glide.api.models.commands.InfoOptions;
 import glide.api.models.commands.SortOptions;
+import glide.api.models.commands.scan.ScanOptions;
 import glide.api.models.exceptions.RequestException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -29,6 +37,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import lombok.SneakyThrows;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -513,5 +522,85 @@ public class TransactionTests {
                 };
         assertEquals(expectedResult[0], results[0]);
         assertTrue((long) expectedResult[1] <= (long) results[1]);
+    }
+
+    @SneakyThrows
+    @Test
+    public void scan_test() {
+        // setup
+        String key = UUID.randomUUID().toString();
+        Map<String, String> msetMap = Map.of(key, UUID.randomUUID().toString());
+        assertEquals(OK, client.mset(msetMap).get());
+
+        String cursor = "0";
+        Object[] keysFound = new Object[0];
+        do {
+            Transaction transaction = new Transaction();
+            transaction.scan(cursor);
+            Object[] results = client.exec(transaction).get();
+            cursor = (String) ((Object[]) results[0])[0];
+            keysFound = ArrayUtils.addAll(keysFound, (Object[]) ((Object[]) results[0])[1]);
+        } while (!cursor.equals("0"));
+
+        assertTrue(ArrayUtils.contains(keysFound, key));
+    }
+
+    @SneakyThrows
+    @Test
+    public void scan_with_options_test() {
+        // setup
+        Transaction setupTransaction = new Transaction();
+
+        Map<ScanOptions.ObjectType, String> typeKeys =
+                Map.of(
+                        STRING, "{string}-" + UUID.randomUUID(),
+                        LIST, "{list}-" + UUID.randomUUID(),
+                        SET, "{set}-" + UUID.randomUUID(),
+                        ZSET, "{zset}-" + UUID.randomUUID(),
+                        HASH, "{hash}-" + UUID.randomUUID(),
+                        STREAM, "{stream}-" + UUID.randomUUID());
+
+        setupTransaction.set(typeKeys.get(STRING), UUID.randomUUID().toString());
+        setupTransaction.lpush(typeKeys.get(LIST), new String[] {UUID.randomUUID().toString()});
+        setupTransaction.sadd(typeKeys.get(SET), new String[] {UUID.randomUUID().toString()});
+        setupTransaction.zadd(typeKeys.get(ZSET), Map.of(UUID.randomUUID().toString(), 1.0));
+        setupTransaction.hset(
+                typeKeys.get(HASH), Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+        setupTransaction.xadd(
+                typeKeys.get(STREAM), Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()));
+        assertNotNull(client.exec(setupTransaction).get());
+
+        for (var type : ScanOptions.ObjectType.values()) {
+            ScanOptions options = ScanOptions.builder().type(type).count(99L).build();
+
+            String cursor = "0";
+            Object[] keysFound = new Object[0];
+            do {
+                Transaction transaction = new Transaction();
+                transaction.scan(cursor, options);
+                Object[] results = client.exec(transaction).get();
+                cursor = (String) ((Object[]) results[0])[0];
+                keysFound = ArrayUtils.addAll(keysFound, (Object[]) ((Object[]) results[0])[1]);
+            } while (!cursor.equals("0"));
+
+            assertTrue(
+                    ArrayUtils.contains(keysFound, typeKeys.get(type)),
+                    "Unable to find " + typeKeys.get(type) + " in a scan by type");
+
+            options = ScanOptions.builder().matchPattern(typeKeys.get(type)).count(42L).build();
+            cursor = "0";
+            keysFound = new Object[0];
+            do {
+                Transaction transaction = new Transaction();
+                transaction.scan(cursor, options);
+                Object[] results = client.exec(transaction).get();
+                cursor = (String) ((Object[]) results[0])[0];
+                keysFound = ArrayUtils.addAll(keysFound, (Object[]) ((Object[]) results[0])[1]);
+            } while (!cursor.equals("0"));
+
+            assertTrue(
+                    ArrayUtils.contains(keysFound, typeKeys.get(type)),
+                    "Unable to find " + typeKeys.get(type) + " in a scan by match pattern");
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the [SCAN](https://valkey.io/commands/scan/) command for Java (standalone instance)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
