### PR TITLE
Python: replace all commands links to valkey

### DIFF
--- a/python/python/glide/async_commands/cluster_commands.py
+++ b/python/python/glide/async_commands/cluster_commands.py
@@ -49,7 +49,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[bytes]:
         """
         Get information and statistics about the Redis server.
-        See https://redis.io/commands/info/ for details.
+        See https://valkey.io/commands/info/ for details.
 
         Args:
             sections (Optional[List[InfoSection]]): A list of InfoSection values specifying which sections of
@@ -100,7 +100,7 @@ class ClusterCommands(CoreCommands):
     ) -> TOK:
         """
         Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-        See https://redis.io/commands/config-resetstat/ for details.
+        See https://valkey.io/commands/config-resetstat/ for details.
 
         Args:
             route (Optional[Route]): The command will be routed automatically to all nodes, unless `route` is provided, in which
@@ -119,7 +119,7 @@ class ClusterCommands(CoreCommands):
     ) -> TOK:
         """
         Rewrite the configuration file with the current configuration.
-        See https://redis.io/commands/config-rewrite/ for details.
+        See https://valkey.io/commands/config-rewrite/ for details.
 
         Args:
             route (Optional[TRoute]): The command will be routed automatically to all nodes, unless `route` is provided, in which
@@ -142,7 +142,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[int]:
         """
         Returns the current connection id.
-        See https://redis.io/commands/client-id/ for more information.
+        See https://valkey.io/commands/client-id/ for more information.
 
         Args:
             route (Optional[Route]): The command will be sent to a random node, unless `route` is provided, in which
@@ -164,7 +164,7 @@ class ClusterCommands(CoreCommands):
     ) -> bytes:
         """
         Ping the Redis server.
-        See https://redis.io/commands/ping/ for more details.
+        See https://valkey.io/commands/ping/ for more details.
 
         Args:
             message (Optional[TEncodable]): An optional message to include in the PING command. If not provided,
@@ -192,7 +192,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[Dict[bytes, bytes]]:
         """
         Get the values of configuration parameters.
-        See https://redis.io/commands/config-get/ for details.
+        See https://valkey.io/commands/config-get/ for details.
 
         Args:
             parameters (List[TEncodable]): A list of configuration parameter names to retrieve values for.
@@ -224,7 +224,7 @@ class ClusterCommands(CoreCommands):
     ) -> TOK:
         """
         Set configuration parameters to the specified values.
-        See https://redis.io/commands/config-set/ for details.
+        See https://valkey.io/commands/config-set/ for details.
 
         Args:
             parameters_map (Mapping[TEncodable, TEncodable]): A map consisting of configuration
@@ -253,7 +253,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[Optional[bytes]]:
         """
         Get the name of the connection to which the request is routed.
-        See https://redis.io/commands/client-getname/ for more details.
+        See https://valkey.io/commands/client-getname/ for more details.
 
         Args:
             route (Optional[Route]): The command will be routed to a random node, unless `route` is provided,
@@ -279,7 +279,7 @@ class ClusterCommands(CoreCommands):
     async def dbsize(self, route: Optional[Route] = None) -> int:
         """
         Returns the number of keys in the database.
-        See https://redis.io/commands/dbsize for more details.
+        See https://valkey.io/commands/dbsize for more details.
 
         Args:
             route (Optional[Route]): The command will be routed to all primaries, unless `route` is provided,
@@ -301,7 +301,7 @@ class ClusterCommands(CoreCommands):
         """
         Echoes the provided `message` back.
 
-        See https://redis.io/commands/echo for more details.
+        See https://valkey.io/commands/echo for more details.
 
         Args:
             message (TEncodable): The message to be echoed back.
@@ -431,7 +431,7 @@ class ClusterCommands(CoreCommands):
     ) -> TClusterResponse[TResult]:
         """
         Invokes a previously loaded function.
-        See https://redis.io/commands/fcall/ for more details.
+        See https://valkey.io/commands/fcall/ for more details.
 
         Args:
             function (TEncodable): The function name.
@@ -501,7 +501,7 @@ class ClusterCommands(CoreCommands):
         """
         Returns the server time.
 
-        See https://redis.io/commands/time/ for more details.
+        See https://valkey.io/commands/time/ for more details.
 
         Args:
             route (Optional[Route]): The command will be routed to a random node, unless `route` is provided,

--- a/python/python/glide/async_commands/core.py
+++ b/python/python/glide/async_commands/core.py
@@ -371,7 +371,7 @@ class CoreCommands(Protocol):
     ) -> Optional[bytes]:
         """
         Set the given key with the given value. Return value is dependent on the passed options.
-        See https://redis.io/commands/set/ for more details.
+        See https://valkey.io/commands/set/ for more details.
 
         Args:
             key (TEncodable): the key to store.
@@ -412,7 +412,7 @@ class CoreCommands(Protocol):
     async def get(self, key: TEncodable) -> Optional[bytes]:
         """
         Get the value associated with the given key, or null if no such value exists.
-        See https://redis.io/commands/get/ for details.
+        See https://valkey.io/commands/get/ for details.
 
         Args:
             key (TEncodable): The key to retrieve from the database.
@@ -492,7 +492,7 @@ class CoreCommands(Protocol):
         Appends a value to a key.
         If `key` does not exist it is created and set as an empty string, so `APPEND` will be similar to `SET` in this special case.
 
-        See https://redis.io/commands/append for more details.
+        See https://valkey.io/commands/append for more details.
 
         Args:
             key (TEncodable): The key to which the value will be appended.
@@ -514,7 +514,7 @@ class CoreCommands(Protocol):
     async def strlen(self, key: TEncodable) -> int:
         """
         Get the length of the string value stored at `key`.
-        See https://redis.io/commands/strlen/ for more details.
+        See https://valkey.io/commands/strlen/ for more details.
 
         Args:
             key (TEncodable): The key to return its length.
@@ -535,7 +535,7 @@ class CoreCommands(Protocol):
         """
         Renames `key` to `new_key`.
         If `newkey` already exists it is overwritten.
-        See https://redis.io/commands/rename/ for more details.
+        See https://valkey.io/commands/rename/ for more details.
 
         Note:
             When in cluster mode, both `key` and `newkey` must map to the same hash slot.
@@ -579,7 +579,7 @@ class CoreCommands(Protocol):
     async def delete(self, keys: List[TEncodable]) -> int:
         """
         Delete one or more keys from the database. A key is ignored if it does not exist.
-        See https://redis.io/commands/del/ for details.
+        See https://valkey.io/commands/del/ for details.
 
         Note:
             When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
@@ -603,7 +603,7 @@ class CoreCommands(Protocol):
         """
         Increments the number stored at `key` by one. If the key does not exist, it is set to 0 before performing the
         operation.
-        See https://redis.io/commands/incr/ for more details.
+        See https://valkey.io/commands/incr/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -621,7 +621,7 @@ class CoreCommands(Protocol):
     async def incrby(self, key: TEncodable, amount: int) -> int:
         """
         Increments the number stored at `key` by `amount`. If the key does not exist, it is set to 0 before performing
-        the operation. See https://redis.io/commands/incrby/ for more details.
+        the operation. See https://valkey.io/commands/incrby/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -644,7 +644,7 @@ class CoreCommands(Protocol):
         Increment the string representing a floating point number stored at `key` by `amount`.
         By using a negative increment value, the value stored at the `key` is decremented.
         If the key does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/incrbyfloat/ for more details.
+        See https://valkey.io/commands/incrbyfloat/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -696,7 +696,7 @@ class CoreCommands(Protocol):
     async def mset(self, key_value_map: Mapping[TEncodable, TEncodable]) -> TOK:
         """
         Set multiple keys to multiple values in a single atomic operation.
