### PR TITLE
Python: add XINFO GROUPS and XINFO CONSUMERS commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,8 @@
 * Python: Add ZSCAN and HSCAN commands ([#1732](https://github.com/aws/glide-for-redis/pull/1732))
 * Python: Added FCALL_RO command ([#1721](https://github.com/aws/glide-for-redis/pull/1721))
 * Python: Added WATCH and UNWATCH command ([#1736](https://github.com/aws/glide-for-redis/pull/1736))
-* Python: Added LPos command ([#1740](https://github.com/aws/glide-for-redis/pull/1740))
+* Python: Added XINFO GROUPS and XINFO CONSUMERS commands ([#1753](https://github.com/aws/glide-for-redis/pull/1753))
+* Python: Added LPOS command ([#1740](https://github.com/aws/glide-for-redis/pull/1740))
 * Python: Added SCAN command ([#1623](https://github.com/aws/glide-for-redis/pull/1623))
 
 ### Breaking Changes

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -25,7 +25,7 @@ pub(crate) enum ExpectedReturnType<'a> {
     Lolwut,
     ArrayOfStringAndArrays,
     ArrayOfArraysOfDoubleOrNull,
-    ArrayOfMaps(&'a ExpectedReturnType<'a>),
+    ArrayOfMaps(&'a Option<ExpectedReturnType<'a>>),
     StringOrSet,
     ArrayOfPairs,
     ArrayOfMemberScorePairs,
@@ -493,7 +493,7 @@ pub(crate) fn convert_to_expected_type(
             Value::Array(ref array) if array.is_empty() || matches!(array[0], Value::Map(_)) => {
                 Ok(value)
             }
-            Value::Array(array) => convert_array_of_flat_maps(array, Some(*type_of_map_values)),
+            Value::Array(array) => convert_array_of_flat_maps(array, *type_of_map_values),
             // cluster (multi-node) response - go recursive
             Value::Map(map) => convert_map_entries(
                 map,
@@ -943,6 +943,7 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
                 Some(ExpectedReturnType::XAutoClaimReturnType)
             }
         }
+        b"XINFO GROUPS" | b"XINFO CONSUMERS" => Some(ExpectedReturnType::ArrayOfMaps(&None)),
         b"XRANGE" | b"XREVRANGE" => Some(ExpectedReturnType::Map {
             key_type: &Some(ExpectedReturnType::BulkString),
             value_type: &Some(ExpectedReturnType::ArrayOfPairs),
@@ -1008,9 +1009,9 @@ pub(crate) fn expected_type_for_cmd(cmd: &Cmd) -> Option<ExpectedReturnType> {
             }
         }
         b"LOLWUT" => Some(ExpectedReturnType::Lolwut),
-        b"FUNCTION LIST" => Some(ExpectedReturnType::ArrayOfMaps(
-            &ExpectedReturnType::ArrayOfMaps(&ExpectedReturnType::StringOrSet),
-        )),
+        b"FUNCTION LIST" => Some(ExpectedReturnType::ArrayOfMaps(&Some(
+            ExpectedReturnType::ArrayOfMaps(&Some(ExpectedReturnType::StringOrSet)),
+        ))),
         b"FUNCTION STATS" => Some(ExpectedReturnType::FunctionStatsReturnType),
         b"GEOSEARCH" => {
             if cmd.position(b"WITHDIST").is_some()
@@ -1050,6 +1051,127 @@ pub(crate) fn get_value_type<'a>(value: &Value) -> &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn convert_xinfo_groups_xinfo_consumers() {
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("XINFO").arg("GROUPS").arg("key")),
+            Some(ExpectedReturnType::ArrayOfMaps(&None))
+        ));
+
+        assert!(matches!(
+            expected_type_for_cmd(redis::cmd("XINFO").arg("CONSUMERS").arg("key").arg("group")),
+            Some(ExpectedReturnType::ArrayOfMaps(&None))
+        ));
+
+        // The format of the XINFO GROUPS and XINFO CONSUMERS responses are essentially the same, so we only need to
+        // test one of them here.
+        let groups_resp2_response = Value::Array(vec![
+            Value::Array(vec![
+                Value::BulkString("name".to_string().into_bytes()),
+                Value::BulkString("mygroup".to_string().into_bytes()),
+                Value::BulkString("consumers".to_string().into_bytes()),
+                Value::Int(2),
+                Value::BulkString("pending".to_string().into_bytes()),
+                Value::Int(2),
+                Value::BulkString("last-delivered-id".to_string().into_bytes()),
+                Value::BulkString("1638126030001-0".to_string().into_bytes()),
+                Value::BulkString("entries-read".to_string().into_bytes()),
+                Value::Int(2),
+                Value::BulkString("lag".to_string().into_bytes()),
+                Value::Int(0),
+            ]),
+            Value::Array(vec![
+                Value::BulkString("name".to_string().into_bytes()),
+                Value::BulkString("some-other-group".to_string().into_bytes()),
+                Value::BulkString("consumers".to_string().into_bytes()),
+                Value::Int(1),
+                Value::BulkString("pending".to_string().into_bytes()),
+                Value::Int(0),
+                Value::BulkString("last-delivered-id".to_string().into_bytes()),
+                Value::BulkString("1638126028070-0".to_string().into_bytes()),
+                Value::BulkString("entries-read".to_string().into_bytes()),
+                Value::Int(1),
+                Value::BulkString("lag".to_string().into_bytes()),
+                Value::Int(1),
+            ]),
+        ]);
+
+        let groups_resp3_response = Value::Array(vec![
+            Value::Map(vec![
+                (
+                    Value::BulkString("name".to_string().into_bytes()),
+                    Value::BulkString("mygroup".to_string().into_bytes()),
+                ),
+                (
+                    Value::BulkString("consumers".to_string().into_bytes()),
+                    Value::Int(2),
+                ),
+                (
+                    Value::BulkString("pending".to_string().into_bytes()),
+                    Value::Int(2),
+                ),
+                (
+                    Value::BulkString("last-delivered-id".to_string().into_bytes()),
+                    Value::BulkString("1638126030001-0".to_string().into_bytes()),
+                ),
+                (
+                    Value::BulkString("entries-read".to_string().into_bytes()),
+                    Value::Int(2),
+                ),
+                (
+                    Value::BulkString("lag".to_string().into_bytes()),
+                    Value::Int(0),
+                ),
+            ]),
+            Value::Map(vec![
+                (
+                    Value::BulkString("name".to_string().into_bytes()),
+                    Value::BulkString("some-other-group".to_string().into_bytes()),
+                ),
+                (
+                    Value::BulkString("consumers".to_string().into_bytes()),
+                    Value::Int(1),
+                ),
+                (
+                    Value::BulkString("pending".to_string().into_bytes()),
+                    Value::Int(0),
+                ),
+                (
+                    Value::BulkString("last-delivered-id".to_string().into_bytes()),
+                    Value::BulkString("1638126028070-0".to_string().into_bytes()),
+                ),
+                (
+                    Value::BulkString("entries-read".to_string().into_bytes()),
+                    Value::Int(1),
+                ),
+                (
+                    Value::BulkString("lag".to_string().into_bytes()),
+                    Value::Int(1),
+                ),
+            ]),
+        ]);
+
+        // We want the RESP2 response to be converted into RESP3 format.
+        assert_eq!(
+            convert_to_expected_type(
+                groups_resp2_response.clone(),
+                Some(ExpectedReturnType::ArrayOfMaps(&None))
+            )
+            .unwrap(),
+            groups_resp3_response.clone()
+        );
+
+        // RESP3 responses are already in the correct format and should not be converted.
+        assert_eq!(
+            convert_to_expected_type(
+                groups_resp3_response.clone(),
+                Some(ExpectedReturnType::ArrayOfMaps(&None))
+            )
+            .unwrap(),
+            groups_resp3_response.clone()
+        );
+    }
 
     #[test]
     fn convert_function_list() {

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1068,35 +1068,20 @@ mod tests {
     #[test]
     fn convert_xinfo_groups_xinfo_consumers() {
         // The format of the XINFO GROUPS and XINFO CONSUMERS responses are essentially the same, so we only need to
-        // test one of them here.
+        // test one of them here. Only a partial response is represented here for brevity - the rest of the response
+        // follows the same format.
         let groups_resp2_response = Value::Array(vec![
             Value::Array(vec![
                 Value::BulkString("name".to_string().into_bytes()),
                 Value::BulkString("mygroup".to_string().into_bytes()),
-                Value::BulkString("consumers".to_string().into_bytes()),
-                Value::Int(2),
-                Value::BulkString("pending".to_string().into_bytes()),
-                Value::Int(2),
-                Value::BulkString("last-delivered-id".to_string().into_bytes()),
-                Value::BulkString("1638126030001-0".to_string().into_bytes()),
-                Value::BulkString("entries-read".to_string().into_bytes()),
-                Value::Int(2),
                 Value::BulkString("lag".to_string().into_bytes()),
                 Value::Int(0),
             ]),
             Value::Array(vec![
                 Value::BulkString("name".to_string().into_bytes()),
                 Value::BulkString("some-other-group".to_string().into_bytes()),
-                Value::BulkString("consumers".to_string().into_bytes()),
-                Value::Int(1),
-                Value::BulkString("pending".to_string().into_bytes()),
-                Value::Int(0),
-                Value::BulkString("last-delivered-id".to_string().into_bytes()),
-                Value::BulkString("1638126028070-0".to_string().into_bytes()),
-                Value::BulkString("entries-read".to_string().into_bytes()),
-                Value::Int(1),
                 Value::BulkString("lag".to_string().into_bytes()),
-                Value::Int(1),
+                Value::Nil,
             ]),
         ]);
 
@@ -1105,22 +1090,6 @@ mod tests {
                 (
                     Value::BulkString("name".to_string().into_bytes()),
                     Value::BulkString("mygroup".to_string().into_bytes()),
-                ),
-                (
-                    Value::BulkString("consumers".to_string().into_bytes()),
-                    Value::Int(2),
-                ),
-                (
-                    Value::BulkString("pending".to_string().into_bytes()),
-                    Value::Int(2),
-                ),
-                (
-                    Value::BulkString("last-delivered-id".to_string().into_bytes()),
-                    Value::BulkString("1638126030001-0".to_string().into_bytes()),
-                ),
-                (
-                    Value::BulkString("entries-read".to_string().into_bytes()),
-                    Value::Int(2),
                 ),
                 (
                     Value::BulkString("lag".to_string().into_bytes()),
@@ -1133,24 +1102,8 @@ mod tests {
                     Value::BulkString("some-other-group".to_string().into_bytes()),
                 ),
                 (
-                    Value::BulkString("consumers".to_string().into_bytes()),
-                    Value::Int(1),
-                ),
-                (
-                    Value::BulkString("pending".to_string().into_bytes()),
-                    Value::Int(0),
-                ),
-                (
-                    Value::BulkString("last-delivered-id".to_string().into_bytes()),
-                    Value::BulkString("1638126028070-0".to_string().into_bytes()),
-                ),
-                (
-                    Value::BulkString("entries-read".to_string().into_bytes()),
-                    Value::Int(1),
-                ),
-                (
                     Value::BulkString("lag".to_string().into_bytes()),
-                    Value::Int(1),
+                    Value::Nil,
                 ),
             ]),
         ]);

--- a/glide-core/src/client/value_conversion.rs
+++ b/glide-core/src/client/value_conversion.rs
@@ -1053,7 +1053,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn convert_xinfo_groups_xinfo_consumers() {
+    fn xinfo_groups_xinfo_consumers_expected_return_type() {
         assert!(matches!(
             expected_type_for_cmd(redis::cmd("XINFO").arg("GROUPS").arg("key")),
             Some(ExpectedReturnType::ArrayOfMaps(&None))
@@ -1063,7 +1063,10 @@ mod tests {
             expected_type_for_cmd(redis::cmd("XINFO").arg("CONSUMERS").arg("key").arg("group")),
             Some(ExpectedReturnType::ArrayOfMaps(&None))
         ));
+    }
 
+    #[test]
+    fn convert_xinfo_groups_xinfo_consumers() {
         // The format of the XINFO GROUPS and XINFO CONSUMERS responses are essentially the same, so we only need to
         // test one of them here.
         let groups_resp2_response = Value::Array(vec![

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -242,11 +242,11 @@ enum RequestType {
     ZScan = 201;
     HScan = 202;
     XAutoClaim = 203;
+    XInfoGroups = 204;
+    XInfoConsumers = 205;
     Wait = 208;
     XClaim = 209;
     Scan = 210;
-    XInfoGroups = 211;
-    XInfoConsumers = 212;
 }
 
 message Command {

--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -245,6 +245,8 @@ enum RequestType {
     Wait = 208;
     XClaim = 209;
     Scan = 210;
+    XInfoGroups = 211;
+    XInfoConsumers = 212;
 }
 
 message Command {

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -215,6 +215,8 @@ pub enum RequestType {
     Wait = 208,
     XClaim = 209,
     Scan = 210,
+    XInfoGroups = 211,
+    XInfoConsumers = 212,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {
@@ -430,6 +432,8 @@ impl From<::protobuf::EnumOrUnknown<ProtobufRequestType>> for RequestType {
             ProtobufRequestType::ZScan => RequestType::ZScan,
             ProtobufRequestType::HScan => RequestType::HScan,
             ProtobufRequestType::XAutoClaim => RequestType::XAutoClaim,
+            ProtobufRequestType::XInfoGroups => RequestType::XInfoGroups,
+            ProtobufRequestType::XInfoConsumers => RequestType::XInfoConsumers,
             ProtobufRequestType::Wait => RequestType::Wait,
             ProtobufRequestType::XClaim => RequestType::XClaim,
             ProtobufRequestType::Scan => RequestType::Scan,
@@ -646,6 +650,8 @@ impl RequestType {
             RequestType::ZScan => Some(cmd("ZSCAN")),
             RequestType::HScan => Some(cmd("HSCAN")),
             RequestType::XAutoClaim => Some(cmd("XAUTOCLAIM")),
+            RequestType::XInfoGroups => Some(get_two_word_command("XINFO", "GROUPS")),
+            RequestType::XInfoConsumers => Some(get_two_word_command("XINFO", "CONSUMERS")),
             RequestType::Wait => Some(cmd("WAIT")),
             RequestType::XClaim => Some(cmd("XCLAIM")),
             RequestType::Scan => Some(cmd("SCAN")),

--- a/glide-core/src/request_type.rs
+++ b/glide-core/src/request_type.rs
@@ -212,11 +212,11 @@ pub enum RequestType {
     ZScan = 201,
     HScan = 202,
     XAutoClaim = 203,
+    XInfoGroups = 204,
+    XInfoConsumers = 205,
     Wait = 208,
     XClaim = 209,
     Scan = 210,
-    XInfoGroups = 211,
-    XInfoConsumers = 212,
 }
 
 fn get_two_word_command(first: &str, second: &str) -> Cmd {

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -3353,16 +3353,7 @@ class CoreCommands(Protocol):
 
         Returns:
             List[Mapping[bytes, Union[bytes, int, None]]]: A list of mappings, where each mapping represents the
-                attributes of a consumer group for the stream at `key`. Each mapping contains the following info:
-                - name: the consumer group's name.
-                - consumers: the number of consumers in the group.
-                - pending: the length of the group's pending entries list (PEL), which are messages that were delivered
-                but are yet to be acknowledged.
-                - last-delivered-id: the ID of the last entry delivered to the group's consumers.
-                - entries-read: the logical "read counter" of the last entry delivered to the group's consumers. Added
-                in Redis version 7.0.0.
-                - lag: the number of entries in the stream that are still waiting to be delivered to the group's
-                consumers, or `None` when that number can't be determined. Added in Redis version 7.0.0.
+                attributes of a consumer group for the stream at `key`.
 
         Examples:
             >>> await client.xinfo_groups("my_stream")
@@ -3372,8 +3363,8 @@ class CoreCommands(Protocol):
                         b"consumers": 2,
                         b"pending": 2,
                         b"last-delivered-id": b"1638126030001-0",
-                        b"entries-read": 2,
-                        b"lag": 0,
+                        b"entries-read": 2,  # The "entries-read" field was added in Redis version 7.0.0.
+                        b"lag": 0,  # The "lag" field was added in Redis version 7.0.0.
                     },
                     {
                         b"name": b"some-other-group",
@@ -3408,18 +3399,7 @@ class CoreCommands(Protocol):
 
         Returns:
             List[Mapping[bytes, Union[bytes, int]]]: A list of mappings, where each mapping contains the attributes of a
-                consumer for the given consumer group of the stream at `key`. Each mapping contains the following info:
-                - name: the consumer's name.
-                - pending: the number of entries in the pending entries list (PEL): pending messages for the consumer,
-                which are messages that were delivered but are yet to be acknowledged.
-                - idle: if you are using Redis version < 7.2.0, denotes the number of milliseconds that have passed
-                since the consumer's last successful interaction (Examples: XREADGROUP that actually read some entries
-                into the PEL, XCLAIM/XAUTOCLAIM that actually claimed some entries). Otherwise, denotes the number of
-                milliseconds that have passed since the consumer's last attempted interaction (Examples: XREADGROUP,
-                XCLAIM, XAUTOCLAIM).
-                - inactive: the number of milliseconds that have passed since the consumer's last successful interaction
-                (Examples: XREADGROUP that actually read some entries into the PEL, XCLAIM/XAUTOCLAIM that actually
-                claimed some entries). Added in Redis version 7.2.0.
+                consumer for the given consumer group of the stream at `key`.
 
         Examples:
             >>> await client.xinfo_consumers("my_stream", "my_group")
@@ -3428,7 +3408,7 @@ class CoreCommands(Protocol):
                         b"name": b"Alice",
                         b"pending": 1,
                         b"idle": 9104628,
-                        b"inactive": 18104698,
+                        b"inactive": 18104698,  # The "inactive" field was added in Redis version 7.2.0.
                     },
                     {
                         b"name": b"Bob",

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -3341,19 +3341,19 @@ class CoreCommands(Protocol):
 
     async def xinfo_groups(
         self,
-        key: str,
-    ) -> List[Mapping[str, Union[str, int, None]]]:
+        key: TEncodable,
+    ) -> List[Mapping[bytes, Union[bytes, int, None]]]:
         """
         Returns the list of all consumer groups and their attributes for the stream stored at `key`.
 
         See https://valkey.io/commands/xinfo-groups for more details.
 
         Args:
-            key (str): The key of the stream.
+            key (TEncodable): The key of the stream.
 
         Returns:
-            List[Mapping[str, Union[str, int, None]]]: A list of mappings, where each mapping represents the attributes
-                of a consumer group for the stream at `key`. Each mapping contains the following info:
+            List[Mapping[bytes, Union[bytes, int, None]]]: A list of mappings, where each mapping represents the
+                attributes of a consumer group for the stream at `key`. Each mapping contains the following info:
                 - name: the consumer group's name.
                 - consumers: the number of consumers in the group.
                 - pending: the length of the group's pending entries list (PEL), which are messages that were delivered
@@ -3368,34 +3368,34 @@ class CoreCommands(Protocol):
             >>> await client.xinfo_groups("my_stream")
                 [
                     {
-                        "name": "mygroup",
-                        "consumers": 2,
-                        "pending": 2,
-                        "last-delivered-id": "1638126030001-0",
-                        "entries-read": 2,
-                        "lag": 0,
+                        b"name": b"mygroup",
+                        b"consumers": 2,
+                        b"pending": 2,
+                        b"last-delivered-id": b"1638126030001-0",
+                        b"entries-read": 2,
+                        b"lag": 0,
                     },
                     {
-                        "name": "some-other-group",
-                        "consumers": 1,
-                        "pending": 0,
-                        "last-delivered-id": "1638126028070-0",
-                        "entries-read": 1,
-                        "lag": 1,
+                        b"name": b"some-other-group",
+                        b"consumers": 1,
+                        b"pending": 0,
+                        b"last-delivered-id": b"1638126028070-0",
+                        b"entries-read": 1,
+                        b"lag": 1,
                     }
                 ]
                 # The list of consumer groups and their attributes for stream "my_stream".
         """
         return cast(
-            List[Mapping[str, Union[str, int, None]]],
+            List[Mapping[bytes, Union[bytes, int, None]]],
             await self._execute_command(RequestType.XInfoGroups, [key]),
         )
 
     async def xinfo_consumers(
         self,
-        key: str,
-        group_name: str,
-    ) -> List[Mapping[str, Union[str, int]]]:
+        key: TEncodable,
+        group_name: TEncodable,
+    ) -> List[Mapping[bytes, Union[bytes, int]]]:
         """
         Returns the list of all consumers and their attributes for the given consumer group of the stream stored at
         `key`.
@@ -3403,11 +3403,11 @@ class CoreCommands(Protocol):
         See https://valkey.io/commands/xinfo-consumers for more details.
 
         Args:
-            key (str): The key of the stream.
-            group_name (str): The consumer group name.
+            key (TEncodable): The key of the stream.
+            group_name (TEncodable): The consumer group name.
 
         Returns:
-            List[Mapping[str, Union[str, int]]]: A list of mappings, where each mapping represents the attributes of a
+            List[Mapping[bytes, Union[bytes, int]]]: A list of mappings, where each mapping contains the attributes of a
                 consumer for the given consumer group of the stream at `key`. Each mapping contains the following info:
                 - name: the consumer's name.
                 - pending: the number of entries in the pending entries list (PEL): pending messages for the consumer,
@@ -3425,22 +3425,22 @@ class CoreCommands(Protocol):
             >>> await client.xinfo_consumers("my_stream", "my_group")
                 [
                     {
-                        "name": "Alice",
-                        "pending": 1,
-                        "idle": 9104628,
-                        "inactive": 18104698,
+                        b"name": b"Alice",
+                        b"pending": 1,
+                        b"idle": 9104628,
+                        b"inactive": 18104698,
                     },
                     {
-                        "name": "Bob",
-                        "pending": 1,
-                        "idle": 83841983,
-                        "inactive": 993841998,
+                        b"name": b"Bob",
+                        b"pending": 1,
+                        b"idle": 83841983,
+                        b"inactive": 993841998,
                     }
                 ]
                 # The list of consumers and their attributes for consumer group "my_group" of stream "my_stream".
         """
         return cast(
-            List[Mapping[str, Union[str, int]]],
+            List[Mapping[bytes, Union[bytes, int]]],
             await self._execute_command(RequestType.XInfoConsumers, [key, group_name]),
         )
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2534,6 +2534,65 @@ class BaseTransaction:
 
         return self.append_command(RequestType.XAutoClaim, args)
 
+    def xinfo_groups(
+        self: TTransaction,
+        key: str,
+    ) -> TTransaction:
+        """
+        Returns the list of all consumer groups and their attributes for the stream stored at `key`.
+
+        See https://valkey.io/commands/xinfo-groups for more details.
+
+        Args:
+            key (str): The key of the stream.
+
+        Command response:
+            List[Mapping[str, Union[str, int, None]]]: A list of mappings, where each mapping represents the attributes
+                of a consumer group for the stream at `key`. Each mapping contains the following info:
+                - name: the consumer group's name.
+                - consumers: the number of consumers in the group.
+                - pending: the length of the group's pending entries list (PEL), which are messages that were delivered
+                but are yet to be acknowledged.
+                - last-delivered-id: the ID of the last entry delivered to the group's consumers.
+                - entries-read: the logical "read counter" of the last entry delivered to the group's consumers. Added
+                in Redis version 7.0.0.
+                - lag: the number of entries in the stream that are still waiting to be delivered to the group's
+                consumers, or `None` when that number can't be determined. Added in Redis version 7.0.0.
+        """
+        return self.append_command(RequestType.XInfoGroups, [key])
+
+    def xinfo_consumers(
+        self: TTransaction,
+        key: str,
+        group_name: str,
+    ) -> TTransaction:
+        """
+        Returns the list of all consumers and their attributes for the given consumer group of the stream stored at
+        `key`.
+
+        See https://valkey.io/commands/xinfo-consumers for more details.
+
+        Args:
+            key (str): The key of the stream.
+            group_name (str): The consumer group name.
+
+        Command response:
+            List[Mapping[str, Union[str, int]]]: A list of mappings, where each mapping represents the attributes of a
+                consumer for the given consumer group of the stream at `key`. Each mapping contains the following info:
+                - name: the consumer's name.
+                - pending: the number of entries in the pending entries list (PEL): pending messages for the consumer,
+                which are messages that were delivered but are yet to be acknowledged.
+                - idle: if you are using Redis version < 7.2.0, denotes the number of milliseconds that have passed
+                since the consumer's last successful interaction (Examples: XREADGROUP that actually read some entries
+                into the PEL, XCLAIM/XAUTOCLAIM that actually claimed some entries). Otherwise, denotes the number of
+                milliseconds that have passed since the consumer's last attempted interaction (Examples: XREADGROUP,
+                XCLAIM, XAUTOCLAIM).
+                - inactive: the number of milliseconds that have passed since the consumer's last successful interaction
+                (Examples: XREADGROUP that actually read some entries into the PEL, XCLAIM/XAUTOCLAIM that actually
+                claimed some entries). Added in Redis version 7.2.0.
+        """
+        return self.append_command(RequestType.XInfoConsumers, [key, group_name])
+
     def geoadd(
         self: TTransaction,
         key: TEncodable,

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2548,16 +2548,7 @@ class BaseTransaction:
 
         Command response:
             List[Mapping[bytes, Union[bytes, int, None]]]: A list of mappings, where each mapping represents the
-                attributes of a consumer group for the stream at `key`. Each mapping contains the following info:
-                - name: the consumer group's name.
-                - consumers: the number of consumers in the group.
-                - pending: the length of the group's pending entries list (PEL), which are messages that were delivered
-                but are yet to be acknowledged.
-                - last-delivered-id: the ID of the last entry delivered to the group's consumers.
-                - entries-read: the logical "read counter" of the last entry delivered to the group's consumers. Added
-                in Redis version 7.0.0.
-                - lag: the number of entries in the stream that are still waiting to be delivered to the group's
-                consumers, or `None` when that number can't be determined. Added in Redis version 7.0.0.
+                attributes of a consumer group for the stream at `key`.
         """
         return self.append_command(RequestType.XInfoGroups, [key])
 
@@ -2578,18 +2569,7 @@ class BaseTransaction:
 
         Command response:
             List[Mapping[bytes, Union[bytes, int]]]: A list of mappings, where each mapping contains the attributes of a
-                consumer for the given consumer group of the stream at `key`. Each mapping contains the following info:
-                - name: the consumer's name.
-                - pending: the number of entries in the pending entries list (PEL): pending messages for the consumer,
-                which are messages that were delivered but are yet to be acknowledged.
-                - idle: if you are using Redis version < 7.2.0, denotes the number of milliseconds that have passed
-                since the consumer's last successful interaction (Examples: XREADGROUP that actually read some entries
-                into the PEL, XCLAIM/XAUTOCLAIM that actually claimed some entries). Otherwise, denotes the number of
-                milliseconds that have passed since the consumer's last attempted interaction (Examples: XREADGROUP,
-                XCLAIM, XAUTOCLAIM).
-                - inactive: the number of milliseconds that have passed since the consumer's last successful interaction
-                (Examples: XREADGROUP that actually read some entries into the PEL, XCLAIM/XAUTOCLAIM that actually
-                claimed some entries). Added in Redis version 7.2.0.
+                consumer for the given consumer group of the stream at `key`.
         """
         return self.append_command(RequestType.XInfoConsumers, [key, group_name])
 

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -2536,7 +2536,7 @@ class BaseTransaction:
 
     def xinfo_groups(
         self: TTransaction,
-        key: str,
+        key: TEncodable,
     ) -> TTransaction:
         """
         Returns the list of all consumer groups and their attributes for the stream stored at `key`.
@@ -2544,11 +2544,11 @@ class BaseTransaction:
         See https://valkey.io/commands/xinfo-groups for more details.
 
         Args:
-            key (str): The key of the stream.
+            key (TEncodable): The key of the stream.
 
         Command response:
-            List[Mapping[str, Union[str, int, None]]]: A list of mappings, where each mapping represents the attributes
-                of a consumer group for the stream at `key`. Each mapping contains the following info:
+            List[Mapping[bytes, Union[bytes, int, None]]]: A list of mappings, where each mapping represents the
+                attributes of a consumer group for the stream at `key`. Each mapping contains the following info:
                 - name: the consumer group's name.
                 - consumers: the number of consumers in the group.
                 - pending: the length of the group's pending entries list (PEL), which are messages that were delivered
@@ -2563,8 +2563,8 @@ class BaseTransaction:
 
     def xinfo_consumers(
         self: TTransaction,
-        key: str,
-        group_name: str,
+        key: TEncodable,
+        group_name: TEncodable,
     ) -> TTransaction:
         """
         Returns the list of all consumers and their attributes for the given consumer group of the stream stored at
@@ -2573,11 +2573,11 @@ class BaseTransaction:
         See https://valkey.io/commands/xinfo-consumers for more details.
 
         Args:
-            key (str): The key of the stream.
-            group_name (str): The consumer group name.
+            key (TEncodable): The key of the stream.
+            group_name (TEncodable): The consumer group name.
 
         Command response:
-            List[Mapping[str, Union[str, int]]]: A list of mappings, where each mapping represents the attributes of a
+            List[Mapping[bytes, Union[bytes, int]]]: A list of mappings, where each mapping contains the attributes of a
                 consumer for the given consumer group of the stream at `key`. Each mapping contains the following info:
                 - name: the consumer's name.
                 - pending: the number of entries in the pending entries list (PEL): pending messages for the consumer,

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -6353,6 +6353,186 @@ class TestCommands:
 
     @pytest.mark.parametrize("cluster_mode", [True, False])
     @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_xinfo_groups_xinfo_consumers(
+        self, redis_client: TGlideClient, protocol
+    ):
+        key = get_random_string(10)
+        group_name1 = get_random_string(10)
+        group_name2 = get_random_string(10)
+        consumer1 = get_random_string(10)
+        consumer2 = get_random_string(10)
+        stream_id0_0 = "0-0"
+        stream_id1_0 = "1-0"
+        stream_id1_1 = "1-1"
+        stream_id1_2 = "1-2"
+        stream_id1_3 = "1-3"
+
+        # setup: add 3 entries to stream, create consumer group and consumer1, read 1 entry from stream with consumer1
+        assert (
+            await redis_client.xadd(
+                key, [("f1", "v1"), ("f2", "v2")], StreamAddOptions(stream_id1_0)
+            )
+            == stream_id1_0.encode()
+        )
+        assert (
+            await redis_client.xadd(key, [("f3", "v3")], StreamAddOptions(stream_id1_1))
+            == stream_id1_1.encode()
+        )
+        assert (
+            await redis_client.xadd(key, [("f4", "v4")], StreamAddOptions(stream_id1_2))
+            == stream_id1_2.encode()
+        )
+        assert await redis_client.xgroup_create(key, group_name1, stream_id0_0) == OK
+        assert await redis_client.xreadgroup(
+            {key: ">"}, group_name1, consumer1, StreamReadGroupOptions(count=1)
+        ) == {key.encode(): {stream_id1_0.encode(): [[b"f1", b"v1"], [b"f2", b"v2"]]}}
+
+        # sleep to ensure the idle time value and inactive time value returned by xinfo_consumers is > 0
+        time.sleep(2)
+        consumers_result = await redis_client.xinfo_consumers(key, group_name1)
+        assert len(consumers_result) == 1
+        # cast key type to bytes so that mypy won't complain about passing byte strings to get() when str was expected
+        consumer1_info = cast(Mapping[bytes, Union[str, int]], consumers_result[0])
+        assert consumer1_info.get(b"name") == consumer1.encode()
+        assert consumer1_info.get(b"pending") == 1
+        assert cast(int, consumer1_info.get(b"idle")) > 0
+        if not await check_if_server_version_lt(redis_client, "7.2.0"):
+            assert (
+                cast(int, consumer1_info.get(b"inactive"))
+                > 0  # "inactive" was added in Redis 7.2.0
+            )
+
+        # create consumer2 and read the rest of the entries with it
+        assert (
+            await redis_client.xgroup_create_consumer(key, group_name1, consumer2)
+            is True
+        )
+        assert await redis_client.xreadgroup({key: ">"}, group_name1, consumer2) == {
+            key.encode(): {
+                stream_id1_1.encode(): [[b"f3", b"v3"]],
+                stream_id1_2.encode(): [[b"f4", b"v4"]],
+            }
+        }
+
+        # verify that xinfo_consumers contains info for 2 consumers now
+        consumers_result = await redis_client.xinfo_consumers(key, group_name1)
+        assert len(consumers_result) == 2
+
+        # add one more entry
+        assert (
+            await redis_client.xadd(key, [("f5", "v5")], StreamAddOptions(stream_id1_3))
+            == stream_id1_3.encode()
+        )
+
+        groups = await redis_client.xinfo_groups(key)
+        assert len(groups) == 1
+        group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+        assert group1_info.get(b"name") == group_name1.encode()
+        assert group1_info.get(b"consumers") == 2
+        assert group1_info.get(b"pending") == 3
+        assert group1_info.get(b"last-delivered-id") == stream_id1_2.encode()
+        if not await check_if_server_version_lt(redis_client, "7.0.0"):
+            assert (
+                group1_info.get(b"entries-read")
+                == 3  # we have read stream entries 1-0, 1-1, and 1-2
+            )
+            assert (
+                group1_info.get(b"lag")
+                == 1  # we still have not read one entry in the stream, entry 1-3
+            )
+
+        # verify xgroup_set_id effects the returned value from xinfo_groups
+        assert await redis_client.xgroup_set_id(key, group_name1, stream_id1_1) == OK
+        groups = await redis_client.xinfo_groups(key)
+        assert len(groups) == 1
+        group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+        assert group1_info.get(b"name") == group_name1.encode()
+        assert group1_info.get(b"consumers") == 2
+        assert group1_info.get(b"pending") == 3
+        assert group1_info.get(b"last-delivered-id") == stream_id1_1.encode()
+        # entries-read and lag were added to the result in 7.0.0
+        if not await check_if_server_version_lt(redis_client, "7.0.0"):
+            assert (
+                group1_info.get(b"entries-read")
+                is None  # gets set to None when we change the last delivered ID
+            )
+            assert (
+                group1_info.get(b"lag")
+                is None  # gets set to None when we change the last delivered ID
+            )
+
+        if not await check_if_server_version_lt(redis_client, "7.0.0"):
+            # verify xgroup_set_id with entries_read_id effects the returned value from xinfo_groups
+            assert (
+                await redis_client.xgroup_set_id(
+                    key, group_name1, stream_id1_1, entries_read_id="1"
+                )
+                == OK
+            )
+            groups = await redis_client.xinfo_groups(key)
+            assert len(groups) == 1
+            group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+            assert group1_info.get(b"name") == group_name1.encode()
+            assert group1_info.get(b"consumers") == 2
+            assert group1_info.get(b"pending") == 3
+            assert group1_info.get(b"last-delivered-id") == stream_id1_1.encode()
+            assert group1_info.get(b"entries-read") == 1
+            assert (
+                group1_info.get(b"lag")
+                == 3  # lag is calculated as number of stream entries minus entries-read
+            )
+
+        # add one more consumer group
+        assert await redis_client.xgroup_create(key, group_name2, stream_id0_0) == OK
+
+        # verify that xinfo_groups contains info for 2 consumer groups now
+        groups = await redis_client.xinfo_groups(key)
+        assert len(groups) == 2
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
+    async def test_xinfo_groups_xinfo_consumers_edge_cases_and_failures(
+        self, redis_client: TGlideClient, protocol
+    ):
+        key = get_random_string(10)
+        string_key = get_random_string(10)
+        non_existing_key = get_random_string(10)
+        group_name = get_random_string(10)
+        stream_id1_0 = "1-0"
+
+        # passing a non-existing key raises an error
+        with pytest.raises(RequestError):
+            await redis_client.xinfo_groups(non_existing_key)
+        with pytest.raises(RequestError):
+            await redis_client.xinfo_consumers(non_existing_key, group_name)
+
+        assert (
+            await redis_client.xadd(
+                key, [("f1", "v1"), ("f2", "v2")], StreamAddOptions(stream_id1_0)
+            )
+            == stream_id1_0.encode()
+        )
+
+        # passing a non-existing group raises an error
+        with pytest.raises(RequestError):
+            await redis_client.xinfo_consumers(key, "non_existing_group")
+
+        # no groups exist yet
+        assert await redis_client.xinfo_groups(key) == []
+
+        assert await redis_client.xgroup_create(key, group_name, stream_id1_0) == OK
+        # no consumers exist yet
+        assert await redis_client.xinfo_consumers(key, group_name) == []
+
+        # key exists, but it is not a stream
+        assert await redis_client.set(string_key, "foo") == OK
+        with pytest.raises(RequestError):
+            await redis_client.xinfo_groups(string_key)
+        with pytest.raises(RequestError):
+            await redis_client.xinfo_consumers(string_key, group_name)
+
+    @pytest.mark.parametrize("cluster_mode", [True, False])
+    @pytest.mark.parametrize("protocol", [ProtocolVersion.RESP2, ProtocolVersion.RESP3])
     async def test_xgroup_set_id(
         self, redis_client: TGlideClient, cluster_mode, protocol, request
     ):

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -6391,8 +6391,7 @@ class TestCommands:
         time.sleep(2)
         consumers_result = await redis_client.xinfo_consumers(key, group_name1)
         assert len(consumers_result) == 1
-        # cast key type to bytes so that mypy won't complain about passing byte strings to get() when str was expected
-        consumer1_info = cast(Mapping[bytes, Union[str, int]], consumers_result[0])
+        consumer1_info = consumers_result[0]
         assert consumer1_info.get(b"name") == consumer1.encode()
         assert consumer1_info.get(b"pending") == 1
         assert cast(int, consumer1_info.get(b"idle")) > 0
@@ -6426,7 +6425,7 @@ class TestCommands:
 
         groups = await redis_client.xinfo_groups(key)
         assert len(groups) == 1
-        group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+        group1_info = groups[0]
         assert group1_info.get(b"name") == group_name1.encode()
         assert group1_info.get(b"consumers") == 2
         assert group1_info.get(b"pending") == 3
@@ -6445,7 +6444,7 @@ class TestCommands:
         assert await redis_client.xgroup_set_id(key, group_name1, stream_id1_1) == OK
         groups = await redis_client.xinfo_groups(key)
         assert len(groups) == 1
-        group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+        group1_info = groups[0]
         assert group1_info.get(b"name") == group_name1.encode()
         assert group1_info.get(b"consumers") == 2
         assert group1_info.get(b"pending") == 3
@@ -6471,7 +6470,7 @@ class TestCommands:
             )
             groups = await redis_client.xinfo_groups(key)
             assert len(groups) == 1
-            group1_info = cast(Mapping[bytes, Union[str, int]], groups[0])
+            group1_info = groups[0]
             assert group1_info.get(b"name") == group_name1.encode()
             assert group1_info.get(b"consumers") == 2
             assert group1_info.get(b"pending") == 3

--- a/python/python/tests/test_async_client.py
+++ b/python/python/tests/test_async_client.py
@@ -6414,7 +6414,10 @@ class TestCommands:
         }
 
         # verify that xinfo_consumers contains info for 2 consumers now
-        consumers_result = await redis_client.xinfo_consumers(key, group_name1)
+        # test with byte string args
+        consumers_result = await redis_client.xinfo_consumers(
+            key.encode(), group_name1.encode()
+        )
         assert len(consumers_result) == 2
 
         # add one more entry
@@ -6442,7 +6445,8 @@ class TestCommands:
 
         # verify xgroup_set_id effects the returned value from xinfo_groups
         assert await redis_client.xgroup_set_id(key, group_name1, stream_id1_1) == OK
-        groups = await redis_client.xinfo_groups(key)
+        # test with byte string arg
+        groups = await redis_client.xinfo_groups(key.encode())
         assert len(groups) == 1
         group1_info = groups[0]
         assert group1_info.get(b"name") == group_name1.encode()

--- a/python/python/tests/test_transaction.py
+++ b/python/python/tests/test_transaction.py
@@ -580,6 +580,8 @@ async def transaction_test(
     args.append({b"0-1": [[b"foo", b"bar"]]})
     transaction.xtrim(key11, TrimByMinId(threshold="0-2", exact=True))
     args.append(1)
+    transaction.xinfo_groups(key11)
+    args.append([])
 
     group_name1 = get_random_string(10)
     group_name2 = get_random_string(10)
@@ -590,6 +592,8 @@ async def transaction_test(
         key11, group_name2, "0-0", StreamGroupOptions(make_stream=True)
     )
     args.append(OK)
+    transaction.xinfo_consumers(key11, group_name1)
+    args.append([])
     transaction.xgroup_create_consumer(key11, group_name1, consumer)
     args.append(True)
     transaction.xreadgroup(


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
https://redis.io/docs/latest/commands/xinfo-groups/
https://redis.io/docs/latest/commands/xinfo-consumers/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
