### PR TITLE
Python: Update docstring links

### DIFF
--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -325,7 +325,7 @@ class ClusterCommands(CoreCommands):
         """
         Loads a library to Redis.
 
-        See https://valkey.io/docs/latest/commands/function-load/ for more details.
+        See https://valkey.io/commands/function-load/ for more details.
 
         Args:
             library_code (str): The source code that implements the library.
@@ -359,7 +359,7 @@ class ClusterCommands(CoreCommands):
         """
         Deletes all function libraries.
 
-        See https://valkey.io/docs/latest/commands/function-flush/ for more details.
+        See https://valkey.io/commands/function-flush/ for more details.
 
         Args:
             mode (Optional[FlushMode]): The flushing mode, could be either `SYNC` or `ASYNC`.
@@ -390,7 +390,7 @@ class ClusterCommands(CoreCommands):
         """
         Deletes a library and all its functions.
 
-        See https://valkey.io/docs/latest/commands/function-delete/ for more details.
+        See https://valkey.io/commands/function-delete/ for more details.
 
         Args:
             library_code (str): The libary name to delete

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -237,7 +237,7 @@ class StandaloneCommands(CoreCommands):
         """
         Loads a library to Redis.
 
-        See https://valkey.io/docs/latest/commands/function-load/ for more details.
+        See https://valkey.io/commands/function-load/ for more details.
 
         Args:
             library_code (str): The source code that implements the library.
@@ -266,7 +266,7 @@ class StandaloneCommands(CoreCommands):
         """
         Deletes all function libraries.
 
-        See https://valkey.io/docs/latest/commands/function-flush/ for more details.
+        See https://valkey.io/commands/function-flush/ for more details.
 
         Args:
             mode (Optional[FlushMode]): The flushing mode, could be either `SYNC` or `ASYNC`.
@@ -292,7 +292,7 @@ class StandaloneCommands(CoreCommands):
         """
         Deletes a library and all its functions.
 
-        See https://valkey.io/docs/latest/commands/function-delete/ for more details.
+        See https://valkey.io/commands/function-delete/ for more details.
 
         Args:
             library_code (str): The libary name to delete

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -1784,7 +1784,7 @@ class BaseTransaction:
         """
         Loads a library to Redis.
 
-        See https://valkey.io/docs/latest/commands/function-load/ for more details.
+        See https://valkey.io/commands/function-load/ for more details.
 
         Args:
             library_code (str): The source code that implements the library.
@@ -1807,7 +1807,7 @@ class BaseTransaction:
         """
         Deletes all function libraries.
 
-        See https://valkey.io/docs/latest/commands/function-flush/ for more details.
+        See https://valkey.io/commands/function-flush/ for more details.
 
         Args:
             mode (Optional[FlushMode]): The flushing mode, could be either `SYNC` or `ASYNC`.
@@ -1826,7 +1826,7 @@ class BaseTransaction:
         """
         Deletes a library and all its functions.
 
-        See https://valkey.io/docs/latest/commands/function-delete/ for more details.
+        See https://valkey.io/commands/function-delete/ for more details.
 
         Args:
             library_code (str): The libary name to delete


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

A number of the docstrings for python functions are using an old URL pattern which currently results in 404 errors. Updating URLs to new pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