-        See https://redis.io/commands/mset/ for more details.
+        See https://valkey.io/commands/mset/ for more details.
 
         Note:
             When in cluster mode, the command may route to multiple nodes when keys in `key_value_map` map to different hash slots.
@@ -749,7 +749,7 @@ class CoreCommands(Protocol):
     async def mget(self, keys: List[TEncodable]) -> List[Optional[bytes]]:
         """
         Retrieve the values of multiple keys.
-        See https://redis.io/commands/mget/ for more details.
+        See https://valkey.io/commands/mget/ for more details.
 
         Note:
             When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
@@ -775,7 +775,7 @@ class CoreCommands(Protocol):
         """
         Decrement the number stored at `key` by one. If the key does not exist, it is set to 0 before performing the
         operation.
-        See https://redis.io/commands/decr/ for more details.
+        See https://valkey.io/commands/decr/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -794,7 +794,7 @@ class CoreCommands(Protocol):
         """
         Decrements the number stored at `key` by `amount`. If the key does not exist, it is set to 0 before performing
         the operation.
-        See https://redis.io/commands/decrby/ for more details.
+        See https://valkey.io/commands/decrby/ for more details.
 
         Args:
           key (TEncodable): The key to decrement its value.
@@ -842,7 +842,7 @@ class CoreCommands(Protocol):
     ) -> int:
         """
         Sets the specified fields to their respective values in the hash stored at `key`.
-        See https://redis.io/commands/hset/ for more details.
+        See https://valkey.io/commands/hset/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -867,7 +867,7 @@ class CoreCommands(Protocol):
     async def hget(self, key: TEncodable, field: TEncodable) -> Optional[bytes]:
         """
         Retrieves the value associated with `field` in the hash stored at `key`.
-        See https://redis.io/commands/hget/ for more details.
+        See https://valkey.io/commands/hget/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -899,7 +899,7 @@ class CoreCommands(Protocol):
         Sets `field` in the hash stored at `key` to `value`, only if `field` does not yet exist.
         If `key` does not exist, a new key holding a hash is created.
         If `field` already exists, this operation has no effect.
-        See https://redis.io/commands/hsetnx/ for more details.
+        See https://valkey.io/commands/hsetnx/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -925,7 +925,7 @@ class CoreCommands(Protocol):
         Increment or decrement the value of a `field` in the hash stored at `key` by the specified amount.
         By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
         If `field` or `key` does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/hincrby/ for more details.
+        See https://valkey.io/commands/hincrby/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -953,7 +953,7 @@ class CoreCommands(Protocol):
         amount.
         By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
         If `field` or `key` does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/hincrbyfloat/ for more details.
+        See https://valkey.io/commands/hincrbyfloat/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -978,7 +978,7 @@ class CoreCommands(Protocol):
     async def hexists(self, key: TEncodable, field: TEncodable) -> bool:
         """
         Check if a field exists in the hash stored at `key`.
-        See https://redis.io/commands/hexists/ for more details.
+        See https://valkey.io/commands/hexists/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1001,7 +1001,7 @@ class CoreCommands(Protocol):
     async def hgetall(self, key: TEncodable) -> Dict[bytes, bytes]:
         """
         Returns all fields and values of the hash stored at `key`.
-        See https://redis.io/commands/hgetall/ for details.
+        See https://valkey.io/commands/hgetall/ for details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1024,7 +1024,7 @@ class CoreCommands(Protocol):
     ) -> List[Optional[bytes]]:
         """
         Retrieve the values associated with specified fields in the hash stored at `key`.
-        See https://redis.io/commands/hmget/ for details.
+        See https://valkey.io/commands/hmget/ for details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1047,7 +1047,7 @@ class CoreCommands(Protocol):
     async def hdel(self, key: TEncodable, fields: List[TEncodable]) -> int:
         """
         Remove specified fields from the hash stored at `key`.
-        See https://redis.io/commands/hdel/ for more details.
+        See https://valkey.io/commands/hdel/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1067,7 +1067,7 @@ class CoreCommands(Protocol):
         """
         Returns the number of fields contained in the hash stored at `key`.
 
-        See https://redis.io/commands/hlen/ for more details.
+        See https://valkey.io/commands/hlen/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1088,7 +1088,7 @@ class CoreCommands(Protocol):
         """
         Returns all values in the hash stored at `key`.
 
-        See https://redis.io/commands/hvals/ for more details.
+        See https://valkey.io/commands/hvals/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1106,7 +1106,7 @@ class CoreCommands(Protocol):
         """
         Returns all field names in the hash stored at `key`.
 
-        See https://redis.io/commands/hkeys/ for more details.
+        See https://valkey.io/commands/hkeys/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -1226,7 +1226,7 @@ class CoreCommands(Protocol):
         Insert all the specified values at the head of the list stored at `key`.
         `elements` are inserted one after the other to the head of the list, from the leftmost element
         to the rightmost element. If `key` does not exist, it is created as empty list before performing the push operations.
-        See https://redis.io/commands/lpush/ for more details.
+        See https://valkey.io/commands/lpush/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1250,7 +1250,7 @@ class CoreCommands(Protocol):
         Inserts all the specified values at the head of the list stored at `key`, only if `key` exists and holds a list.
         If `key` is not a list, this performs no operation.
 
-        See https://redis.io/commands/lpushx/ for more details.
+        See https://valkey.io/commands/lpushx/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1273,7 +1273,7 @@ class CoreCommands(Protocol):
         """
         Remove and return the first elements of the list stored at `key`.
         The command pops a single element from the beginning of the list.
-        See https://redis.io/commands/lpop/ for details.
+        See https://valkey.io/commands/lpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1296,7 +1296,7 @@ class CoreCommands(Protocol):
     async def lpop_count(self, key: TEncodable, count: int) -> Optional[List[bytes]]:
         """
         Remove and return up to `count` elements from the list stored at `key`, depending on the list's length.
-        See https://redis.io/commands/lpop/ for details.
+        See https://valkey.io/commands/lpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1432,7 +1432,7 @@ class CoreCommands(Protocol):
         The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next
         element and so on. These offsets can also be negative numbers indicating offsets starting at the end of the list,
         with -1 being the last element of the list, -2 being the penultimate, and so on.
-        See https://redis.io/commands/lrange/ for details.
+        See https://valkey.io/commands/lrange/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1472,7 +1472,7 @@ class CoreCommands(Protocol):
         Negative indices can be used to designate elements starting at the tail of the list.
         Here, -1 means the last element, -2 means the penultimate and so forth.
 
-        See https://redis.io/commands/lindex/ for more details.
+        See https://valkey.io/commands/lindex/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1525,7 +1525,7 @@ class CoreCommands(Protocol):
         Inserts all the specified values at the tail of the list stored at `key`.
         `elements` are inserted one after the other to the tail of the list, from the leftmost element
         to the rightmost element. If `key` does not exist, it is created as empty list before performing the push operations.
-        See https://redis.io/commands/rpush/ for more details.
+        See https://valkey.io/commands/rpush/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1549,7 +1549,7 @@ class CoreCommands(Protocol):
         Inserts all the specified values at the tail of the list stored at `key`, only if `key` exists and holds a list.
         If `key` is not a list, this performs no operation.
 
