### PR TITLE
Java: Address pubsub PR comments

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -298,8 +298,6 @@ public abstract class BaseClient
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
 
-    public static final GlideString TOK = GlideString.of(OK);
-
     protected final CommandManager commandManager;
     protected final ConnectionManager connectionManager;
     protected final ConcurrentLinkedDeque<PubSubMessage> messageQueue;
@@ -432,12 +430,12 @@ public abstract class BaseClient
 
     protected static MessageHandler buildMessageHandler(BaseClientConfiguration config) {
         if (config.getSubscriptionConfiguration() == null) {
-            return new MessageHandler(Optional.empty(), Optional.empty(), responseResolver);
+            return new MessageHandler(Optional.empty(), Optional.empty(), binaryResponseResolver);
         }
         return new MessageHandler(
                 config.getSubscriptionConfiguration().getCallback(),
                 config.getSubscriptionConfiguration().getContext(),
-                responseResolver);
+                binaryResponseResolver);
     }
 
     protected static ChannelHandler buildChannelHandler(
@@ -3806,7 +3804,7 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<GlideString> publish(
+    public CompletableFuture<String> publish(
             @NonNull GlideString message, @NonNull GlideString channel) {
         return commandManager.submitNewCommand(
                 Publish,
@@ -3814,7 +3812,7 @@ public abstract class BaseClient
                 response -> {
                     // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
                     handleLongResponse(response);
-                    return TOK;
+                    return OK;
                 });
     }
 

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -297,6 +297,7 @@ public abstract class BaseClient
 
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
+    public static final GlideString TOK = GlideString.of(OK);
 
     protected final CommandManager commandManager;
     protected final ConnectionManager connectionManager;
@@ -3801,6 +3802,18 @@ public abstract class BaseClient
                     handleLongResponse(response);
                     return OK;
                 });
