### PR TITLE
Remove protobuf fields from protobuf

### DIFF
--- a/glide-core/src/protobuf/redis_request.proto
+++ b/glide-core/src/protobuf/redis_request.proto
@@ -273,9 +273,9 @@ message Transaction {
 
 message ClusterScan {
     string cursor = 1;
-    optional string match_pattern = 2;
-    optional int64 count = 3;
-    optional string object_type = 4;
+    string match_pattern = 2;
+    int64 count = 3;
+    string object_type = 4;
 }
 
 message RedisRequest {


### PR DESCRIPTION
All fields in protobuf are optional by default and the 'optional' field isn't supported in all protobuf version