-        See https://redis.io/commands/rpushx/ for more details.
+        See https://valkey.io/commands/rpushx/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1572,7 +1572,7 @@ class CoreCommands(Protocol):
         """
         Removes and returns the last elements of the list stored at `key`.
         The command pops a single element from the end of the list.
-        See https://redis.io/commands/rpop/ for details.
+        See https://valkey.io/commands/rpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1595,7 +1595,7 @@ class CoreCommands(Protocol):
     async def rpop_count(self, key: TEncodable, count: int) -> Optional[List[bytes]]:
         """
         Removes and returns up to `count` elements from the list stored at `key`, depending on the list's length.
-        See https://redis.io/commands/rpop/ for details.
+        See https://valkey.io/commands/rpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1655,7 +1655,7 @@ class CoreCommands(Protocol):
         """
         Inserts `element` in the list at `key` either before or after the `pivot`.
 
-        See https://redis.io/commands/linsert/ for details.
+        See https://valkey.io/commands/linsert/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1780,7 +1780,7 @@ class CoreCommands(Protocol):
         Add specified members to the set stored at `key`.
         Specified members that are already a member of this set are ignored.
         If `key` does not exist, a new set is created before adding `members`.
-        See https://redis.io/commands/sadd/ for more details.
+        See https://valkey.io/commands/sadd/ for more details.
 
         Args:
             key (TEncodable): The key where members will be added to its set.
@@ -1799,7 +1799,7 @@ class CoreCommands(Protocol):
         """
         Remove specified members from the set stored at `key`.
         Specified members that are not a member of this set are ignored.
-        See https://redis.io/commands/srem/ for details.
+        See https://valkey.io/commands/srem/ for details.
 
         Args:
             key (TEncodable): The key from which members will be removed.
@@ -1818,7 +1818,7 @@ class CoreCommands(Protocol):
     async def smembers(self, key: TEncodable) -> Set[bytes]:
         """
         Retrieve all the members of the set value stored at `key`.
-        See https://redis.io/commands/smembers/ for details.
+        See https://valkey.io/commands/smembers/ for details.
 
         Args:
             key (TEncodable): The key from which to retrieve the set members.
@@ -1838,7 +1838,7 @@ class CoreCommands(Protocol):
     async def scard(self, key: TEncodable) -> int:
         """
         Retrieve the set cardinality (number of elements) of the set stored at `key`.
-        See https://redis.io/commands/scard/ for details.
+        See https://valkey.io/commands/scard/ for details.
 
         Args:
             key (TEncodable): The key from which to retrieve the number of set members.
@@ -1909,7 +1909,7 @@ class CoreCommands(Protocol):
         """
         Returns if `member` is a member of the set stored at `key`.
 
-        See https://redis.io/commands/sismember/ for more details.
+        See https://valkey.io/commands/sismember/ for more details.
 
         Args:
             key (TEncodable): The key of the set.
@@ -2198,7 +2198,7 @@ class CoreCommands(Protocol):
         element and so on.
         These offsets can also be negative numbers indicating offsets starting at the end of the list, with -1 being the last
         element of the list, -2 being the penultimate, and so on.
-        See https://redis.io/commands/ltrim/ for more details.
+        See https://valkey.io/commands/ltrim/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -2228,7 +2228,7 @@ class CoreCommands(Protocol):
         If `count` is negative, it removes elements equal to `element` moving from tail to head.
         If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
         equal to `element`.
-        See https://redis.io/commands/lrem/ for more details.
+        See https://valkey.io/commands/lrem/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -2251,7 +2251,7 @@ class CoreCommands(Protocol):
     async def llen(self, key: TEncodable) -> int:
         """
         Get the length of the list stored at `key`.
-        See https://redis.io/commands/llen/ for details.
+        See https://valkey.io/commands/llen/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -2269,7 +2269,7 @@ class CoreCommands(Protocol):
     async def exists(self, keys: List[TEncodable]) -> int:
         """
         Returns the number of keys in `keys` that exist in the database.
-        See https://redis.io/commands/exists/ for more details.
+        See https://valkey.io/commands/exists/ for more details.
 
         Note:
             When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
@@ -2292,8 +2292,8 @@ class CoreCommands(Protocol):
         Unlink (delete) multiple keys from the database.
         A key is ignored if it does not exist.
         This command, similar to DEL, removes specified keys and ignores non-existent ones.
-        However, this command does not block the server, while [DEL](https://redis.io/commands/del) does.
-        See https://redis.io/commands/unlink/ for more details.
+        However, this command does not block the server, while [DEL](https://valkey.io/commands/del) does.
+        See https://valkey.io/commands/unlink/ for more details.
 
         Note:
             When in cluster mode, the command may route to multiple nodes when `keys` map to different hash slots.
@@ -2321,7 +2321,7 @@ class CoreCommands(Protocol):
         If `key` already has an existing expire set, the time to live is updated to the new value.
         If `seconds` is a non-positive number, the key will be deleted rather than expired.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/expire/ for more details.
+        See https://valkey.io/commands/expire/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -2354,7 +2354,7 @@ class CoreCommands(Protocol):
         deleted.
         If `key` already has an existing expire set, the time to live is updated to the new value.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/expireat/ for more details.
+        See https://valkey.io/commands/expireat/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -2387,7 +2387,7 @@ class CoreCommands(Protocol):
         If `key` already has an existing expire set, the time to live is updated to the new value.
         If `milliseconds` is a non-positive number, the key will be deleted rather than expired.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/pexpire/ for more details.
+        See https://valkey.io/commands/pexpire/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -2422,7 +2422,7 @@ class CoreCommands(Protocol):
         deleted.
         If `key` already has an existing expire set, the time to live is updated to the new value.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/pexpireat/ for more details.
+        See https://valkey.io/commands/pexpireat/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -2502,7 +2502,7 @@ class CoreCommands(Protocol):
     async def ttl(self, key: TEncodable) -> int:
         """
         Returns the remaining time to live of `key` that has a timeout.
-        See https://redis.io/commands/ttl/ for more details.
+        See https://valkey.io/commands/ttl/ for more details.
 
         Args:
             key (TEncodable): The key to return its timeout.
@@ -2526,7 +2526,7 @@ class CoreCommands(Protocol):
     ) -> int:
         """
         Returns the remaining time to live of `key` that has a timeout, in milliseconds.
-        See https://redis.io/commands/pttl for more details.
+        See https://valkey.io/commands/pttl for more details.
 
         Args:
             key (TEncodable): The key to return its timeout.
@@ -2553,7 +2553,7 @@ class CoreCommands(Protocol):
         Remove the existing timeout on `key`, turning the key from volatile (a key with an expire set) to
         persistent (a key that will never expire as no timeout is associated).
 
-        See https://redis.io/commands/persist/ for more details.
+        See https://valkey.io/commands/persist/ for more details.
 
         Args:
             key (TEncodable): The key to remove the existing timeout on.
@@ -2574,7 +2574,7 @@ class CoreCommands(Protocol):
         """
         Returns the bytes string representation of the type of the value stored at `key`.
 
-        See https://redis.io/commands/type/ for more details.
+        See https://valkey.io/commands/type/ for more details.
 
         Args:
             key (TEncodable): The key to check its data type.
@@ -3642,7 +3642,7 @@ class CoreCommands(Protocol):
         Adds members with their scores to the sorted set stored at `key`.
         If a member is already a part of the sorted set, its score is updated.
 
-        See https://redis.io/commands/zadd/ for more details.
+        See https://valkey.io/commands/zadd/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3705,7 +3705,7 @@ class CoreCommands(Protocol):
         If `member` does not exist in the sorted set, it is added with `increment` as its score (as if its previous score was 0.0).
         If `key` does not exist, a new sorted set with the specified member as its sole member is created.
 