+    }
+
+    @Override
+    public CompletableFuture<GlideString> publish(@NonNull GlideString message, @NonNull GlideString channel) {
+        return commandManager.submitNewCommand(
+            Publish,
+            new GlideString[] {channel, message},
+            response -> {
+                // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
+                handleLongResponse(response);
+                return TOK;
+            });
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -297,6 +297,7 @@ public abstract class BaseClient
 
     /** Redis simple string response with "OK" */
     public static final String OK = ConstantResponse.OK.toString();
+
     public static final GlideString TOK = GlideString.of(OK);
 
     protected final CommandManager commandManager;
@@ -3805,15 +3806,16 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<GlideString> publish(@NonNull GlideString message, @NonNull GlideString channel) {
+    public CompletableFuture<GlideString> publish(
+            @NonNull GlideString message, @NonNull GlideString channel) {
         return commandManager.submitNewCommand(
-            Publish,
-            new GlideString[] {channel, message},
-            response -> {
-                // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
-                handleLongResponse(response);
-                return TOK;
-            });
+                Publish,
+                new GlideString[] {channel, message},
+                response -> {
+                    // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
+                    handleLongResponse(response);
+                    return TOK;
+                });
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -3792,7 +3792,7 @@ public abstract class BaseClient
     }
 
     @Override
-    public CompletableFuture<String> publish(@NonNull String channel, @NonNull String message) {
+    public CompletableFuture<String> publish(@NonNull String message, @NonNull String channel) {
         return commandManager.submitNewCommand(
                 Publish,
                 new String[] {channel, message},

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1,7 +1,6 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api;
 
-import static glide.api.BaseClient.OK;
 import static glide.api.commands.ServerManagementCommands.VERSION_REDIS_API;
 import static glide.api.models.GlideString.gs;
 import static glide.api.models.commands.SortBaseOptions.STORE_COMMAND_STRING;

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1006,19 +1006,19 @@ public class RedisClusterClient extends BaseClient
 
     @Override
     public CompletableFuture<GlideString> publish(
-        @NonNull GlideString message, @NonNull GlideString channel, boolean sharded) {
+            @NonNull GlideString message, @NonNull GlideString channel, boolean sharded) {
         if (!sharded) {
             return publish(message, channel);
         }
 
         return commandManager.submitNewCommand(
-            SPublish,
-            new GlideString[] {channel, message},
-            response -> {
-                // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
-                handleLongResponse(response);
-                return TOK;
-            });
+                SPublish,
+                new GlideString[] {channel, message},
+                response -> {
+                    // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
+                    handleLongResponse(response);
+                    return TOK;
+                });
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1005,7 +1005,7 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
-    public CompletableFuture<GlideString> publish(
+    public CompletableFuture<String> publish(
             @NonNull GlideString message, @NonNull GlideString channel, boolean sharded) {
         if (!sharded) {
             return publish(message, channel);
@@ -1017,7 +1017,7 @@ public class RedisClusterClient extends BaseClient
                 response -> {
                     // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
                     handleLongResponse(response);
-                    return TOK;
+                    return OK;
                 });
     }
 

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -987,19 +987,22 @@ public class RedisClusterClient extends BaseClient
                 new GlideString[0],
                 route,
                 response -> handleFunctionStatsBinaryResponse(response, route instanceof SingleNodeRoute));
-    public CompletableFuture<String> publish(@NonNull String channel, @NonNull String message, boolean sharded) {
+    }
+
+    public CompletableFuture<String> publish(
+            @NonNull String message, @NonNull String channel, boolean sharded) {
         if (!sharded) {
-            return publish(channel, message);
+            return publish(message, channel);
         }
 
         return commandManager.submitNewCommand(
-            SPublish,
-            new String[] {channel, message},
-            response -> {
-                // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
-                handleLongResponse(response);
-                return OK;
-            });
+                SPublish,
+                new String[] {channel, message},
+                response -> {
+                    // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
+                    handleLongResponse(response);
+                    return OK;
+                });
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1005,6 +1005,23 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
+    public CompletableFuture<GlideString> publish(
+        @NonNull GlideString message, @NonNull GlideString channel, boolean sharded) {
+        if (!sharded) {
+            return publish(message, channel);
+        }
+
+        return commandManager.submitNewCommand(
+            SPublish,
+            new GlideString[] {channel, message},
+            response -> {
+                // Check, but ignore the number - it is never valid. A GLIDE bug/limitation TODO
+                handleLongResponse(response);
+                return TOK;
+            });
+    }
+
+    @Override
     public CompletableFuture<String> unwatch(@NonNull Route route) {
         return commandManager.submitNewCommand(
                 UnWatch, new String[0], route, this::handleStringResponse);

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -1185,8 +1185,8 @@ public class RedisClusterClient extends BaseClient
                     Logger.log(
                             Logger.Level.ERROR,
                             "ClusterScanCursor",
-                            () -> "Error releasing cursor " + cursorHandle + ": " + ex.getMessage());
-                    Logger.log(Logger.Level.ERROR, "ClusterScanCursor", ex);
+                            () -> "Error releasing cursor " + cursorHandle,
+                            ex);
                 } finally {
                     // Mark the cursor as closed to avoid double-free (if close() gets called more than once).
                     isClosed = true;

--- a/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
@@ -14,14 +14,14 @@ public interface PubSubBaseCommands {
      * Publishes message on pubsub channel.
      *
      * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
-     * @param channel The channel to publish the message on.
      * @param message The message to publish.
+     * @param channel The channel to publish the message on.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String response = client.publish("announcements", "The cat said 'meow'!").get();
+     * String response = client.publish("The cat said 'meow'!", "announcements").get();
      * assert response.equals("OK");
      * }</pre>
      */
-    CompletableFuture<String> publish(String channel, String message);
+    CompletableFuture<String> publish(String message, String channel);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
@@ -3,6 +3,8 @@ package glide.api.commands;
 
 import java.util.concurrent.CompletableFuture;
 
+import glide.api.models.GlideString;
+
 /**
  * Supports commands for the "Pub/Sub" group for standalone and cluster clients.
  *
@@ -24,4 +26,19 @@ public interface PubSubBaseCommands {
      * }</pre>
      */
     CompletableFuture<String> publish(String message, String channel);
+
+    /**
+     * Publishes message on pubsub channel.
+     *
+     * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
+     * @param message The message to publish.
+     * @param channel The channel to publish the message on.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * String response = client.publish("The cat said 'meow'!", "announcements").get();
+     * assert response.equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<GlideString> publish(GlideString message, GlideString channel);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
@@ -1,9 +1,8 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.commands;
 
-import java.util.concurrent.CompletableFuture;
-
 import glide.api.models.GlideString;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Supports commands for the "Pub/Sub" group for standalone and cluster clients.

--- a/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubBaseCommands.java
@@ -35,9 +35,9 @@ public interface PubSubBaseCommands {
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String response = client.publish("The cat said 'meow'!", "announcements").get();
+     * String response = client.publish(gs("The cat said 'meow'!"), gs("announcements")).get();
      * assert response.equals("OK");
      * }</pre>
      */
-    CompletableFuture<GlideString> publish(GlideString message, GlideString channel);
+    CompletableFuture<String> publish(GlideString message, GlideString channel);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -14,16 +14,16 @@ public interface PubSubClusterCommands extends PubSubBaseCommands {
      * Publishes message on pubsub channel.
      *
      * @since Redis 7.0 and above.
-     * @see <a href="https://valkey.io/commands/spublish/">valkey.io</a> for details.
-     * @param channel The channel to publish the message on.
+     * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
      * @param message The message to publish.
+     * @param channel The channel to publish the message on.
      * @param sharded Indicates that this should be run in sharded mode.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String response = client.publish("announcements", "The cat said 'meow'!", true).get();
+     * String response = client.publish("The cat said 'meow'!", "announcements", true).get();
      * assert response.equals("OK");
      * }</pre>
      */
-    CompletableFuture<String> publish(String channel, String message, boolean sharded);
+    CompletableFuture<String> publish(String message, String channel, boolean sharded);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @see <a href="https://valkey.io/commands/publish/">Pub/Sub Commands</a>
  */
-public interface PubSubClusterCommands extends PubSubBaseCommands {
+public interface PubSubClusterCommands {
 
     /**
      * Publishes message on pubsub channel.
@@ -17,7 +17,8 @@ public interface PubSubClusterCommands extends PubSubBaseCommands {
      * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
      * @param message The message to publish.
      * @param channel The channel to publish the message on.
-     * @param sharded Indicates that this should be run in sharded mode.
+     * @param sharded Indicates that this should be run in sharded mode. Setting <code>sharded</code>
+     *     to <code>true</code> is only applicable with Redis 7.0+.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -41,9 +41,9 @@ public interface PubSubClusterCommands {
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String response = client.publish("The cat said 'meow'!", "announcements", true).get();
+     * String response = client.publish(gs("The cat said 'meow'!"), gs("announcements"), true).get();
      * assert response.equals("OK");
      * }</pre>
      */
-    CompletableFuture<GlideString> publish(GlideString message, GlideString channel, boolean sharded);
+    CompletableFuture<String> publish(GlideString message, GlideString channel, boolean sharded);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -3,6 +3,8 @@ package glide.api.commands;
 
 import java.util.concurrent.CompletableFuture;
 
+import glide.api.models.GlideString;
+
 /**
  * Supports commands for the "Pub/Sub" group for a cluster client.
  *
@@ -27,4 +29,22 @@ public interface PubSubClusterCommands {
      * }</pre>
      */
     CompletableFuture<String> publish(String message, String channel, boolean sharded);
+
+    /**
+     * Publishes message on pubsub channel.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
+     * @param message The message to publish.
+     * @param channel The channel to publish the message on.
+     * @param sharded Indicates that this should be run in sharded mode. Setting <code>sharded</code>
+     *     to <code>true</code> is only applicable with Redis 7.0+.
+     * @return <code>OK</code>.
+     * @example
+     *     <pre>{@code
+     * String response = client.publish("The cat said 'meow'!", "announcements", true).get();
+     * assert response.equals("OK");
+     * }</pre>
+     */
+    CompletableFuture<GlideString> publish(GlideString message, GlideString channel, boolean sharded);
 }

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -1,9 +1,8 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.api.commands;
 
-import java.util.concurrent.CompletableFuture;
-
 import glide.api.models.GlideString;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Supports commands for the "Pub/Sub" group for a cluster client.

--- a/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/PubSubClusterCommands.java
@@ -8,21 +8,22 @@ import java.util.concurrent.CompletableFuture;
  *
  * @see <a href="https://valkey.io/commands/publish/">Pub/Sub Commands</a>
  */
-public interface PubSubClusterCommands {
+public interface PubSubClusterCommands extends PubSubBaseCommands {
 
     /**
-     * Publishes message on pubsub channel in sharded mode.
+     * Publishes message on pubsub channel.
      *
      * @since Redis 7.0 and above.
      * @see <a href="https://valkey.io/commands/spublish/">valkey.io</a> for details.
      * @param channel The channel to publish the message on.
      * @param message The message to publish.
+     * @param sharded Indicates that this should be run in sharded mode.
      * @return <code>OK</code>.
      * @example
      *     <pre>{@code
-     * String response = client.spublish("announcements", "The cat said 'meow'!").get();
+     * String response = client.publish("announcements", "The cat said 'meow'!", true).get();
      * assert response.equals("OK");
      * }</pre>
      */
-    CompletableFuture<String> spublish(String channel, String message);
+    CompletableFuture<String> publish(String channel, String message, boolean sharded);
 }

--- a/java/client/src/main/java/glide/api/logging/Logger.java
+++ b/java/client/src/main/java/glide/api/logging/Logger.java
@@ -4,9 +4,9 @@ package glide.api.logging;
 import static glide.ffi.resolvers.LoggerResolver.initInternal;
 import static glide.ffi.resolvers.LoggerResolver.logInternal;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.function.Supplier;
 import lombok.Getter;
 import lombok.NonNull;
@@ -178,24 +178,44 @@ public final class Logger {
      *
      * @param level The log level of the provided message.
      * @param logIdentifier The log identifier should give the log a context.
+     * @param message The message to log with the exception.
      * @param throwable The exception or error to log.
      */
     public static void log(
-            @NonNull Level level, @NonNull String logIdentifier, @NonNull Throwable throwable) {
+            @NonNull Level level,
+            @NonNull String logIdentifier,
+            @NonNull String message,
+            @NonNull Throwable throwable) {
         // TODO: Add the corresponding API to Python and Node.js.
-        log(
-                level,
-                logIdentifier,
-                () -> {
-                    try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                            PrintStream printStream = new PrintStream(outputStream)) {
-                        throwable.printStackTrace(printStream);
-                        return printStream.toString();
-                    } catch (IOException e) {
-                        // This can't happen with a ByteArrayOutputStream.
-                        return null;
-                    }
-                });
+        log(level, logIdentifier, () -> message + ": " + prettyPrintException(throwable));
+    }
+
+    /**
+     * Logs the provided exception or error if the provided log level is lower than the logger level.
+     *
+     * @param level The log level of the provided message.
+     * @param logIdentifier The log identifier should give the log a context.
+     * @param message The message to log with the exception.
+     * @param throwable The exception or error to log.
+     */
+    public static void log(
+            @NonNull Level level,
+            @NonNull String logIdentifier,
+            @NonNull Supplier<String> message,
+            @NonNull Throwable throwable) {
+        // TODO: Add the corresponding API to Python and Node.js.
+        log(level, logIdentifier, () -> message.get() + ": " + prettyPrintException(throwable));
+    }
+
+    private static String prettyPrintException(@NonNull Throwable throwable) {
+        try (StringWriter stringWriter = new StringWriter();
+                PrintWriter printWriter = new PrintWriter(stringWriter)) {
+            throwable.printStackTrace(printWriter);
+            return stringWriter.toString();
+        } catch (IOException e) {
+            // This can't happen with a ByteArrayOutputStream.
+            return null;
+        }
     }
 
     /**

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -5824,11 +5824,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @implNote ArgType is limited to String or GlideString, any other type will throw
      *     IllegalArgumentException
      * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
-     * @param channel The channel to publish the message on.
      * @param message The message to publish.
+     * @param channel The channel to publish the message on.
      * @return Command response - The number of clients that received the message.
      */
-    public <ArgType> T publish(@NonNull ArgType channel, @NonNull ArgType message) {
+    public <ArgType> T publish(@NonNull ArgType message, @NonNull ArgType channel) {
         checkTypeOrThrow(channel);
         protobufTransaction.addCommands(
                 buildCommand(Publish, newArgsBuilder().add(channel).add(message)));

--- a/java/client/src/main/java/glide/api/models/ClusterTransaction.java
+++ b/java/client/src/main/java/glide/api/models/ClusterTransaction.java
@@ -40,11 +40,15 @@ public class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * @implNote ArgType is limited to String or GlideString, any other type will throw
      *     IllegalArgumentException
      * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
-     * @param channel The channel to publish the message on.
      * @param message The message to publish.
+     * @param channel The channel to publish the message on.
+     * @param sharded Indicates that this should be run in sharded mode.
      * @return Command response - The number of clients that received the message.
      */
-    public <ArgType> ClusterTransaction spublish(@NonNull ArgType channel, @NonNull ArgType message) {
+    public <ArgType> ClusterTransaction spublish(@NonNull ArgType message, @NonNull ArgType channel, sharded) {
+        if (!sharded) {
+            return super.publish(message, channel);
+        }
         checkTypeOrThrow(channel);
         protobufTransaction.addCommands(
                 buildCommand(SPublish, newArgsBuilder().add(channel).add(message)));

--- a/java/client/src/main/java/glide/api/models/ClusterTransaction.java
+++ b/java/client/src/main/java/glide/api/models/ClusterTransaction.java
@@ -42,10 +42,12 @@ public class ClusterTransaction extends BaseTransaction<ClusterTransaction> {
      * @see <a href="https://valkey.io/commands/publish/">valkey.io</a> for details.
      * @param message The message to publish.
      * @param channel The channel to publish the message on.
-     * @param sharded Indicates that this should be run in sharded mode.
+     * @param sharded Indicates that this should be run in sharded mode. Setting <code>sharded</code>
+     *     to <code>true</code> is only applicable with Redis 7.0+.
      * @return Command response - The number of clients that received the message.
      */
-    public <ArgType> ClusterTransaction spublish(@NonNull ArgType message, @NonNull ArgType channel, sharded) {
+    public <ArgType> ClusterTransaction publish(
+            @NonNull ArgType message, @NonNull ArgType channel, boolean sharded) {
         if (!sharded) {
             return super.publish(message, channel);
         }

--- a/java/client/src/main/java/glide/api/models/GlideString.java
+++ b/java/client/src/main/java/glide/api/models/GlideString.java
@@ -64,8 +64,10 @@ public class GlideString implements Comparable<GlideString> {
             return string;
         }
 
-        assert canConvertToString() : "Value cannot be represented as a string";
-        return string;
+        if (canConvertToString()) {
+            return string;
+        }
+        return String.format("Value not convertible to string: byte[] %d", Arrays.hashCode(bytes));
     }
 
     public int compareTo(GlideString o) {

--- a/java/client/src/main/java/glide/api/models/PubSubMessage.java
+++ b/java/client/src/main/java/glide/api/models/PubSubMessage.java
@@ -10,21 +10,21 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class PubSubMessage {
     /** An incoming message received. */
-    private final String message;
+    private final GlideString message;
 
     /** A name of the originating channel. */
-    private final String channel;
+    private final GlideString channel;
 
     /** A pattern matched to the channel name. */
-    private final Optional<String> pattern;
+    private final Optional<GlideString> pattern;
 
-    public PubSubMessage(String message, String channel, String pattern) {
+    public PubSubMessage(GlideString message, GlideString channel, GlideString pattern) {
         this.message = message;
         this.channel = channel;
         this.pattern = Optional.ofNullable(pattern);
     }
 
-    public PubSubMessage(String message, String channel) {
+    public PubSubMessage(GlideString message, GlideString channel) {
         this.message = message;
         this.channel = channel;
         this.pattern = Optional.empty();

--- a/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
@@ -7,13 +7,12 @@ import glide.api.models.configuration.ClusterSubscriptionConfiguration.ClusterSu
 import glide.api.models.configuration.ClusterSubscriptionConfiguration.PubSubClusterChannelMode;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.PubSubChannelMode;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.StandaloneSubscriptionConfigurationBuilder;
+import glide.api.models.exceptions.ConfigurationError;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-
-import glide.api.models.exceptions.ConfigurationError;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -90,7 +89,8 @@ public abstract class BaseSubscriptionConfiguration {
          */
         public B callback(MessageCallback callback, Object context) {
             if (context != null && callback == null) {
-                throw new ConfigurationError("PubSub subscriptions with a context require a callback function to be configured.");
+                throw new ConfigurationError(
+                        "PubSub subscriptions with a context require a callback function to be configured.");
             }
             this.callback = Optional.ofNullable(callback);
             this.context = Optional.ofNullable(context);
@@ -105,7 +105,8 @@ public abstract class BaseSubscriptionConfiguration {
          */
         public B callback(MessageCallback callback) {
             if (callback == null && this.context.isPresent()) {
-                throw new ConfigurationError("PubSub subscriptions with a context require a callback function to be configured.");
+                throw new ConfigurationError(
+                        "PubSub subscriptions with a context require a callback function to be configured.");
             }
             this.callback = Optional.ofNullable(callback);
             return self();

--- a/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
@@ -2,6 +2,7 @@
 package glide.api.models.configuration;
 
 import glide.api.BaseClient;
+import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
 import glide.api.models.configuration.ClusterSubscriptionConfiguration.ClusterSubscriptionConfigurationBuilder;
 import glide.api.models.configuration.ClusterSubscriptionConfiguration.PubSubClusterChannelMode;
@@ -9,6 +10,7 @@ import glide.api.models.configuration.StandaloneSubscriptionConfiguration.PubSub
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.StandaloneSubscriptionConfigurationBuilder;
 import glide.api.models.exceptions.ConfigurationError;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -70,9 +72,10 @@ public abstract class BaseSubscriptionConfiguration {
         protected Optional<Object> context = Optional.empty();
 
         protected <M extends ChannelMode> void addSubscription(
-                Map<M, Set<String>> subscriptions, M mode, String channelOrPattern) {
+            Map<M, Set<GlideString>> subscriptions, M mode, GlideString channelOrPattern) {
             if (!subscriptions.containsKey(mode)) {
-                subscriptions.put(mode, new HashSet<>());
+                // Note: Use a LinkedHashSet to preserve order for ease of debugging and unit testing.
+                subscriptions.put(mode, new LinkedHashSet<>());
             }
             subscriptions.get(mode).add(channelOrPattern);
         }

--- a/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
@@ -86,7 +86,7 @@ public abstract class BaseSubscriptionConfiguration {
         /**
          * Set a callback and a context.
          *
-         * @param callback The {@link #callback}.
+         * @param callback The {@link #callback}. This can be null to unset the callback.
          * @param context The {@link #context}.
          */
         public B callback(MessageCallback callback, Object context) {
@@ -103,7 +103,7 @@ public abstract class BaseSubscriptionConfiguration {
          * Set a callback without context. <code>null</code> will be supplied to all callback calls as a
          * context.
          *
-         * @param callback The {@link #callback}.
+         * @param callback The {@link #callback}. This can be null to unset the callback.
          */
         public B callback(MessageCallback callback) {
             if (callback == null && this.context.isPresent()) {

--- a/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
+
+import glide.api.models.exceptions.ConfigurationError;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -87,6 +89,9 @@ public abstract class BaseSubscriptionConfiguration {
          * @param context The {@link #context}.
          */
         public B callback(MessageCallback callback, Object context) {
+            if (context != null && callback == null) {
+                throw new ConfigurationError("PubSub subscriptions with a context require a callback function to be configured.");
+            }
             this.callback = Optional.ofNullable(callback);
             this.context = Optional.ofNullable(context);
             return self();
@@ -99,6 +104,9 @@ public abstract class BaseSubscriptionConfiguration {
          * @param callback The {@link #callback}.
          */
         public B callback(MessageCallback callback) {
+            if (callback == null && this.context.isPresent()) {
+                throw new ConfigurationError("PubSub subscriptions with a context require a callback function to be configured.");
+            }
             this.callback = Optional.ofNullable(callback);
             return self();
         }

--- a/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/BaseSubscriptionConfiguration.java
@@ -9,7 +9,6 @@ import glide.api.models.configuration.ClusterSubscriptionConfiguration.PubSubClu
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.PubSubChannelMode;
 import glide.api.models.configuration.StandaloneSubscriptionConfiguration.StandaloneSubscriptionConfigurationBuilder;
 import glide.api.models.exceptions.ConfigurationError;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -72,7 +71,7 @@ public abstract class BaseSubscriptionConfiguration {
         protected Optional<Object> context = Optional.empty();
 
         protected <M extends ChannelMode> void addSubscription(
-            Map<M, Set<GlideString>> subscriptions, M mode, GlideString channelOrPattern) {
+                Map<M, Set<GlideString>> subscriptions, M mode, GlideString channelOrPattern) {
             if (!subscriptions.containsKey(mode)) {
                 // Note: Use a LinkedHashSet to preserve order for ease of debugging and unit testing.
                 subscriptions.put(mode, new LinkedHashSet<>());

--- a/java/client/src/main/java/glide/api/models/configuration/ClusterSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClusterSubscriptionConfiguration.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import glide.api.models.GlideString;
 import lombok.Getter;
 
 /**
@@ -55,13 +57,13 @@ public final class ClusterSubscriptionConfiguration extends BaseSubscriptionConf
      * Will be applied via <code>SUBSCRIBE</code>/<code>PSUBSCRIBE</code>/<code>SSUBSCRIBE</code>
      * commands during connection establishment.
      */
-    private final Map<PubSubClusterChannelMode, Set<String>> subscriptions;
+    private final Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions;
 
     // All code below is a custom implementation of `SuperBuilder`
     private ClusterSubscriptionConfiguration(
             Optional<MessageCallback> callback,
             Optional<Object> context,
-            Map<PubSubClusterChannelMode, Set<String>> subscriptions) {
+            Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions) {
         super(callback, context);
         this.subscriptions = subscriptions;
     }
@@ -77,7 +79,7 @@ public final class ClusterSubscriptionConfiguration extends BaseSubscriptionConf
 
         private ClusterSubscriptionConfigurationBuilder() {}
 
-        private Map<PubSubClusterChannelMode, Set<String>> subscriptions = new HashMap<>(3);
+        private Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions = new HashMap<>(3);
 
         /**
          * Add a subscription to a channel or to multiple channels if {@link
@@ -85,7 +87,7 @@ public final class ClusterSubscriptionConfiguration extends BaseSubscriptionConf
          * See {@link ClusterSubscriptionConfiguration#subscriptions}.
          */
         public ClusterSubscriptionConfigurationBuilder subscription(
-                PubSubClusterChannelMode mode, String channelOrPattern) {
+                PubSubClusterChannelMode mode, GlideString channelOrPattern) {
             addSubscription(subscriptions, mode, channelOrPattern);
             return this;
         }
@@ -95,7 +97,7 @@ public final class ClusterSubscriptionConfiguration extends BaseSubscriptionConf
          * See {@link ClusterSubscriptionConfiguration#subscriptions}.
          */
         public ClusterSubscriptionConfigurationBuilder subscriptions(
-                Map<PubSubClusterChannelMode, Set<String>> subscriptions) {
+                Map<PubSubClusterChannelMode, Set<GlideString>> subscriptions) {
             this.subscriptions = subscriptions;
             return this;
         }
@@ -106,7 +108,7 @@ public final class ClusterSubscriptionConfiguration extends BaseSubscriptionConf
          * See {@link ClusterSubscriptionConfiguration#subscriptions}.
          */
         public ClusterSubscriptionConfigurationBuilder subscriptions(
-                PubSubClusterChannelMode mode, Set<String> subscriptions) {
+                PubSubClusterChannelMode mode, Set<GlideString> subscriptions) {
             this.subscriptions.put(mode, subscriptions);
             return this;
         }

--- a/java/client/src/main/java/glide/api/models/configuration/ClusterSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/ClusterSubscriptionConfiguration.java
@@ -2,12 +2,11 @@
 package glide.api.models.configuration;
 
 import glide.api.RedisClusterClient;
+import glide.api.models.GlideString;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import glide.api.models.GlideString;
 import lombok.Getter;
 
 /**

--- a/java/client/src/main/java/glide/api/models/configuration/StandaloneSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/StandaloneSubscriptionConfiguration.java
@@ -2,10 +2,12 @@
 package glide.api.models.configuration;
 
 import glide.api.RedisClient;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import glide.api.models.GlideString;
 import lombok.Getter;
 
 /**
@@ -48,13 +50,13 @@ public final class StandaloneSubscriptionConfiguration extends BaseSubscriptionC
      * Will be applied via <code>SUBSCRIBE</code>/<code>PSUBSCRIBE</code> commands during connection
      * establishment.
      */
-    private final Map<PubSubChannelMode, Set<String>> subscriptions;
+    private final Map<PubSubChannelMode, Set<GlideString>> subscriptions;
 
     // All code below is a custom implementation of `SuperBuilder`
     public StandaloneSubscriptionConfiguration(
             Optional<MessageCallback> callback,
             Optional<Object> context,
-            Map<PubSubChannelMode, Set<String>> subscriptions) {
+            Map<PubSubChannelMode, Set<GlideString>> subscriptions) {
         super(callback, context);
         this.subscriptions = subscriptions;
     }
@@ -70,7 +72,8 @@ public final class StandaloneSubscriptionConfiguration extends BaseSubscriptionC
 
         private StandaloneSubscriptionConfigurationBuilder() {}
 
-        private Map<PubSubChannelMode, Set<String>> subscriptions = new HashMap<>(2);
+        // Note: Use a LinkedHashMap to preserve order for ease of debugging and unit testing.
+        private Map<PubSubChannelMode, Set<GlideString>> subscriptions = new LinkedHashMap<>(2);
 
         /**
          * Add a subscription to a channel or to multiple channels if {@link PubSubChannelMode#PATTERN}
@@ -78,7 +81,7 @@ public final class StandaloneSubscriptionConfiguration extends BaseSubscriptionC
          * See {@link StandaloneSubscriptionConfiguration#subscriptions}.
          */
         public StandaloneSubscriptionConfigurationBuilder subscription(
-                PubSubChannelMode mode, String channelOrPattern) {
+                PubSubChannelMode mode, GlideString channelOrPattern) {
             addSubscription(subscriptions, mode, channelOrPattern);
             return self();
         }
@@ -88,7 +91,7 @@ public final class StandaloneSubscriptionConfiguration extends BaseSubscriptionC
          * See {@link StandaloneSubscriptionConfiguration#subscriptions}.
          */
         public StandaloneSubscriptionConfigurationBuilder subscriptions(
-                Map<PubSubChannelMode, Set<String>> subscriptions) {
+                Map<PubSubChannelMode, Set<GlideString>> subscriptions) {
             this.subscriptions = subscriptions;
             return this;
         }
@@ -99,7 +102,7 @@ public final class StandaloneSubscriptionConfiguration extends BaseSubscriptionC
          * See {@link StandaloneSubscriptionConfiguration#subscriptions}.
          */
         public StandaloneSubscriptionConfigurationBuilder subscriptions(
-                PubSubChannelMode mode, Set<String> subscriptions) {
+                PubSubChannelMode mode, Set<GlideString> subscriptions) {
             this.subscriptions.put(mode, subscriptions);
             return this;
         }

--- a/java/client/src/main/java/glide/api/models/configuration/StandaloneSubscriptionConfiguration.java
+++ b/java/client/src/main/java/glide/api/models/configuration/StandaloneSubscriptionConfiguration.java
@@ -2,12 +2,11 @@
 package glide.api.models.configuration;
 
 import glide.api.RedisClient;
+import glide.api.models.GlideString;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import glide.api.models.GlideString;
 import lombok.Getter;
 
 /**

--- a/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
+++ b/java/client/src/main/java/glide/connectors/handlers/CallbackDispatcher.java
@@ -76,7 +76,7 @@ public class CallbackDispatcher {
      *
      * @param response A response received
      */
-    public void completeRequest(Response response) {
+    public void completeRequest(Response response) throws MessageHandler.MessageCallbackException {
         if (response.hasClosingError()) {
             // According to https://github.com/aws/glide-for-redis/issues/851
             // a response with a closing error may arrive with any/random callback ID (usually -1)

--- a/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
@@ -1,9 +1,8 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
-import static glide.api.models.GlideString.gs;
-
 import glide.api.logging.Logger;
+import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
 import glide.api.models.configuration.BaseSubscriptionConfiguration.MessageCallback;
 import glide.api.models.exceptions.RedisException;
@@ -49,8 +48,8 @@ public class MessageHandler {
             throw new RedisException("Received invalid push: empty or in incorrect format.");
         }
         @SuppressWarnings("unchecked")
-        Map<String, Object> push = (Map<String, Object>) data;
-        PushKind pushType = Enum.valueOf(PushKind.class, (String) push.get("kind"));
+        Map<GlideString, Object> push = (Map<GlideString, Object>) data;
+        PushKind pushType = Enum.valueOf(PushKind.class, ((GlideString) push.get("kind")).getString());
         Object[] values = (Object[]) push.get("values");
 
         switch (pushType) {
@@ -63,11 +62,11 @@ public class MessageHandler {
             case PMessage:
                 handle(
                         new PubSubMessage(
-                                gs((String) values[2]), gs((String) values[1]), gs((String) values[0])));
+                                (GlideString) values[2], (GlideString) values[1], (GlideString) values[0]));
                 return;
             case Message:
             case SMessage:
-                handle(new PubSubMessage(gs((String) values[1]), gs((String) values[0])));
+                handle(new PubSubMessage((GlideString) values[1], (GlideString) values[0]));
                 return;
             case Subscribe:
             case PSubscribe:

--- a/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
@@ -4,7 +4,6 @@ package glide.connectors.handlers;
 import static glide.api.models.GlideString.gs;
 
 import glide.api.logging.Logger;
-import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
 import glide.api.models.configuration.BaseSubscriptionConfiguration.MessageCallback;
 import glide.api.models.exceptions.RedisException;
@@ -62,7 +61,9 @@ public class MessageHandler {
                         "Transport disconnected, messages might be lost");
                 break;
             case PMessage:
-                handle(new PubSubMessage(gs((String) values[2]), gs((String) values[1]), gs((String) values[0])));
+                handle(
+                        new PubSubMessage(
+                                gs((String) values[2]), gs((String) values[1]), gs((String) values[0])));
                 return;
             case Message:
             case SMessage:

--- a/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
@@ -1,7 +1,10 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import static glide.api.models.GlideString.gs;
+
 import glide.api.logging.Logger;
+import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
 import glide.api.models.configuration.BaseSubscriptionConfiguration.MessageCallback;
 import glide.api.models.exceptions.RedisException;
@@ -59,11 +62,11 @@ public class MessageHandler {
                         "Transport disconnected, messages might be lost");
                 break;
             case PMessage:
-                handle(new PubSubMessage((String) values[2], (String) values[1], (String) values[0]));
+                handle(new PubSubMessage(gs((String) values[2]), gs((String) values[1]), gs((String) values[0])));
                 return;
             case Message:
             case SMessage:
-                handle(new PubSubMessage((String) values[1], (String) values[0]));
+                handle(new PubSubMessage(gs((String) values[1]), gs((String) values[0])));
                 return;
             case Subscribe:
             case PSubscribe:

--- a/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
@@ -4,7 +4,6 @@ package glide.connectors.handlers;
 import static glide.api.models.GlideString.gs;
 
 import glide.api.logging.Logger;
-import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
 import glide.api.models.configuration.BaseSubscriptionConfiguration.MessageCallback;
 import glide.api.models.exceptions.RedisException;
@@ -50,8 +49,9 @@ public class MessageHandler {
             throw new RedisException("Received invalid push: empty or in incorrect format.");
         }
         @SuppressWarnings("unchecked")
-        Map<GlideString, Object> push = (Map<GlideString, Object>) data;
+        Map<String, Object> push = (Map<String, Object>) data;
         PushKind pushType = Enum.valueOf(PushKind.class, push.get("kind").toString());
+        // The objects in values will actually be byte[].
         Object[] values = (Object[]) push.get("values");
 
         switch (pushType) {

--- a/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/MessageHandler.java
@@ -1,6 +1,8 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.connectors.handlers;
 
+import static glide.api.models.GlideString.gs;
+
 import glide.api.logging.Logger;
 import glide.api.models.GlideString;
 import glide.api.models.PubSubMessage;
@@ -49,7 +51,7 @@ public class MessageHandler {
         }
         @SuppressWarnings("unchecked")
         Map<GlideString, Object> push = (Map<GlideString, Object>) data;
-        PushKind pushType = Enum.valueOf(PushKind.class, ((GlideString) push.get("kind")).getString());
+        PushKind pushType = Enum.valueOf(PushKind.class, push.get("kind").toString());
         Object[] values = (Object[]) push.get("values");
 
         switch (pushType) {
@@ -62,11 +64,11 @@ public class MessageHandler {
             case PMessage:
                 handle(
                         new PubSubMessage(
-                                (GlideString) values[2], (GlideString) values[1], (GlideString) values[0]));
+                                gs((byte[]) values[2]), gs((byte[]) values[1]), gs((byte[]) values[0])));
                 return;
             case Message:
             case SMessage:
-                handle(new PubSubMessage((GlideString) values[1], (GlideString) values[0]));
+                handle(new PubSubMessage(gs((byte[]) values[1]), gs((byte[]) values[0])));
                 return;
             case Subscribe:
             case PSubscribe:

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -33,6 +33,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         Logger.log(ERROR, "read handler", () -> "=== exceptionCaught " + ctx + " " + cause);
+        Logger.log(ERROR, "read handler", cause);
 
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -32,8 +32,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Handles uncaught exceptions from {@link #channelRead(ChannelHandlerContext, Object)}. */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        Logger.log(ERROR, "read handler", () -> "=== exceptionCaught " + ctx + " " + cause);
-        Logger.log(ERROR, "read handler", cause);
+        Logger.log(ERROR, "read handler", () -> "=== exceptionCaught " + ctx, cause);
 
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);

--- a/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
+++ b/java/client/src/main/java/glide/connectors/handlers/ReadHandler.java
@@ -19,7 +19,7 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Submit responses from glide to an instance {@link CallbackDispatcher} to handle them. */
     @Override
     public void channelRead(@NonNull ChannelHandlerContext ctx, @NonNull Object msg)
-            throws RuntimeException {
+            throws MessageHandler.MessageCallbackException {
         if (msg instanceof Response) {
             Response response = (Response) msg;
             callbackDispatcher.completeRequest(response);
@@ -32,8 +32,20 @@ public class ReadHandler extends ChannelInboundHandlerAdapter {
     /** Handles uncaught exceptions from {@link #channelRead(ChannelHandlerContext, Object)}. */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        Logger.log(ERROR, "read handler", () -> "=== exceptionCaught " + ctx, cause);
+        if (cause instanceof MessageHandler.MessageCallbackException) {
+            Logger.log(
+                    ERROR,
+                    "read handler",
+                    () -> "=== Exception thrown from pubsub callback " + ctx,
+                    cause.getCause());
 
+            // Mimic the behavior of if this got thrown by a user thread. Print to stderr,
+            cause.printStackTrace();
+
+            // Unwrap. Only works for Exceptions and not Errors.
+            throw ((MessageHandler.MessageCallbackException) cause).getCause();
+        }
+        Logger.log(ERROR, "read handler", () -> "=== exceptionCaught " + ctx, cause);
         callbackDispatcher.distributeClosingException(
                 "An unhandled error while reading from UDS channel: " + cause);
     }

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -1,6 +1,7 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
+import glide.api.models.GlideString;
 import response.ResponseOuterClass.Response;
 
 public class RedisValueResolver {
@@ -16,7 +17,8 @@ public class RedisValueResolver {
     }
 
     /**
-     * Resolve a value received from Redis using given C-style pointer.
+     * Resolve a value received from Redis using given C-style pointer. String data is assumed to be
+     * UTF-8 and exposed as <code>String</code> objects.
      *
      * @param pointer A memory pointer from {@link Response}
      * @return A RESP3 value
@@ -25,7 +27,7 @@ public class RedisValueResolver {
 
     /**
      * Resolve a value received from Redis using given C-style pointer. This method does not assume
-     * that strings are valid UTF-8 encoded strings
+     * that strings are valid UTF-8 encoded strings and will expose this data as {@link GlideString}.
      *
      * @param pointer A memory pointer from {@link Response}
      * @return A RESP3 value

--- a/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/RedisValueResolver.java
@@ -1,7 +1,6 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.ffi.resolvers;
 
-import glide.api.models.GlideString;
 import response.ResponseOuterClass.Response;
 
 public class RedisValueResolver {
@@ -27,7 +26,8 @@ public class RedisValueResolver {
 
     /**
      * Resolve a value received from Redis using given C-style pointer. This method does not assume
-     * that strings are valid UTF-8 encoded strings and will expose this data as {@link GlideString}.
+     * that strings are valid UTF-8 encoded strings and will expose this data as a <code>byte[]</code>
+     * .
      *
      * @param pointer A memory pointer from {@link Response}
      * @return A RESP3 value

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -149,7 +149,6 @@ public class ConnectionManager {
             var subscriptionsBuilder = PubSubSubscriptions.newBuilder();
             for (var entry : configuration.getSubscriptionConfiguration().getSubscriptions().entrySet()) {
                 var channelsBuilder = PubSubChannelsOrPatterns.newBuilder();
-                System.out.println(entry.getValue());
                 for (var channel : entry.getValue()) {
                     channelsBuilder.addChannelsOrPatterns(ByteString.copyFrom(channel.getBytes()));
                 }

--- a/java/client/src/main/java/glide/managers/ConnectionManager.java
+++ b/java/client/src/main/java/glide/managers/ConnectionManager.java
@@ -149,8 +149,9 @@ public class ConnectionManager {
             var subscriptionsBuilder = PubSubSubscriptions.newBuilder();
             for (var entry : configuration.getSubscriptionConfiguration().getSubscriptions().entrySet()) {
                 var channelsBuilder = PubSubChannelsOrPatterns.newBuilder();
+                System.out.println(entry.getValue());
                 for (var channel : entry.getValue()) {
-                    channelsBuilder.addChannelsOrPatterns(ByteString.copyFromUtf8(channel));
+                    channelsBuilder.addChannelsOrPatterns(ByteString.copyFrom(channel.getBytes()));
                 }
                 subscriptionsBuilder.putChannelsOrPatternsByType(
                         entry.getKey().ordinal(), channelsBuilder.build());
@@ -178,7 +179,7 @@ public class ConnectionManager {
             for (var entry : configuration.getSubscriptionConfiguration().getSubscriptions().entrySet()) {
                 var channelsBuilder = PubSubChannelsOrPatterns.newBuilder();
                 for (var channel : entry.getValue()) {
-                    channelsBuilder.addChannelsOrPatterns(ByteString.copyFromUtf8(channel));
+                    channelsBuilder.addChannelsOrPatterns(ByteString.copyFrom(channel.getBytes()));
                 }
                 subscriptionsBuilder.putChannelsOrPatternsByType(
                         entry.getKey().ordinal(), channelsBuilder.build());

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -11695,7 +11695,7 @@ public class RedisClientTest {
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<String> response = service.publish(channel, message);
+        CompletableFuture<String> response = service.publish(message, channel);
         String payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -2637,7 +2637,7 @@ public class RedisClusterClientTest {
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<String> response = service.publish(channel, message, true);
+        CompletableFuture<String> response = service.publish(message, channel, true);
         String payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -2637,7 +2637,7 @@ public class RedisClusterClientTest {
                 .thenReturn(testResponse);
 
         // exercise
-        CompletableFuture<String> response = service.spublish(channel, message);
+        CompletableFuture<String> response = service.publish(channel, message, true);
         String payload = response.get();
 
         // verify

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -28,7 +28,7 @@ public class ClusterTransactionTests {
         ClusterTransaction transaction = new ClusterTransaction();
         List<Pair<RequestType, ArgsArray>> results = new LinkedList<>();
 
-        transaction.spublish("ch1", "msg");
+        transaction.publish("ch1", "msg", true);
         results.add(Pair.of(SPublish, buildArgs("ch1", "msg")));
 
         transaction.sortReadOnly(

--- a/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/ClusterTransactionTests.java
@@ -28,7 +28,7 @@ public class ClusterTransactionTests {
         ClusterTransaction transaction = new ClusterTransaction();
         List<Pair<RequestType, ArgsArray>> results = new LinkedList<>();
 
-        transaction.publish("ch1", "msg", true);
+        transaction.publish("msg", "ch1", true);
         results.add(Pair.of(SPublish, buildArgs("ch1", "msg")));
 
         transaction.sortReadOnly(

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -1224,7 +1224,7 @@ public class TransactionTests {
         transaction.lcsLen("key1", "key2");
         results.add(Pair.of(LCS, buildArgs("key1", "key2", "LEN")));
 
-        transaction.publish("ch1", "msg");
+        transaction.publish("msg", "ch1");
         results.add(Pair.of(Publish, buildArgs("ch1", "msg")));
 
         transaction.lcsIdx("key1", "key2");

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -182,12 +182,15 @@ public class ConnectionManagerTest {
                                                 Map.of(
                                                         EXACT.ordinal(),
                                                                 PubSubChannelsOrPatterns.newBuilder()
-                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("channel_1").getBytes()))
-                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("channel_2").getBytes()))
+                                                                        .addChannelsOrPatterns(
+                                                                                ByteString.copyFrom(gs("channel_1").getBytes()))
+                                                                        .addChannelsOrPatterns(
+                                                                                ByteString.copyFrom(gs("channel_2").getBytes()))
                                                                         .build(),
                                                         PATTERN.ordinal(),
                                                                 PubSubChannelsOrPatterns.newBuilder()
-                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("*chatRoom*").getBytes()))
+                                                                        .addChannelsOrPatterns(
+                                                                                ByteString.copyFrom(gs("*chatRoom*").getBytes()))
                                                                         .build()))
                                         .build())
                         .build();

--- a/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
+++ b/java/client/src/test/java/glide/managers/ConnectionManagerTest.java
@@ -1,6 +1,7 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide.managers;
 
+import static glide.api.models.GlideString.gs;
 import static glide.api.models.configuration.NodeAddress.DEFAULT_HOST;
 import static glide.api.models.configuration.NodeAddress.DEFAULT_PORT;
 import static glide.api.models.configuration.StandaloneSubscriptionConfiguration.PubSubChannelMode.EXACT;
@@ -144,9 +145,9 @@ public class ConnectionManagerTest {
                         .clientName(CLIENT_NAME)
                         .subscriptionConfiguration(
                                 StandaloneSubscriptionConfiguration.builder()
-                                        .subscription(EXACT, "channel_1")
-                                        .subscription(EXACT, "channel_2")
-                                        .subscription(PATTERN, "*chatRoom*")
+                                        .subscription(EXACT, gs("channel_1"))
+                                        .subscription(EXACT, gs("channel_2"))
+                                        .subscription(PATTERN, gs("*chatRoom*"))
                                         .build())
                         .build();
         ConnectionRequest expectedProtobufConnectionRequest =
@@ -181,12 +182,12 @@ public class ConnectionManagerTest {
                                                 Map.of(
                                                         EXACT.ordinal(),
                                                                 PubSubChannelsOrPatterns.newBuilder()
-                                                                        .addChannelsOrPatterns(ByteString.copyFromUtf8("channel_1"))
-                                                                        .addChannelsOrPatterns(ByteString.copyFromUtf8("channel_2"))
+                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("channel_1").getBytes()))
+                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("channel_2").getBytes()))
                                                                         .build(),
                                                         PATTERN.ordinal(),
                                                                 PubSubChannelsOrPatterns.newBuilder()
-                                                                        .addChannelsOrPatterns(ByteString.copyFromUtf8("*chatRoom*"))
+                                                                        .addChannelsOrPatterns(ByteString.copyFrom(gs("*chatRoom*").getBytes()))
                                                                         .build()))
                                         .build())
                         .build();

--- a/java/integTest/build.gradle
+++ b/java/integTest/build.gradle
@@ -50,7 +50,7 @@ ext {
     extractRedisVersion = { String output ->
         // Redis response:
         // Redis server v=7.2.3 sha=00000000:0 malloc=jemalloc-5.3.0 bits=64 build=7504b1fedf883f2
-        // Valkey response: 
+        // Valkey response:
         // Server v=7.2.5 sha=26388270:0 malloc=jemalloc-5.3.0 bits=64 build=ea40bb1576e402d6
         return output.split("v=")[1].split(" ")[0]
     }
@@ -136,6 +136,10 @@ tasks.withType(Test) {
         events "started", "skipped", "passed", "failed"
         showStandardStreams true
     }
+
+    minHeapSize = "2048m" // Initial heap size. Needed for max size tests.
+    maxHeapSize = "2048m" // Maximum heap size. Needed for max size tests.
+
     afterTest { desc, result ->
         logger.quiet "${desc.className}.${desc.name}: ${result.resultType} ${(result.getEndTime() - result.getStartTime())/1000}s"
     }

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -194,11 +194,6 @@ public class PubSubTests {
     //  test_pubsub_exact_happy_path_many_channels_co_existence
     //  test_sharded_pubsub_co_existence
     //  test_pubsub_pattern_co_existence
-    // TODO tests below blocked by https://github.com/aws/glide-for-redis/issues/1649
-    //  test_pubsub_exact_max_size_PubsubMessage
-    //  test_pubsub_sharded_max_size_PubsubMessage
-    //  test_pubsub_exact_max_size_PubsubMessage_callback
-    //  test_pubsub_sharded_max_size_PubsubMessage_callback
 
     // TODO why `publish` returns 0 on cluster or > 1 on standalone when there is only 1 receiver???
     //  meanwhile, all pubsubMessages are delivered.
@@ -813,9 +808,6 @@ public class PubSubTests {
                 assertThrows(ExecutionException.class, () -> clusterClient.exec(transaction).get());
         assertInstanceOf(RequestException.class, exception.getCause());
         assertTrue(exception.getMessage().toLowerCase().contains("crossslot"));
-
-        // TODO test when callback throws an exception - currently nothing happens now
-        //  it should terminate the client
     }
 
     @SneakyThrows

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -213,7 +213,7 @@ public class PubSubTests {
         var sender = createClient(standalone);
         clients.addAll(List.of(listener, sender));
 
-        sender.publish(channel, message).get();
+        sender.publish(message, channel).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the message
 
         verifyReceivedPubsubMessages(
@@ -246,7 +246,7 @@ public class PubSubTests {
         clients.addAll(List.of(listener, sender));
 
         for (var pubsubMessage : messages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -273,7 +273,7 @@ public class PubSubTests {
         var sender = (RedisClusterClient) createClient(false);
         clients.addAll(List.of(listener, sender));
 
-        sender.publish(channel, pubsubMessage, true).get();
+        sender.publish(pubsubMessage, channel, true).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the message
 
         verifyReceivedPubsubMessages(
@@ -308,7 +308,7 @@ public class PubSubTests {
         clients.addAll(List.of(listener, sender));
 
         for (var pubsubMessage : pubsubMessages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel(), true).get();
         }
         sender.publish(UUID.randomUUID().toString(), UUID.randomUUID().toString(), true).get();
 
@@ -343,9 +343,9 @@ public class PubSubTests {
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // need some time to propagate subscriptions - why?
 
         for (var entry : message2channels.entrySet()) {
-            sender.publish(entry.getKey(), entry.getValue()).get();
+            sender.publish(entry.getValue(), entry.getKey()).get();
         }
-        sender.publish("channel", UUID.randomUUID().toString()).get();
+        sender.publish(UUID.randomUUID().toString(), "channel").get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
         var expected =
@@ -385,9 +385,9 @@ public class PubSubTests {
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // need some time to propagate subscriptions - why?
 
         for (var pubsubMessage : messages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
-        sender.publish("channel", UUID.randomUUID().toString()).get();
+        sender.publish(UUID.randomUUID().toString(), "channel").get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
         verifyReceivedPubsubMessages(
@@ -435,7 +435,7 @@ public class PubSubTests {
         clients.addAll(List.of(listener, sender));
 
         for (var pubsubMessage : messages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -483,7 +483,7 @@ public class PubSubTests {
         clients.addAll(List.of(listenerExactSub, listenerPatternSub, sender));
 
         for (var pubsubMessage : messages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -560,10 +560,10 @@ public class PubSubTests {
         clients.addAll(List.of(listener, sender));
 
         for (var pubsubMessage : messages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
         for (var pubsubMessage : shardedMessages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel(), true).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -634,13 +634,13 @@ public class PubSubTests {
         clients.addAll(List.of(listenerExact, listenerPattern, listenerSharded, sender));
 
         for (var pubsubMessage : exactMessages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
         for (var pubsubMessage : patternMessages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel()).get();
         }
         for (var pubsubMessage : shardedMessages) {
-            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
+            sender.publish(pubsubMessage.getMessage(), pubsubMessage.getChannel(), true).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -712,9 +712,9 @@ public class PubSubTests {
                 (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsSharded);
         clients.addAll(List.of(listenerExact, listenerPattern, listenerSharded));
 
-        listenerPattern.publish(channel, exactMessage.getMessage()).get();
-        listenerSharded.publish(channel, patternMessage.getMessage()).get();
-        listenerExact.publish(channel, shardedMessage.getMessage(), true).get();
+        listenerPattern.publish(exactMessage.getMessage(), channel).get();
+        listenerSharded.publish(patternMessage.getMessage(), channel).get();
+        listenerExact.publish(shardedMessage.getMessage(), channel, true).get();
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
@@ -774,9 +774,9 @@ public class PubSubTests {
 
         clients.addAll(List.of(listenerExact, listenerPattern, listenerSharded));
 
-        listenerPattern.publish(channel, exactMessage.getMessage()).get();
-        listenerSharded.publish(channel, patternMessage.getMessage()).get();
-        listenerExact.publish(channel, shardedMessage.getMessage(), true).get();
+        listenerPattern.publish(exactMessage.getMessage(), channel).get();
+        listenerSharded.publish(patternMessage.getMessage(), channel).get();
+        listenerExact.publish(shardedMessage.getMessage(), channel, true).get();
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
@@ -816,9 +816,9 @@ public class PubSubTests {
         var clusterClient = (RedisClusterClient) createClient(false);
         var transaction =
                 new ClusterTransaction()
-                        .publish("abc", "one", true)
-                        .publish("mnk", "two", true)
-                        .publish("xyz", "three", true);
+                        .publish("one", "abc", true)
+                        .publish("two", "mnk", true)
+                        .publish("three", "xyz", true);
         var exception =
                 assertThrows(ExecutionException.class, () -> clusterClient.exec(transaction).get());
         assertInstanceOf(RequestException.class, exception.getCause());
@@ -869,15 +869,15 @@ public class PubSubTests {
         if (standalone) {
             var transaction =
                     new Transaction()
-                            .publish(exactMessage.getChannel(), exactMessage.getMessage())
-                            .publish(patternMessage.getChannel(), patternMessage.getMessage());
+                            .publish(exactMessage.getMessage(), exactMessage.getChannel())
+                            .publish(patternMessage.getMessage(), patternMessage.getChannel());
             ((RedisClient) sender).exec(transaction).get();
         } else {
             var transaction =
                     new ClusterTransaction()
-                            .publish(shardedMessage.getChannel(), shardedMessage.getMessage(), true)
-                            .publish(exactMessage.getChannel(), exactMessage.getMessage())
-                            .publish(patternMessage.getChannel(), patternMessage.getMessage());
+                            .publish(shardedMessage.getMessage(), shardedMessage.getChannel(), true)
+                            .publish(exactMessage.getMessage(), exactMessage.getChannel())
+                            .publish(patternMessage.getMessage(), patternMessage.getChannel());
             ((RedisClusterClient) sender).exec(transaction).get();
         }
 

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -273,7 +273,7 @@ public class PubSubTests {
         var sender = (RedisClusterClient) createClient(false);
         clients.addAll(List.of(listener, sender));
 
-        sender.spublish(channel, pubsubMessage).get();
+        sender.publish(channel, pubsubMessage, true).get();
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the message
 
         verifyReceivedPubsubMessages(
@@ -308,9 +308,9 @@ public class PubSubTests {
         clients.addAll(List.of(listener, sender));
 
         for (var pubsubMessage : pubsubMessages) {
-            sender.spublish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
         }
-        sender.spublish(UUID.randomUUID().toString(), UUID.randomUUID().toString()).get();
+        sender.publish(UUID.randomUUID().toString(), UUID.randomUUID().toString(), true).get();
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
@@ -563,7 +563,7 @@ public class PubSubTests {
             sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
         }
         for (var pubsubMessage : shardedMessages) {
-            sender.spublish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -640,7 +640,7 @@ public class PubSubTests {
             sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
         }
         for (var pubsubMessage : shardedMessages) {
-            sender.spublish(pubsubMessage.getChannel(), pubsubMessage.getMessage()).get();
+            sender.publish(pubsubMessage.getChannel(), pubsubMessage.getMessage(), true).get();
         }
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
@@ -714,7 +714,7 @@ public class PubSubTests {
 
         listenerPattern.publish(channel, exactMessage.getMessage()).get();
         listenerSharded.publish(channel, patternMessage.getMessage()).get();
-        listenerExact.spublish(channel, shardedMessage.getMessage()).get();
+        listenerExact.publish(channel, shardedMessage.getMessage(), true).get();
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
@@ -776,7 +776,7 @@ public class PubSubTests {
 
         listenerPattern.publish(channel, exactMessage.getMessage()).get();
         listenerSharded.publish(channel, patternMessage.getMessage()).get();
-        listenerExact.spublish(channel, shardedMessage.getMessage()).get();
+        listenerExact.publish(channel, shardedMessage.getMessage(), true).get();
 
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
@@ -816,9 +816,9 @@ public class PubSubTests {
         var clusterClient = (RedisClusterClient) createClient(false);
         var transaction =
                 new ClusterTransaction()
-                        .spublish("abc", "one")
-                        .spublish("mnk", "two")
-                        .spublish("xyz", "three");
+                        .publish("abc", "one", true)
+                        .publish("mnk", "two", true)
+                        .publish("xyz", "three", true);
         var exception =
                 assertThrows(ExecutionException.class, () -> clusterClient.exec(transaction).get());
         assertInstanceOf(RequestException.class, exception.getCause());
@@ -875,7 +875,7 @@ public class PubSubTests {
         } else {
             var transaction =
                     new ClusterTransaction()
-                            .spublish(shardedMessage.getChannel(), shardedMessage.getMessage())
+                            .publish(shardedMessage.getChannel(), shardedMessage.getMessage(), true)
                             .publish(exactMessage.getChannel(), exactMessage.getMessage())
                             .publish(patternMessage.getChannel(), patternMessage.getMessage());
             ((RedisClusterClient) sender).exec(transaction).get();

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -699,25 +699,30 @@ public class PubSubTests {
         var patternMessage = new PubSubMessage(UUID.randomUUID().toString(), channel, channel);
         var shardedMessage = new PubSubMessage(UUID.randomUUID().toString(), channel);
         Map<PubSubClusterChannelMode, Set<String>> subscriptionsExact =
-            Map.of(PubSubClusterChannelMode.EXACT, Set.of(channel));
+                Map.of(PubSubClusterChannelMode.EXACT, Set.of(channel));
         Map<PubSubClusterChannelMode, Set<String>> subscriptionsPattern =
-            Map.of(PubSubClusterChannelMode.PATTERN, Set.of(channel));
+                Map.of(PubSubClusterChannelMode.PATTERN, Set.of(channel));
         Map<PubSubClusterChannelMode, Set<String>> subscriptionsSharded =
-            Map.of(PubSubClusterChannelMode.SHARDED, Set.of(channel));
+                Map.of(PubSubClusterChannelMode.SHARDED, Set.of(channel));
 
-        var listenerExact = !useCallback ? (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsExact) :
-            (RedisClusterClient) createListener(
-                false, true, PubSubClusterChannelMode.EXACT.ordinal(), subscriptionsExact);
+        var listenerExact =
+                !useCallback
+                        ? (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsExact)
+                        : (RedisClusterClient)
+                                createListener(
+                                        false, true, PubSubClusterChannelMode.EXACT.ordinal(), subscriptionsExact);
 
-        var listenerPattern = !useCallback ?
-            (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsPattern) :
-            createListener(
-                false, true, PubSubClusterChannelMode.PATTERN.ordinal(), subscriptionsPattern);
+        var listenerPattern =
+                !useCallback
+                        ? (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsPattern)
+                        : createListener(
+                                false, true, PubSubClusterChannelMode.PATTERN.ordinal(), subscriptionsPattern);
 
-        var listenerSharded = !useCallback ?
-            (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsSharded) :
-            createListener(
-                false, true, PubSubClusterChannelMode.SHARDED.ordinal(), subscriptionsSharded);
+        var listenerSharded =
+                !useCallback
+                        ? (RedisClusterClient) createClientWithSubscriptions(false, subscriptionsSharded)
+                        : createListener(
+                                false, true, PubSubClusterChannelMode.SHARDED.ordinal(), subscriptionsSharded);
 
         clients.addAll(List.of(listenerExact, listenerPattern, listenerSharded));
 
@@ -729,37 +734,37 @@ public class PubSubTests {
 
         if (!useCallback) {
             verifyReceivedPubsubMessages(
-                Set.of(
-                    Pair.of(PubSubClusterChannelMode.EXACT.ordinal(), exactMessage),
-                    Pair.of(
-                        PubSubClusterChannelMode.EXACT.ordinal(),
-                        new PubSubMessage(patternMessage.getMessage(), channel))),
-                listenerExact,
-                false);
+                    Set.of(
+                            Pair.of(PubSubClusterChannelMode.EXACT.ordinal(), exactMessage),
+                            Pair.of(
+                                    PubSubClusterChannelMode.EXACT.ordinal(),
+                                    new PubSubMessage(patternMessage.getMessage(), channel))),
+                    listenerExact,
+                    false);
             verifyReceivedPubsubMessages(
-                Set.of(
-                    Pair.of(PubSubClusterChannelMode.PATTERN.ordinal(), patternMessage),
-                    Pair.of(
-                        PubSubClusterChannelMode.PATTERN.ordinal(),
-                        new PubSubMessage(exactMessage.getMessage(), channel, channel))),
-                listenerPattern,
-                false);
+                    Set.of(
+                            Pair.of(PubSubClusterChannelMode.PATTERN.ordinal(), patternMessage),
+                            Pair.of(
+                                    PubSubClusterChannelMode.PATTERN.ordinal(),
+                                    new PubSubMessage(exactMessage.getMessage(), channel, channel))),
+                    listenerPattern,
+                    false);
             verifyReceivedPubsubMessages(
-                Set.of(Pair.of(PubSubClusterChannelMode.SHARDED.ordinal(), shardedMessage)),
-                listenerSharded,
-                false);
+                    Set.of(Pair.of(PubSubClusterChannelMode.SHARDED.ordinal(), shardedMessage)),
+                    listenerSharded,
+                    false);
         } else {
             var expected =
-                Set.of(
-                    Pair.of(PubSubClusterChannelMode.EXACT.ordinal(), exactMessage),
-                    Pair.of(
-                        PubSubClusterChannelMode.EXACT.ordinal(),
-                        new PubSubMessage(patternMessage.getMessage(), channel)),
-                    Pair.of(PubSubClusterChannelMode.PATTERN.ordinal(), patternMessage),
-                    Pair.of(
-                        PubSubClusterChannelMode.PATTERN.ordinal(),
-                        new PubSubMessage(exactMessage.getMessage(), channel, channel)),
-                    Pair.of(PubSubClusterChannelMode.SHARDED.ordinal(), shardedMessage));
+                    Set.of(
+                            Pair.of(PubSubClusterChannelMode.EXACT.ordinal(), exactMessage),
+                            Pair.of(
+                                    PubSubClusterChannelMode.EXACT.ordinal(),
+                                    new PubSubMessage(patternMessage.getMessage(), channel)),
+                            Pair.of(PubSubClusterChannelMode.PATTERN.ordinal(), patternMessage),
+                            Pair.of(
+                                    PubSubClusterChannelMode.PATTERN.ordinal(),
+                                    new PubSubMessage(exactMessage.getMessage(), channel, channel)),
+                            Pair.of(PubSubClusterChannelMode.SHARDED.ordinal(), shardedMessage));
 
             verifyReceivedPubsubMessages(expected, listenerExact, true);
         }

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -1104,70 +1104,39 @@ public class PubSubTests {
     }
 
     @SneakyThrows
-    @ParameterizedTest(name = "standalone = {0}, use callback = {1}")
-    @MethodSource("getTwoBoolPermutations")
-    public void transaction_with_all_types_of_PubsubMessages_binary(
-            boolean standalone, boolean useCallback) {
+    @ParameterizedTest(name = "standalone = {0}")
+    @ValueSource(booleans = {true, false})
+    public void pubsub_with_binary(boolean standalone) {
         assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in redis 7");
-        skipTestsOnMac();
-        assumeTrue(
-                standalone, // TODO activate tests after fix
-                "Test doesn't work on cluster due to Cross Slot error, probably a bug in `redis-rs`");
 
-        String prefix = "channel";
-        GlideString pattern = gs(new byte[] {(byte) 0xC3, 0x28});
-        GlideString shardPrefix = gs(new byte[] {(byte) 0xA0, (byte) 0xA1});
         GlideString channel = gs(new byte[] {(byte) 0xE2, 0x28, (byte) 0xA1});
-        var exactMessage =
+        var message =
                 new PubSubMessage(gs(new byte[] {(byte) 0xF0, 0x28, (byte) 0x8C, (byte) 0xBC}), channel);
-        var patternMessage =
-                new PubSubMessage(
-                        gs(new byte[] {(byte) 0xF0, (byte) 0x90, 0x28, (byte) 0xBC}), gs(prefix), pattern);
-        var shardedMessage =
-                new PubSubMessage(
-                        gs(new byte[] {(byte) 0xF0, (byte) 0x28, (byte) 0x8C, 0x28}), shardPrefix);
+
+        ArrayList<PubSubMessage> callbackMessages = new ArrayList<>();
+        final MessageCallback callback =
+                (pubSubMessage, context) -> {
+                    ArrayList<PubSubMessage> receivedMessages = (ArrayList<PubSubMessage>) context;
+                    receivedMessages.add(pubSubMessage);
+                };
 
         Map<? extends ChannelMode, Set<GlideString>> subscriptions =
                 standalone
-                        ? Map.of(
-                                PubSubChannelMode.EXACT,
-                                Set.of(channel),
-                                PubSubChannelMode.PATTERN,
-                                Set.of(pattern))
-                        : Map.of(
-                                PubSubClusterChannelMode.EXACT,
-                                Set.of(channel),
-                                PubSubClusterChannelMode.PATTERN,
-                                Set.of(pattern),
-                                PubSubClusterChannelMode.SHARDED,
-                                Set.of(shardPrefix));
+                        ? Map.of(PubSubChannelMode.EXACT, Set.of(channel))
+                        : Map.of(PubSubClusterChannelMode.EXACT, Set.of(channel));
 
-        var listener = createListener(standalone, useCallback, 1, subscriptions);
+        var listener = createClientWithSubscriptions(standalone, subscriptions);
+        var listener2 =
+                createClientWithSubscriptions(
+                        standalone, subscriptions, Optional.of(callback), Optional.of(callbackMessages));
         var sender = createClient(standalone);
-        clients.addAll(List.of(listener, sender));
+        clients.addAll(Arrays.asList(listener, listener2, sender));
 
-        if (standalone) {
-            var transaction =
-                    new Transaction()
-                            .publish(exactMessage.getMessage(), exactMessage.getChannel())
-                            .publish(patternMessage.getMessage(), patternMessage.getChannel());
-            ((RedisClient) sender).exec(transaction).get();
-        } else {
-            var transaction =
-                    new ClusterTransaction()
-                            .publish(shardedMessage.getMessage(), shardedMessage.getChannel(), true)
-                            .publish(exactMessage.getMessage(), exactMessage.getChannel())
-                            .publish(patternMessage.getMessage(), patternMessage.getChannel());
-            ((RedisClusterClient) sender).exec(transaction).get();
-        }
-
+        assertEquals(OK, sender.publish(message.getMessage(), channel).get());
         Thread.sleep(MESSAGE_DELIVERY_DELAY); // deliver the messages
 
-        var expected =
-                standalone
-                        ? Set.of(Pair.of(1, exactMessage), Pair.of(1, patternMessage))
-                        : Set.of(
-                                Pair.of(1, exactMessage), Pair.of(1, patternMessage), Pair.of(1, shardedMessage));
-        verifyReceivedPubsubMessages(expected, listener, useCallback);
+        assertEquals(message, listener.tryGetPubSubMessage());
+        assertEquals(1, callbackMessages.size());
+        assertEquals(message, callbackMessages.get(0));
     }
 }

--- a/java/integTest/src/test/java/glide/PubSubTests.java
+++ b/java/integTest/src/test/java/glide/PubSubTests.java
@@ -332,7 +332,10 @@ public class PubSubTests {
         GlideString pattern = gs(prefix + "*");
         Map<GlideString, GlideString> message2channels =
                 Map.of(
-                        gs(prefix + "1"), gs(UUID.randomUUID().toString()), gs(prefix + "2"), gs(UUID.randomUUID().toString()));
+                        gs(prefix + "1"),
+                        gs(UUID.randomUUID().toString()),
+                        gs(prefix + "2"),
+                        gs(UUID.randomUUID().toString()));
         var subscriptions =
                 Map.of(
                         standalone ? PubSubChannelMode.PATTERN : PubSubClusterChannelMode.PATTERN,

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -1219,10 +1219,10 @@ public class TransactionTestUtilities {
     }
 
     private static Object[] pubsubCommands(BaseTransaction<?> transaction) {
-        transaction.publish("Tchannel", "message");
+        transaction.publish("message", "Tchannel");
 
         return new Object[] {
-            0L, // publish("Tchannel", "message")
+            0L, // publish("message", "Tchannel")
         };
     }
 }

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -277,7 +277,7 @@ public class ClusterTransactionTests {
     @SneakyThrows
     public void spublish() {
         assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in redis 7");
-        ClusterTransaction transaction = new ClusterTransaction().spublish("Schannel", "message");
+        ClusterTransaction transaction = new ClusterTransaction().publish("Schannel", "message", true);
 
         assertArrayEquals(new Object[] {0L}, clusterClient.exec(transaction).get());
     }

--- a/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
+++ b/java/integTest/src/test/java/glide/cluster/ClusterTransactionTests.java
@@ -277,7 +277,7 @@ public class ClusterTransactionTests {
     @SneakyThrows
     public void spublish() {
         assumeTrue(REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0"), "This feature added in redis 7");
-        ClusterTransaction transaction = new ClusterTransaction().publish("Schannel", "message", true);
+        ClusterTransaction transaction = new ClusterTransaction().publish("messagae", "Schannel", true);
 
         assertArrayEquals(new Object[] {0L}, clusterClient.exec(transaction).get());
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Address some of the comments in #1662 about aligning with Python:

- Remove spublish() and provide a cluster-only publish() overload that takes a boolean.
- Match argument order for publish() with Python.
- Add missing integration tests.
- Undo splitting of integration tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
