### PR TITLE
Full tests on macos

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -166,7 +166,7 @@ jobs:
             run: |
                 source .env/bin/activate
                 cd python/tests/
-                pytest -c ../../pytest_pubsub.ini --asyncio-mode=auto test_pubsub.py::TestPubSub
+                pytest --asyncio-mode=auto -k test_pubsub
 
     lint-rust:
         runs-on: ubuntu-latest
@@ -238,7 +238,7 @@ jobs:
               run: |
                   source .env/bin/activate
                   cd python/tests/
-                  pytest -c ../../pytest_pubsub.ini --asyncio-mode=auto test_pubsub.py::TestPubSub
+                  pytest --asyncio-mode=auto -k test_pubsub
 
     build-amazonlinux-latest:
         runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -52,7 +52,7 @@ jobs:
     test-ubuntu-latest:
         runs-on: ubuntu-latest
         needs: load-engine-matrix
-        timeout-minutes: 25
+        timeout-minutes: 35
         strategy:
             fail-fast: false
             matrix:
@@ -128,6 +128,46 @@ jobs:
               with:
                   language-flag: -python
 
+    test-pubsub-ubuntu-latest:
+      runs-on: ubuntu-latest
+      needs: load-engine-matrix
+      timeout-minutes: 35
+      strategy:
+          fail-fast: false
+          matrix:
+              engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
+              python:
+                - "3.8"
+                - "3.9"
+                - "3.10"
+                - "3.11"
+                - "3.12"
+
+      steps:
+          - uses: actions/checkout@v4
+            with:
+                submodules: recursive
+
+          - name: Set up Python
+            uses: actions/setup-python@v4
+            with:
+                python-version: ${{ matrix.python }}
+
+          - name: Build Python wrapper
+            uses: ./.github/workflows/build-python-wrapper
+            with:
+                os: "ubuntu"
+                target: "x86_64-unknown-linux-gnu"
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                engine-version: ${{ matrix.engine.version }}
+
+          - name: Test pubsub with pytest
+            working-directory: ./python
+            run: |
+                source .env/bin/activate
+                cd python/tests/
+                pytest -c ../../pytest_pubsub.ini --asyncio-mode=auto test_pubsub.py::TestPubSub
+
     lint-rust:
         runs-on: ubuntu-latest
         timeout-minutes: 15
@@ -141,9 +181,14 @@ jobs:
                   cargo-toml-folder: ./python
               name: lint python-rust
 
-    build-macos-latest:
+    test-macos-latest:
         runs-on: macos-latest
-        timeout-minutes: 25
+        needs: load-engine-matrix
+        timeout-minutes: 35
+        strategy:
+          fail-fast: false
+          matrix:
+              engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -157,13 +202,43 @@ jobs:
                   os: "macos"
                   target: "aarch64-apple-darwin"
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  engine-version: "7.2.5"
+                  engine-version: ${{ matrix.engine.version }}
 
-            - name: Test compatibility with pytest
+            - name: Test with pytest
               working-directory: ./python
               run: |
                   source .env/bin/activate
-                  pytest --asyncio-mode=auto -m smoke_test
+                  pytest --asyncio-mode=auto
+
+    test-pubsub-macos-latest:
+        runs-on: macos-latest
+        needs: load-engine-matrix
+        timeout-minutes: 35
+        strategy:
+          fail-fast: false
+          matrix:
+              engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: recursive
+            - name: Set up Homebrew
+              uses: Homebrew/actions/setup-homebrew@master
+
+            - name: Build Python wrapper
+              uses: ./.github/workflows/build-python-wrapper
+              with:
+                  os: "macos"
+                  target: "aarch64-apple-darwin"
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  engine-version: ${{ matrix.engine.version }}
+
+            - name: Test pubsub with pytest
+              working-directory: ./python
+              run: |
+                  source .env/bin/activate
+                  cd python/tests/
+                  pytest -c ../../pytest_pubsub.ini --asyncio-mode=auto test_pubsub.py::TestPubSub
 
     build-amazonlinux-latest:
         runs-on: ubuntu-latest

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -117,9 +117,15 @@ impl UnixStreamListener {
                     return ReadSocketClosed.into();
                 }
                 Ok(_) => {
-                    return match self.rotating_buffer.get_requests() {
-                        Ok(requests) => ReceivedValues(requests),
-                        Err(err) => UnhandledError(err.into()).into(),
+                    match self.rotating_buffer.get_requests() {
+                        Ok(requests) => {
+                            if !requests.is_empty() {
+                                // continue to read from socket
+                                return ReceivedValues(requests);
+                            }
+                            continue;
+                        }
+                        Err(err) => return UnhandledError(err.into()).into(),
                     };
                 }
                 Err(ref e)

--- a/glide-core/src/socket_listener.rs
+++ b/glide-core/src/socket_listener.rs
@@ -120,9 +120,9 @@ impl UnixStreamListener {
                     match self.rotating_buffer.get_requests() {
                         Ok(requests) => {
                             if !requests.is_empty() {
-                                // continue to read from socket
                                 return ReceivedValues(requests);
                             }
+                            // continue to read from socket
                             continue;
                         }
                         Err(err) => return UnhandledError(err.into()).into(),

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     smoke_test: mark a test as a build verification testing.
-addopts = -k "not redis_modules and not pubsub"
+addopts = -k "not server_modules and not pubsub"

--- a/python/pytest_pubsub.ini
+++ b/python/pytest_pubsub.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    smoke_test: mark a test as a build verification testing.
-addopts = -k "not redis_modules"

--- a/python/pytest_pubsub.ini
+++ b/python/pytest_pubsub.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     smoke_test: mark a test as a build verification testing.
-addopts = -k "not redis_modules and not pubsub"
+addopts = -k "not redis_modules"

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -152,7 +152,7 @@ class BaseClient(CoreCommands):
         try:
             self._pubsub_lock.acquire()
             for pubsub_future in self._pubsub_futures:
-                if not response_future.done() and not pubsub_future.cancelled():
+                if not pubsub_future.done() and not pubsub_future.cancelled():
                     pubsub_future.set_exception(ClosingError(""))
         finally:
             self._pubsub_lock.release()


### PR DESCRIPTION
1. Enabled all tests on macos latest with all engine versions.
2. Changed pubsub tests to be run in separate task.
3. Fixed uds message parsing in glide-core.
4. Refactored pubsub tests