-        See https://redis.io/commands/zadd/ for more details.
+        See https://valkey.io/commands/zadd/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3754,7 +3754,7 @@ class CoreCommands(Protocol):
         """
         Returns the cardinality (number of elements) of the sorted set stored at `key`.
 
-        See https://redis.io/commands/zcard/ for more details.
+        See https://valkey.io/commands/zcard/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3780,7 +3780,7 @@ class CoreCommands(Protocol):
         """
         Returns the number of members in the sorted set stored at `key` with scores between `min_score` and `max_score`.
 
-        See https://redis.io/commands/zcount/ for more details.
+        See https://valkey.io/commands/zcount/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3861,7 +3861,7 @@ class CoreCommands(Protocol):
         If `count` is provided, up to `count` members with the highest scores are removed and returned.
         Otherwise, only one member with the highest score is removed and returned.
 
-        See https://redis.io/commands/zpopmax for more details.
+        See https://valkey.io/commands/zpopmax for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3929,7 +3929,7 @@ class CoreCommands(Protocol):
         If `count` is provided, up to `count` members with the lowest scores are removed and returned.
         Otherwise, only one member with the lowest score is removed and returned.
 
-        See https://redis.io/commands/zpopmin for more details.
+        See https://valkey.io/commands/zpopmin for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4000,7 +4000,7 @@ class CoreCommands(Protocol):
 
         ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
 
-        See https://redis.io/commands/zrange/ for more details.
+        See https://valkey.io/commands/zrange/ for more details.
 
         To get the elements with their scores, see zrange_withscores.
 
@@ -4036,7 +4036,7 @@ class CoreCommands(Protocol):
         Returns the specified range of elements with their scores in the sorted set stored at `key`.
         Similar to ZRANGE but with a WITHSCORE flag.
 
-        See https://redis.io/commands/zrange/ for more details.
+        See https://valkey.io/commands/zrange/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4110,7 +4110,7 @@ class CoreCommands(Protocol):
         """
         Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
 
-        See https://redis.io/commands/zrank for more details.
+        See https://valkey.io/commands/zrank for more details.
 
         To get the rank of `member` with its score, see `zrank_withscore`.
 
@@ -4140,7 +4140,7 @@ class CoreCommands(Protocol):
         """
         Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
 
-        See https://redis.io/commands/zrank for more details.
+        See https://valkey.io/commands/zrank for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4231,7 +4231,7 @@ class CoreCommands(Protocol):
         Removes the specified members from the sorted set stored at `key`.
         Specified members that are not a member of this set are ignored.
 
-        See https://redis.io/commands/zrem/ for more details.
+        See https://valkey.io/commands/zrem/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4261,7 +4261,7 @@ class CoreCommands(Protocol):
         """
         Removes all elements in the sorted set stored at `key` with a score between `min_score` and `max_score`.
 
-        See https://redis.io/commands/zremrangebyscore/ for more details.
+        See https://valkey.io/commands/zremrangebyscore/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4310,7 +4310,7 @@ class CoreCommands(Protocol):
         Removes all elements in the sorted set stored at `key` with a lexicographical order between `min_lex` and
         `max_lex`.
 
-        See https://redis.io/commands/zremrangebylex/ for more details.
+        See https://valkey.io/commands/zremrangebylex/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4392,7 +4392,7 @@ class CoreCommands(Protocol):
         """
         Returns the number of members in the sorted set stored at `key` with lexicographical values between `min_lex` and `max_lex`.
 
-        See https://redis.io/commands/zlexcount/ for more details.
+        See https://valkey.io/commands/zlexcount/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -4432,7 +4432,7 @@ class CoreCommands(Protocol):
         """
         Returns the score of `member` in the sorted set stored at `key`.
 
-        See https://redis.io/commands/zscore/ for more details.
+        See https://valkey.io/commands/zscore/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -5048,7 +5048,7 @@ class CoreCommands(Protocol):
         If the script has not already been loaded, it will be loaded automatically using the Redis `SCRIPT LOAD` command.
         After that, it will be invoked using the Redis `EVALSHA` command.
 
-        See https://redis.io/commands/script-load/ and https://redis.io/commands/evalsha/ for more details.
+        See https://valkey.io/commands/script-load/ and https://valkey.io/commands/evalsha/ for more details.
 
         Args:
             script (Script): The Lua script to execute.
@@ -5071,7 +5071,7 @@ class CoreCommands(Protocol):
         Creates a new structure if the `key` does not exist.
         When no elements are provided, and `key` exists and is a HyperLogLog, then no operation is performed.
 
-        See https://redis.io/commands/pfadd/ for more details.
+        See https://valkey.io/commands/pfadd/ for more details.
 
         Args:
             key (TEncodable): The key of the HyperLogLog data structure to add elements into.
@@ -5799,7 +5799,7 @@ class CoreCommands(Protocol):
     ) -> TResult:
         """
         Invokes a previously loaded function.
-        See https://redis.io/commands/fcall/ for more details.
+        See https://valkey.io/commands/fcall/ for more details.
         When in cluster mode, all keys in `keys` must map to the same hash slot.
         Args:
             function (TEncodable): The function name.

--- a/python/python/glide/async_commands/redis_modules/json.py
+++ b/python/python/glide/async_commands/redis_modules/json.py
@@ -25,7 +25,7 @@ from glide.protobuf.redis_request_pb2 import RequestType
 
 class JsonGetOptions:
     """
-    Represents options for formatting JSON data, to be used in  the [JSON.GET](https://redis.io/commands/json.get/) command.
+    Represents options for formatting JSON data, to be used in  the [JSON.GET](https://valkey.io/commands/json.get/) command.
 
     Args:
         indent (Optional[str]): Sets an indentation string for nested levels. Defaults to None.
@@ -64,7 +64,7 @@ async def set(
     """
     Sets the JSON value at the specified `path` stored at `key`.
 
-    See https://redis.io/commands/json.set/ for more details.
+    See https://valkey.io/commands/json.set/ for more details.
 
     Args:
         client (TGlideClient): The Redis client to execute the command.
@@ -103,7 +103,7 @@ async def get(
     """
     Retrieves the JSON value at the specified `paths` stored at `key`.
 
-    See https://redis.io/commands/json.get/ for more details.
+    See https://valkey.io/commands/json.get/ for more details.
 
     Args:
         client (TGlideClient): The Redis client to execute the command.
@@ -147,7 +147,7 @@ async def delete(
     """
     Deletes the JSON value at the specified `path` within the JSON document stored at `key`.
 
-    See https://redis.io/commands/json.del/ for more details.
+    See https://valkey.io/commands/json.del/ for more details.
 
     Args:
         client (TGlideClient): The Redis client to execute the command.
@@ -184,7 +184,7 @@ async def forget(
     """
     Deletes the JSON value at the specified `path` within the JSON document stored at `key`.
 
-    See https://redis.io/commands/json.forget/ for more details.
+    See https://valkey.io/commands/json.forget/ for more details.
 
     Args:
         client (TGlideClient): The Redis client to execute the command.
@@ -222,7 +222,7 @@ async def toggle(
     """
     Toggles a Boolean value stored at the specified `path` within the JSON document stored at `key`.
 
-    See https://redis.io/commands/json.toggle/ for more details.
+    See https://valkey.io/commands/json.toggle/ for more details.
 
     Args:
         client (TGlideClient): The Redis client to execute the command.

--- a/python/python/glide/async_commands/standalone_commands.py
+++ b/python/python/glide/async_commands/standalone_commands.py
@@ -41,7 +41,7 @@ class StandaloneCommands(CoreCommands):
     ) -> bytes:
         """
         Get information and statistics about the Redis server.
-        See https://redis.io/commands/info/ for details.
+        See https://valkey.io/commands/info/ for details.
 
         Args:
             sections (Optional[List[InfoSection]]): A list of InfoSection values specifying which sections of
@@ -79,7 +79,7 @@ class StandaloneCommands(CoreCommands):
     async def select(self, index: int) -> TOK:
         """
         Change the currently selected Redis database.
-        See https://redis.io/commands/select/ for details.
+        See https://valkey.io/commands/select/ for details.
 
         Args:
             index (int): The index of the database to select.
@@ -92,7 +92,7 @@ class StandaloneCommands(CoreCommands):
     async def config_resetstat(self) -> TOK:
         """
         Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-        See https://redis.io/commands/config-resetstat/ for details.
+        See https://valkey.io/commands/config-resetstat/ for details.
 
         Returns:
             OK: Returns "OK" to confirm that the statistics were successfully reset.
@@ -102,7 +102,7 @@ class StandaloneCommands(CoreCommands):
     async def config_rewrite(self) -> TOK:
         """
         Rewrite the configuration file with the current configuration.
-        See https://redis.io/commands/config-rewrite/ for details.
+        See https://valkey.io/commands/config-rewrite/ for details.
 
         Returns:
             OK: OK is returned when the configuration was rewritten properly. Otherwise, an error is raised.
@@ -114,7 +114,7 @@ class StandaloneCommands(CoreCommands):
     ) -> int:
         """
         Returns the current connection id.
-        See https://redis.io/commands/client-id/ for more information.
+        See https://valkey.io/commands/client-id/ for more information.
 
         Returns:
             int: the id of the client.
@@ -124,7 +124,7 @@ class StandaloneCommands(CoreCommands):
     async def ping(self, message: Optional[TEncodable] = None) -> bytes:
         """
         Ping the Redis server.
-        See https://redis.io/commands/ping/ for more details.
+        See https://valkey.io/commands/ping/ for more details.
 
         Args:
            message (Optional[TEncodable]): An optional message to include in the PING command. If not provided,
@@ -145,7 +145,7 @@ class StandaloneCommands(CoreCommands):
     async def config_get(self, parameters: List[TEncodable]) -> Dict[bytes, bytes]:
         """
         Get the values of configuration parameters.
-        See https://redis.io/commands/config-get/ for details.
+        See https://valkey.io/commands/config-get/ for details.
 
         Args:
             parameters (List[TEncodable]): A list of configuration parameter names to retrieve values for.
@@ -167,7 +167,7 @@ class StandaloneCommands(CoreCommands):
     async def config_set(self, parameters_map: Mapping[TEncodable, TEncodable]) -> TOK:
         """
         Set configuration parameters to the specified values.
-        See https://redis.io/commands/config-set/ for details.
+        See https://valkey.io/commands/config-set/ for details.
 
         Args:
             parameters_map (Mapping[TEncodable, TEncodable]): A map consisting of configuration
@@ -188,7 +188,7 @@ class StandaloneCommands(CoreCommands):
     async def client_getname(self) -> Optional[bytes]:
         """
         Get the name of the primary's connection.
-        See https://redis.io/commands/client-getname/ for more details.
+        See https://valkey.io/commands/client-getname/ for more details.
 
         Returns:
             Optional[bytes]: Returns the name of the client connection as a byte string if a name is set,
@@ -205,7 +205,7 @@ class StandaloneCommands(CoreCommands):
     async def dbsize(self) -> int:
         """
         Returns the number of keys in the currently selected database.
-        See https://redis.io/commands/dbsize for more details.
+        See https://valkey.io/commands/dbsize for more details.
 
         Returns:
             int: The number of keys in the currently selected database.
@@ -220,7 +220,7 @@ class StandaloneCommands(CoreCommands):
         """
         Echoes the provided `message` back.
 
-        See https://redis.io/commands/echo for more details.
+        See https://valkey.io/commands/echo for more details.
 
         Args:
             message (TEncodable): The message to be echoed back.
@@ -321,7 +321,7 @@ class StandaloneCommands(CoreCommands):
         """
         Returns the server time.
 
-        See https://redis.io/commands/time/ for more details.
+        See https://valkey.io/commands/time/ for more details.
 
         Returns:
             List[bytes]:  The current server time as a two items `array`:

--- a/python/python/glide/async_commands/transaction.py
+++ b/python/python/glide/async_commands/transaction.py
@@ -96,7 +96,7 @@ class BaseTransaction:
     def get(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Get the value associated with the given key, or null if no such value exists.
-        See https://redis.io/commands/get/ for details.
+        See https://valkey.io/commands/get/ for details.
 
         Args:
             key (TEncodable): The key to retrieve from the database.
@@ -153,7 +153,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Set the given key with the given value. Return value is dependent on the passed options.
-            See https://redis.io/commands/set/ for details.
+            See https://valkey.io/commands/set/ for details.
 
             @example - Set "foo" to "bar" only if "foo" already exists, and set the key expiration to 5 seconds:
 
@@ -191,7 +191,7 @@ class BaseTransaction:
     def strlen(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Get the length of the string value stored at `key`.
-        See https://redis.io/commands/strlen/ for more details.
+        See https://valkey.io/commands/strlen/ for more details.
 
         Args:
             key (TEncodable): The key to return its length.
@@ -210,7 +210,7 @@ class BaseTransaction:
         If `newkey` already exists it is overwritten.
         In Cluster mode, both `key` and `newkey` must be in the same hash slot,
         meaning that in practice only keys that have the same hash tag can be reliably renamed in cluster.
-        See https://redis.io/commands/rename/ for more details.
+        See https://valkey.io/commands/rename/ for more details.
 
         Args:
             key (TEncodable) : The key to rename.
@@ -264,7 +264,7 @@ class BaseTransaction:
         Appends a value to a key.
         If `key` does not exist it is created and set as an empty string, so `APPEND` will be similar to SET in this special case.
 
-        See https://redis.io/commands/append for more details.
+        See https://valkey.io/commands/append for more details.
 
         Args:
             key (TEncodable): The key to which the value will be appended.
@@ -281,7 +281,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Get information and statistics about the Redis server.
-        See https://redis.io/commands/info/ for details.
+        See https://valkey.io/commands/info/ for details.
 
         Args:
             sections (Optional[List[InfoSection]]): A list of InfoSection values specifying which sections of
@@ -298,7 +298,7 @@ class BaseTransaction:
     def delete(self: TTransaction, keys: List[TEncodable]) -> TTransaction:
         """
         Delete one or more keys from the database. A key is ignored if it does not exist.
-        See https://redis.io/commands/del/ for details.
+        See https://valkey.io/commands/del/ for details.
 
         Args:
             keys (List[TEncodable]): A list of keys to be deleted from the database.
@@ -311,7 +311,7 @@ class BaseTransaction:
     def config_get(self: TTransaction, parameters: List[TEncodable]) -> TTransaction:
         """
         Get the values of configuration parameters.
-        See https://redis.io/commands/config-get/ for details.
+        See https://valkey.io/commands/config-get/ for details.
 
         Args:
             parameters (List[TEncodable]): A list of configuration parameter names to retrieve values for.
@@ -327,7 +327,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Set configuration parameters to the specified values.
-        See https://redis.io/commands/config-set/ for details.
+        See https://valkey.io/commands/config-set/ for details.
 
         Args:
             parameters_map (Mapping[TEncodable, TEncodable]): A map consisting of configuration
@@ -344,7 +344,7 @@ class BaseTransaction:
     def config_resetstat(self: TTransaction) -> TTransaction:
         """
         Resets the statistics reported by Redis using the INFO and LATENCY HISTOGRAM commands.
-        See https://redis.io/commands/config-resetstat/ for details.
+        See https://valkey.io/commands/config-resetstat/ for details.
 
         Command response:
             OK: a simple OK response.
@@ -356,7 +356,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Set multiple keys to multiple values in a single atomic operation.
-        See https://redis.io/commands/mset/ for more details.
+        See https://valkey.io/commands/mset/ for more details.
 
         Args:
             parameters (Mapping[TEncodable, TEncodable]): A map of key value pairs.
@@ -392,7 +392,7 @@ class BaseTransaction:
     def mget(self: TTransaction, keys: List[TEncodable]) -> TTransaction:
         """
         Retrieve the values of multiple keys.
-        See https://redis.io/commands/mget/ for more details.
+        See https://valkey.io/commands/mget/ for more details.
 
         Args:
             keys (List[TEncodable]): A list of keys to retrieve values for.
@@ -420,7 +420,7 @@ class BaseTransaction:
     def config_rewrite(self: TTransaction) -> TTransaction:
         """
         Rewrite the configuration file with the current configuration.
-        See https://redis.io/commands/config-rewrite/ for details.
+        See https://valkey.io/commands/config-rewrite/ for details.
 
         Command response:
             OK: OK is returned when the configuration was rewritten properly. Otherwise, the transaction fails with an error.
@@ -430,7 +430,7 @@ class BaseTransaction:
     def client_id(self: TTransaction) -> TTransaction:
         """
         Returns the current connection id.
-        See https://redis.io/commands/client-id/ for more information.
+        See https://valkey.io/commands/client-id/ for more information.
 
         Command response:
             int: the id of the client.
@@ -442,7 +442,7 @@ class BaseTransaction:
         Increments the number stored at `key` by one.
         If `key` does not exist, it is set to 0 before performing the
         operation.
-        See https://redis.io/commands/incr/ for more details.
+        See https://valkey.io/commands/incr/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -456,7 +456,7 @@ class BaseTransaction:
         """
         Increments the number stored at `key` by `amount`. If the key does not exist, it is set to 0 before performing
         the operation.
-        See https://redis.io/commands/incrby/ for more details.
+        See https://valkey.io/commands/incrby/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -472,7 +472,7 @@ class BaseTransaction:
         Increment the string representing a floating point number stored at `key` by `amount`.
         By using a negative increment value, the value stored at the `key` is decremented.
         If the key does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/incrbyfloat/ for more details.
+        See https://valkey.io/commands/incrbyfloat/ for more details.
 
         Args:
           key (TEncodable): The key to increment its value.
@@ -486,7 +486,7 @@ class BaseTransaction:
     def ping(self: TTransaction, message: Optional[TEncodable] = None) -> TTransaction:
         """
         Ping the Redis server.
-        See https://redis.io/commands/ping/ for more details.
+        See https://valkey.io/commands/ping/ for more details.
 
         Args:
            message (Optional[TEncodable]): An optional message to include in the PING command. If not provided,
@@ -502,7 +502,7 @@ class BaseTransaction:
         """
         Decrements the number stored at `key` by one. If the key does not exist, it is set to 0 before performing the
         operation.
-        See https://redis.io/commands/decr/ for more details.
+        See https://valkey.io/commands/decr/ for more details.
 
         Args:
           key (TEncodable): The key to decrement its value.
@@ -516,7 +516,7 @@ class BaseTransaction:
         """
         Decrements the number stored at `key` by `amount`. If the key does not exist, it is set to 0 before performing
         the operation.
-        See https://redis.io/commands/decrby/ for more details.
+        See https://valkey.io/commands/decrby/ for more details.
 
         Args:
           key (TEncodable): The key to decrement its value.
@@ -559,7 +559,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Sets the specified fields to their respective values in the hash stored at `key`.
-        See https://redis.io/commands/hset/ for more details.
+        See https://valkey.io/commands/hset/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -577,7 +577,7 @@ class BaseTransaction:
     def hget(self: TTransaction, key: TEncodable, field: TEncodable) -> TTransaction:
         """
         Retrieves the value associated with `field` in the hash stored at `key`.
-        See https://redis.io/commands/hget/ for more details.
+        See https://valkey.io/commands/hget/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -599,7 +599,7 @@ class BaseTransaction:
         Sets `field` in the hash stored at `key` to `value`, only if `field` does not yet exist.
         If `key` does not exist, a new key holding a hash is created.
         If `field` already exists, this operation has no effect.
-        See https://redis.io/commands/hsetnx/ for more details.
+        See https://valkey.io/commands/hsetnx/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -621,7 +621,7 @@ class BaseTransaction:
         Increment or decrement the value of a `field` in the hash stored at `key` by the specified amount.
         By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
         If `field` or `key` does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/hincrby/ for more details.
+        See https://valkey.io/commands/hincrby/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -645,7 +645,7 @@ class BaseTransaction:
         amount.
         By using a negative increment value, the value stored at `field` in the hash stored at `key` is decremented.
         If `field` or `key` does not exist, it is set to 0 before performing the operation.
-        See https://redis.io/commands/hincrbyfloat/ for more details.
+        See https://valkey.io/commands/hincrbyfloat/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -661,7 +661,7 @@ class BaseTransaction:
     def hexists(self: TTransaction, key: TEncodable, field: TEncodable) -> TTransaction:
         """
         Check if a field exists in the hash stored at `key`.
-        See https://redis.io/commands/hexists/ for more details.
+        See https://valkey.io/commands/hexists/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -677,7 +677,7 @@ class BaseTransaction:
         """
         Returns the number of fields contained in the hash stored at `key`.
 
-        See https://redis.io/commands/hlen/ for more details.
+        See https://valkey.io/commands/hlen/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -691,7 +691,7 @@ class BaseTransaction:
     def client_getname(self: TTransaction) -> TTransaction:
         """
         Get the name of the connection on which the transaction is being executed.
-        See https://redis.io/commands/client-getname/ for more details.
+        See https://valkey.io/commands/client-getname/ for more details.
 
         Command response:
             Optional[bytes]: Returns the name of the client connection as a bytes string if a name is set,
@@ -702,7 +702,7 @@ class BaseTransaction:
     def hgetall(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Returns all fields and values of the hash stored at `key`.
-        See https://redis.io/commands/hgetall/ for details.
+        See https://valkey.io/commands/hgetall/ for details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -719,7 +719,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Retrieve the values associated with specified fields in the hash stored at `key`.
-        See https://redis.io/commands/hmget/ for details.
+        See https://valkey.io/commands/hmget/ for details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -737,7 +737,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Remove specified fields from the hash stored at `key`.
-        See https://redis.io/commands/hdel/ for more details.
+        See https://valkey.io/commands/hdel/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -753,7 +753,7 @@ class BaseTransaction:
         """
         Returns all values in the hash stored at `key`.
 
-        See https://redis.io/commands/hvals/ for more details.
+        See https://valkey.io/commands/hvals/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -767,7 +767,7 @@ class BaseTransaction:
         """
         Returns all field names in the hash stored at `key`.
 
-        See https://redis.io/commands/hkeys/ for more details.
+        See https://valkey.io/commands/hkeys/ for more details.
 
         Args:
             key (TEncodable): The key of the hash.
@@ -857,7 +857,7 @@ class BaseTransaction:
         Insert all the specified values at the head of the list stored at `key`.
         `elements` are inserted one after the other to the head of the list, from the leftmost element
         to the rightmost element. If `key` does not exist, it is created as empty list before performing the push operations.
-        See https://redis.io/commands/lpush/ for more details.
+        See https://valkey.io/commands/lpush/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -875,7 +875,7 @@ class BaseTransaction:
         Inserts all the specified values at the head of the list stored at `key`, only if `key` exists and holds a list.
         If `key` is not a list, this performs no operation.
 
-        See https://redis.io/commands/lpushx/ for more details.
+        See https://valkey.io/commands/lpushx/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -890,7 +890,7 @@ class BaseTransaction:
         """
         Remove and return the first elements of the list stored at `key`.
         The command pops a single element from the beginning of the list.
-        See https://redis.io/commands/lpop/ for details.
+        See https://valkey.io/commands/lpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -904,7 +904,7 @@ class BaseTransaction:
     def lpop_count(self: TTransaction, key: TEncodable, count: int) -> TTransaction:
         """
         Remove and return up to `count` elements from the list stored at `key`, depending on the list's length.
-        See https://redis.io/commands/lpop/ for details.
+        See https://valkey.io/commands/lpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1003,7 +1003,7 @@ class BaseTransaction:
         The offsets `start` and `end` are zero-based indexes, with 0 being the first element of the list, 1 being the next
         element and so on. These offsets can also be negative numbers indicating offsets starting at the end of the list,
         with -1 being the last element of the list, -2 being the penultimate, and so on.
-        See https://redis.io/commands/lrange/ for details.
+        See https://valkey.io/commands/lrange/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1030,7 +1030,7 @@ class BaseTransaction:
         Negative indices can be used to designate elements starting at the tail of the list.
         Here, -1 means the last element, -2 means the penultimate and so forth.
 
-        See https://redis.io/commands/lindex/ for more details.
+        See https://valkey.io/commands/lindex/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1074,7 +1074,7 @@ class BaseTransaction:
         Inserts all the specified values at the tail of the list stored at `key`.
         `elements` are inserted one after the other to the tail of the list, from the leftmost element
         to the rightmost element. If `key` does not exist, it is created as empty list before performing the push operations.
-        See https://redis.io/commands/rpush/ for more details.
+        See https://valkey.io/commands/rpush/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1093,7 +1093,7 @@ class BaseTransaction:
         Inserts all the specified values at the tail of the list stored at `key`, only if `key` exists and holds a list.
         If `key` is not a list, this performs no operation.
 
-        See https://redis.io/commands/rpushx/ for more details.
+        See https://valkey.io/commands/rpushx/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1110,7 +1110,7 @@ class BaseTransaction:
         """
         Removes and returns the last elements of the list stored at `key`.
         The command pops a single element from the end of the list.
-        See https://redis.io/commands/rpop/ for details.
+        See https://valkey.io/commands/rpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1124,7 +1124,7 @@ class BaseTransaction:
     def rpop_count(self: TTransaction, key: TEncodable, count: int) -> TTransaction:
         """
         Removes and returns up to `count` elements from the list stored at `key`, depending on the list's length.
-        See https://redis.io/commands/rpop/ for details.
+        See https://valkey.io/commands/rpop/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1254,7 +1254,7 @@ class BaseTransaction:
         Add specified members to the set stored at `key`.
         Specified members that are already a member of this set are ignored.
         If `key` does not exist, a new set is created before adding `members`.
-        See https://redis.io/commands/sadd/ for more details.
+        See https://valkey.io/commands/sadd/ for more details.
 
         Args:
             key (TEncodable): The key where members will be added to its set.
@@ -1271,7 +1271,7 @@ class BaseTransaction:
         """
         Remove specified members from the set stored at `key`.
         Specified members that are not a member of this set are ignored.
-        See https://redis.io/commands/srem/ for details.
+        See https://valkey.io/commands/srem/ for details.
 
         Args:
             key (TEncodable): The key from which members will be removed.
@@ -1286,7 +1286,7 @@ class BaseTransaction:
     def smembers(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Retrieve all the members of the set value stored at `key`.
-        See https://redis.io/commands/smembers/ for details.
+        See https://valkey.io/commands/smembers/ for details.
 
         Args:
             key (TEncodable): The key from which to retrieve the set members.
@@ -1300,7 +1300,7 @@ class BaseTransaction:
     def scard(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Retrieve the set cardinality (number of elements) of the set stored at `key`.
-        See https://redis.io/commands/scard/ for details.
+        See https://valkey.io/commands/scard/ for details.
 
         Args:
             key (TEncodable): The key from which to retrieve the number of set members.
@@ -1351,7 +1351,7 @@ class BaseTransaction:
         """
         Returns if `member` is a member of the set stored at `key`.
 
-        See https://redis.io/commands/sismember/ for more details.
+        See https://valkey.io/commands/sismember/ for more details.
 
         Args:
             key (TEncodable): The key of the set.
@@ -1537,7 +1537,7 @@ class BaseTransaction:
         element and so on.
         These offsets can also be negative numbers indicating offsets starting at the end of the list, with -1 being the last
         element of the list, -2 being the penultimate, and so on.
-        See https://redis.io/commands/ltrim/ for more details.
+        See https://valkey.io/commands/ltrim/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1565,7 +1565,7 @@ class BaseTransaction:
         If `count` is negative, it removes elements equal to `element` moving from tail to head.
         If `count` is 0 or greater than the occurrences of elements equal to `element`, it removes all elements
         equal to `element`.
-        See https://redis.io/commands/lrem/ for more details.
+        See https://valkey.io/commands/lrem/ for more details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1581,7 +1581,7 @@ class BaseTransaction:
     def llen(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Get the length of the list stored at `key`.
-        See https://redis.io/commands/llen/ for details.
+        See https://valkey.io/commands/llen/ for details.
 
         Args:
             key (TEncodable): The key of the list.
@@ -1595,7 +1595,7 @@ class BaseTransaction:
     def exists(self: TTransaction, keys: List[TEncodable]) -> TTransaction:
         """
         Returns the number of keys in `keys` that exist in the database.
-        See https://redis.io/commands/exists/ for more details.
+        See https://valkey.io/commands/exists/ for more details.
 
         Args:
             keys (List[TEncodable]): The list of keys to check.
@@ -1611,8 +1611,8 @@ class BaseTransaction:
         Unlink (delete) multiple keys from the database.
         A key is ignored if it does not exist.
         This command, similar to DEL, removes specified keys and ignores non-existent ones.
-        However, this command does not block the server, while [DEL](https://redis.io/commands/del) does.
-        See https://redis.io/commands/unlink/ for more details.
+        However, this command does not block the server, while [DEL](https://valkey.io/commands/del) does.
+        See https://valkey.io/commands/unlink/ for more details.
 
         Args:
             keys (List[TEncodable]): The list of keys to unlink.
@@ -1633,7 +1633,7 @@ class BaseTransaction:
         If `key` already has an existing expire set, the time to live is updated to the new value.
         If `seconds` is a non-positive number, the key will be deleted rather than expired.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/expire/ for more details.
+        See https://valkey.io/commands/expire/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -1662,7 +1662,7 @@ class BaseTransaction:
         deleted.
         If `key` already has an existing expire set, the time to live is updated to the new value.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/expireat/ for more details.
+        See https://valkey.io/commands/expireat/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -1691,7 +1691,7 @@ class BaseTransaction:
         If `key` already has an existing expire set, the time to live is updated to the new value.
         If `milliseconds` is a non-positive number, the key will be deleted rather than expired.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/pexpire/ for more details.
+        See https://valkey.io/commands/pexpire/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -1722,7 +1722,7 @@ class BaseTransaction:
         deleted.
         If `key` already has an existing expire set, the time to live is updated to the new value.
         The timeout will only be cleared by commands that delete or overwrite the contents of `key`.
-        See https://redis.io/commands/pexpireat/ for more details.
+        See https://valkey.io/commands/pexpireat/ for more details.
 
         Args:
             key (TEncodable): The key to set a timeout on.
@@ -1778,7 +1778,7 @@ class BaseTransaction:
     def ttl(self: TTransaction, key: TEncodable) -> TTransaction:
         """
         Returns the remaining time to live of `key` that has a timeout.
-        See https://redis.io/commands/ttl/ for more details.
+        See https://valkey.io/commands/ttl/ for more details.
 
         Args:
             key (TEncodable): The key to return its timeout.
@@ -1794,7 +1794,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Returns the remaining time to live of `key` that has a timeout, in milliseconds.
-        See https://redis.io/commands/pttl for more details.
+        See https://valkey.io/commands/pttl for more details.
 
         Args:
             key (TEncodable): The key to return its timeout.
@@ -1812,7 +1812,7 @@ class BaseTransaction:
         Remove the existing timeout on `key`, turning the key from volatile (a key with an expire set) to
         persistent (a key that will never expire as no timeout is associated).
 
-        See https://redis.io/commands/persist/ for more details.
+        See https://valkey.io/commands/persist/ for more details.
 
         Args:
             key (TEncodable): The key to remove the existing timeout on.
@@ -1826,7 +1826,7 @@ class BaseTransaction:
         """
         Echoes the provided `message` back.
 
-        See https://redis.io/commands/echo for more details.
+        See https://valkey.io/commands/echo for more details.
 
         Args:
             message (TEncodable): The message to be echoed back.
@@ -1851,7 +1851,7 @@ class BaseTransaction:
         """
          Returns the string representation of the type of the value stored at `key`.
 
-         See https://redis.io/commands/type/ for more details.
+         See https://valkey.io/commands/type/ for more details.
 
         Args:
             key (TEncodable): The key to check its data type.
@@ -1933,7 +1933,7 @@ class BaseTransaction:
     ) -> TTransaction:
         """
         Invokes a previously loaded function.
-        See https://redis.io/commands/fcall/ for more details.
+        See https://valkey.io/commands/fcall/ for more details.
         Args:
             function (TEncodable): The function name.
             keys (Optional[List[TEncodable]]): A list of keys accessed by the function. To ensure the correct
@@ -2735,7 +2735,7 @@ class BaseTransaction:
         Adds members with their scores to the sorted set stored at `key`.
         If a member is already a part of the sorted set, its score is updated.
 
-        See https://redis.io/commands/zadd/ for more details.
+        See https://valkey.io/commands/zadd/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -2789,7 +2789,7 @@ class BaseTransaction:
         If `member` does not exist in the sorted set, it is added with `increment` as its score (as if its previous score was 0.0).
         If `key` does not exist, a new sorted set with the specified member as its sole member is created.
 
-        See https://redis.io/commands/zadd/ for more details.
+        See https://valkey.io/commands/zadd/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -2829,7 +2829,7 @@ class BaseTransaction:
         """
         Returns the cardinality (number of elements) of the sorted set stored at `key`.
 
-        See https://redis.io/commands/zcard/ for more details.
+        See https://valkey.io/commands/zcard/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -2849,7 +2849,7 @@ class BaseTransaction:
         """
         Returns the number of members in the sorted set stored at `key` with scores between `min_score` and `max_score`.
 
-        See https://redis.io/commands/zcount/ for more details.
+        See https://valkey.io/commands/zcount/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -2908,7 +2908,7 @@ class BaseTransaction:
         If `count` is provided, up to `count` members with the highest scores are removed and returned.
         Otherwise, only one member with the highest score is removed and returned.
 
-        See https://redis.io/commands/zpopmax for more details.
+        See https://valkey.io/commands/zpopmax for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -2956,7 +2956,7 @@ class BaseTransaction:
         If `count` is provided, up to `count` members with the lowest scores are removed and returned.
         Otherwise, only one member with the lowest score is removed and returned.
 
-        See https://redis.io/commands/zpopmin for more details.
+        See https://valkey.io/commands/zpopmin for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3007,7 +3007,7 @@ class BaseTransaction:
 
         ZRANGE can perform different types of range queries: by index (rank), by the score, or by lexicographical order.
 
-        See https://redis.io/commands/zrange/ for more details.
+        See https://valkey.io/commands/zrange/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3035,7 +3035,7 @@ class BaseTransaction:
         Returns the specified range of elements with their scores in the sorted set stored at `key`.
         Similar to ZRANGE but with a WITHSCORE flag.
 
-        See https://redis.io/commands/zrange/ for more details.
+        See https://valkey.io/commands/zrange/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3092,7 +3092,7 @@ class BaseTransaction:
         """
         Returns the rank of `member` in the sorted set stored at `key`, with scores ordered from low to high.
 
-        See https://redis.io/commands/zrank for more details.
+        See https://valkey.io/commands/zrank for more details.
 
         To get the rank of `member` with its score, see `zrank_withscore`.
 
@@ -3114,7 +3114,7 @@ class BaseTransaction:
         """
         Returns the rank of `member` in the sorted set stored at `key` with its score, where scores are ordered from the lowest to highest.
 
-        See https://redis.io/commands/zrank for more details.
+        See https://valkey.io/commands/zrank for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3180,7 +3180,7 @@ class BaseTransaction:
         Removes the specified members from the sorted set stored at `key`.
         Specified members that are not a member of this set are ignored.
 
-        See https://redis.io/commands/zrem/ for more details.
+        See https://valkey.io/commands/zrem/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3201,7 +3201,7 @@ class BaseTransaction:
         """
         Removes all elements in the sorted set stored at `key` with a score between `min_score` and `max_score`.
 
-        See https://redis.io/commands/zremrangebyscore/ for more details.
+        See https://valkey.io/commands/zremrangebyscore/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3241,7 +3241,7 @@ class BaseTransaction:
         Removes all elements in the sorted set stored at `key` with a lexicographical order between `min_lex` and
         `max_lex`.
 
-        See https://redis.io/commands/zremrangebylex/ for more details.
+        See https://valkey.io/commands/zremrangebylex/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3305,7 +3305,7 @@ class BaseTransaction:
         """
         Returns the number of members in the sorted set stored at `key` with lexographical values between `min_lex` and `max_lex`.
 
-        See https://redis.io/commands/zlexcount/ for more details.
+        See https://valkey.io/commands/zlexcount/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3336,7 +3336,7 @@ class BaseTransaction:
         """
         Returns the score of `member` in the sorted set stored at `key`.
 
-        See https://redis.io/commands/zscore/ for more details.
+        See https://valkey.io/commands/zscore/ for more details.
 
         Args:
             key (TEncodable): The key of the sorted set.
@@ -3732,7 +3732,7 @@ class BaseTransaction:
     def dbsize(self: TTransaction) -> TTransaction:
         """
         Returns the number of keys in the currently selected database.
-        See https://redis.io/commands/dbsize for more details.
+        See https://valkey.io/commands/dbsize for more details.
 
         Commands response:
             int: The number of keys in the database.
@@ -3747,7 +3747,7 @@ class BaseTransaction:
         Creates a new structure if the `key` does not exist.
         When no elements are provided, and `key` exists and is a HyperLogLog, then no operation is performed.
 
-        See https://redis.io/commands/pfadd/ for more details.
+        See https://valkey.io/commands/pfadd/ for more details.
 
         Args:
             key (TEncodable): The key of the HyperLogLog data structure to add elements into.
@@ -4520,7 +4520,7 @@ class Transaction(BaseTransaction):
     def select(self, index: int) -> "Transaction":
         """
         Change the currently selected Redis database.
-        See https://redis.io/commands/select/ for details.
+        See https://valkey.io/commands/select/ for details.
 
         Args:
             index (int): The index of the database to select.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
