### PR TITLE
Java: Add `XINFO GROUPS` and `XINFO CONSUMERS` commands

### DIFF
--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -148,6 +148,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsu
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoConsumers;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoGroups;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -2707,6 +2709,23 @@ public abstract class BaseClient
                         new GlideString[] {gs(JUST_ID_REDIS_API)});
         return commandManager.submitNewCommand(
                 XClaim, args, response -> castArray(handleArrayResponse(response), GlideString.class));
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Object>[]> xinfoGroups(@NonNull String key) {
+        return commandManager.submitNewCommand(
+                XInfoGroups,
+                new String[] {key},
+                response -> castArray(handleArrayResponse(response), Map.class));
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Object>[]> xinfoConsumers(
+            @NonNull String key, @NonNull String groupName) {
+        return commandManager.submitNewCommand(
+                XInfoConsumers,
+                new String[] {key, groupName},
+                response -> castArray(handleArrayResponse(response), Map.class));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -2724,7 +2724,7 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 XInfoGroups,
                 new GlideString[] {key},
-                response -> castArray(handleArrayResponse(response), Map.class));
+                response -> castArray(handleArrayResponseBinary(response), Map.class));
     }
 
     @Override
@@ -2742,7 +2742,7 @@ public abstract class BaseClient
         return commandManager.submitNewCommand(
                 XInfoConsumers,
                 new GlideString[] {key, groupName},
-                response -> castArray(handleArrayResponse(response), Map.class));
+                response -> castArray(handleArrayResponseBinary(response), Map.class));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -2720,11 +2720,28 @@ public abstract class BaseClient
     }
 
     @Override
+    public CompletableFuture<Map<GlideString, Object>[]> xinfoGroups(@NonNull GlideString key) {
+        return commandManager.submitNewCommand(
+                XInfoGroups,
+                new GlideString[] {key},
+                response -> castArray(handleArrayResponse(response), Map.class));
+    }
+
+    @Override
     public CompletableFuture<Map<String, Object>[]> xinfoConsumers(
             @NonNull String key, @NonNull String groupName) {
         return commandManager.submitNewCommand(
                 XInfoConsumers,
                 new String[] {key, groupName},
+                response -> castArray(handleArrayResponse(response), Map.class));
+    }
+
+    @Override
+    public CompletableFuture<Map<GlideString, Object>[]> xinfoConsumers(
+            @NonNull GlideString key, @NonNull GlideString groupName) {
+        return commandManager.submitNewCommand(
+                XInfoConsumers,
+                new GlideString[] {key, groupName},
                 response -> castArray(handleArrayResponse(response), Map.class));
     }
 

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -1288,7 +1288,7 @@ public interface StreamBaseCommands {
      *     attributes of a consumer group for the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] groups = client.xinfoGroups("key").get();
+     * Map<String, Object>[] groups = client.xinfoGroups("key").get();
      * for (int i = 0; i < groups.length; i ++) {
      *     System.out.println("Info of group: " + groups[0].get("name"));
      *     System.out.println("\tname: " + groups[0].get("name"));
@@ -1312,15 +1312,15 @@ public interface StreamBaseCommands {
      *     attributes of a consumer group for the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] groups = client.xinfoGroups(gs("key")).get();
+     * Map<GlideString, Object>[] groups = client.xinfoGroups(gs("key")).get();
      * for (int i = 0; i < groups.length; i ++) {
-     *     System.out.println("Info of group: " + groups[0].get("name"));
-     *     System.out.println("\tname: " + groups[0].get("name"));
-     *     System.out.println("\tconsumers: " + groups[0].get("consumers"));
-     *     System.out.println("\tpending: " + groups[0].get("pending"));
-     *     System.out.println("\tlast-delivered-id: " + groups[0].get("last-delivered-id"));
-     *     System.out.println("\tentries-read: " + groups[0].get("entries-read"));
-     *     System.out.println("\tlag: " + groups[0].get("lag"));
+     *     System.out.println("Info of group: " + groups[0].get(gs("name")));
+     *     System.out.println("\tname: " + groups[0].get(gs("name")));
+     *     System.out.println("\tconsumers: " + groups[0].get(gs("consumers")));
+     *     System.out.println("\tpending: " + groups[0].get(gs("pending")));
+     *     System.out.println("\tlast-delivered-id: " + groups[0].get(gs("last-delivered-id")));
+     *     System.out.println("\tentries-read: " + groups[0].get(gs("entries-read")));
+     *     System.out.println("\tlag: " + groups[0].get(gs("lag")));
      * }
      * }</pre>
      */
@@ -1337,7 +1337,7 @@ public interface StreamBaseCommands {
      *     of a consumer for the given consumer group of the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] consumers = client.xinfoConsumers("key", "groupName").get();
+     * Map<String, Object>[] consumers = client.xinfoConsumers("key", "groupName").get();
      * for (int i = 0; i < consumers.length; i ++) {
      *     System.out.println("Info of consumer: " + consumers[0].get("name"));
      *     System.out.println("\tname: " + consumers[0].get("name"));
@@ -1360,13 +1360,13 @@ public interface StreamBaseCommands {
      *     of a consumer for the given consumer group of the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] consumers = client.xinfoConsumers(gs("key"), gs("groupName")).get();
+     * Map<GlideString, Object>[] consumers = client.xinfoConsumers(gs("key"), gs("groupName")).get();
      * for (int i = 0; i < consumers.length; i ++) {
-     *     System.out.println("Info of consumer: " + consumers[0].get("name"));
-     *     System.out.println("\tname: " + consumers[0].get("name"));
-     *     System.out.println("\tpending: " + consumers[0].get("pending"));
-     *     System.out.println("\tidle: " + consumers[0].get("idle"));
-     *     System.out.println("\tinactive: " + consumers[0].get("inactive"));
+     *     System.out.println("Info of consumer: " + consumers[0].get(gs("name")));
+     *     System.out.println("\tname: " + consumers[0].get(gs("name")));
+     *     System.out.println("\tpending: " + consumers[0].get(gs("pending")));
+     *     System.out.println("\tidle: " + consumers[0].get(gs("idle")));
+     *     System.out.println("\tinactive: " + consumers[0].get(gs("inactive")));
      * }
      * }</pre>
      */

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -15,6 +15,7 @@ import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import lombok.NonNull;
 
 /**
  * Supports commands and transactions for the "Stream Commands" group for standalone and cluster
@@ -1277,4 +1278,52 @@ public interface StreamBaseCommands {
             long minIdleTime,
             GlideString[] ids,
             StreamClaimOptions options);
+
+    /**
+     * Returns the list of all consumer groups and their attributes for the stream stored at <code>key
+     * </code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @return An <code>Array</code> of mappings, where each mapping represents the attributes of a
+     *     consumer group for the stream at <code>key</code>.
+     * @example
+     *     <pre>{@code
+     * Map[] groups = client.xinfoGroups(key).get();
+     * for (int i = 0; i < groups.length; i ++) {
+     *     System.out.println("Info of group: " + groups[0].get("name"));
+     *     System.out.println("\tname: " + groups[0].get("name"));
+     *     System.out.println("\tconsumers: " + groups[0].get("consumers"));
+     *     System.out.println("\tpending: " + groups[0].get("pending"));
+     *     System.out.println("\tlast-delivered-id: " + groups[0].get("last-delivered-id"));
+     *     System.out.println("\tentries-read: " + groups[0].get("entries-read"));
+     *     System.out.println("\tlag: " + groups[0].get("lag"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<String, Object>[]> xinfoGroups(@NonNull String key);
+
+    /**
+     * Returns the list of all consumers and their attributes for the given consumer group of the
+     * stream stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The consumer group name.
+     * @return An <code>Array</code> of mappings, where each mapping contains the attributes of a
+     *     consumer for the given consumer group of the stream at <code>key</code>.
+     * @example
+     *     <pre>{@code
+     * Map[] consumers = client.xinfoConsumers(key, groupName1).get();
+     * for (int i = 0; i < consumers.length; i ++) {
+     *     System.out.println("Info of consumer: " + consumers[0].get("name"));
+     *     System.out.println("\tname: " + consumers[0].get("name"));
+     *     System.out.println("\tpending: " + consumers[0].get("pending"));
+     *     System.out.println("\tidle: " + consumers[0].get("idle"));
+     *     System.out.println("\tinactive: " + consumers[0].get("inactive"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<String, Object>[]> xinfoConsumers(
+            @NonNull String key, @NonNull String groupName);
 }

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -1304,6 +1304,30 @@ public interface StreamBaseCommands {
     CompletableFuture<Map<String, Object>[]> xinfoGroups(@NonNull String key);
 
     /**
+     * Returns the list of all consumer groups and their attributes for the stream stored at <code>key
+     * </code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @return An <code>Array</code> of mappings, where each mapping represents the attributes of a
+     *     consumer group for the stream at <code>key</code>.
+     * @example
+     *     <pre>{@code
+     * Map[] groups = client.xinfoGroups(key).get();
+     * for (int i = 0; i < groups.length; i ++) {
+     *     System.out.println("Info of group: " + groups[0].get("name"));
+     *     System.out.println("\tname: " + groups[0].get("name"));
+     *     System.out.println("\tconsumers: " + groups[0].get("consumers"));
+     *     System.out.println("\tpending: " + groups[0].get("pending"));
+     *     System.out.println("\tlast-delivered-id: " + groups[0].get("last-delivered-id"));
+     *     System.out.println("\tentries-read: " + groups[0].get("entries-read"));
+     *     System.out.println("\tlag: " + groups[0].get("lag"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> xinfoGroups(@NonNull GlideString key);
+
+    /**
      * Returns the list of all consumers and their attributes for the given consumer group of the
      * stream stored at <code>key</code>.
      *
@@ -1326,4 +1350,28 @@ public interface StreamBaseCommands {
      */
     CompletableFuture<Map<String, Object>[]> xinfoConsumers(
             @NonNull String key, @NonNull String groupName);
+
+    /**
+     * Returns the list of all consumers and their attributes for the given consumer group of the
+     * stream stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The consumer group name.
+     * @return An <code>Array</code> of mappings, where each mapping contains the attributes of a
+     *     consumer for the given consumer group of the stream at <code>key</code>.
+     * @example
+     *     <pre>{@code
+     * Map[] consumers = client.xinfoConsumers(key, groupName1).get();
+     * for (int i = 0; i < consumers.length; i ++) {
+     *     System.out.println("Info of consumer: " + consumers[0].get("name"));
+     *     System.out.println("\tname: " + consumers[0].get("name"));
+     *     System.out.println("\tpending: " + consumers[0].get("pending"));
+     *     System.out.println("\tidle: " + consumers[0].get("idle"));
+     *     System.out.println("\tinactive: " + consumers[0].get("inactive"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> xinfoConsumers(
+            @NonNull GlideString key, @NonNull GlideString groupName);
 }

--- a/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
+++ b/java/client/src/main/java/glide/api/commands/StreamBaseCommands.java
@@ -15,7 +15,6 @@ import glide.api.models.commands.stream.StreamReadOptions;
 import glide.api.models.commands.stream.StreamTrimOptions;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import lombok.NonNull;
 
 /**
  * Supports commands and transactions for the "Stream Commands" group for standalone and cluster
@@ -1285,11 +1284,11 @@ public interface StreamBaseCommands {
      *
      * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @return An <code>Array</code> of mappings, where each mapping represents the attributes of a
-     *     consumer group for the stream at <code>key</code>.
+     * @return An <code>Array</code> of <code>Maps</code>, where each mapping represents the
+     *     attributes of a consumer group for the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] groups = client.xinfoGroups(key).get();
+     * Map[] groups = client.xinfoGroups("key").get();
      * for (int i = 0; i < groups.length; i ++) {
      *     System.out.println("Info of group: " + groups[0].get("name"));
      *     System.out.println("\tname: " + groups[0].get("name"));
@@ -1301,7 +1300,7 @@ public interface StreamBaseCommands {
      * }
      * }</pre>
      */
-    CompletableFuture<Map<String, Object>[]> xinfoGroups(@NonNull String key);
+    CompletableFuture<Map<String, Object>[]> xinfoGroups(String key);
 
     /**
      * Returns the list of all consumer groups and their attributes for the stream stored at <code>key
@@ -1309,11 +1308,11 @@ public interface StreamBaseCommands {
      *
      * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @return An <code>Array</code> of mappings, where each mapping represents the attributes of a
-     *     consumer group for the stream at <code>key</code>.
+     * @return An <code>Array</code> of <code>Maps</code>, where each mapping represents the
+     *     attributes of a consumer group for the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] groups = client.xinfoGroups(key).get();
+     * Map[] groups = client.xinfoGroups(gs("key")).get();
      * for (int i = 0; i < groups.length; i ++) {
      *     System.out.println("Info of group: " + groups[0].get("name"));
      *     System.out.println("\tname: " + groups[0].get("name"));
@@ -1325,7 +1324,7 @@ public interface StreamBaseCommands {
      * }
      * }</pre>
      */
-    CompletableFuture<Map<GlideString, Object>[]> xinfoGroups(@NonNull GlideString key);
+    CompletableFuture<Map<GlideString, Object>[]> xinfoGroups(GlideString key);
 
     /**
      * Returns the list of all consumers and their attributes for the given consumer group of the
@@ -1334,11 +1333,11 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The consumer group name.
-     * @return An <code>Array</code> of mappings, where each mapping contains the attributes of a
-     *     consumer for the given consumer group of the stream at <code>key</code>.
+     * @return An <code>Array</code> of <code>Maps</code>, where each mapping contains the attributes
+     *     of a consumer for the given consumer group of the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] consumers = client.xinfoConsumers(key, groupName1).get();
+     * Map[] consumers = client.xinfoConsumers("key", "groupName").get();
      * for (int i = 0; i < consumers.length; i ++) {
      *     System.out.println("Info of consumer: " + consumers[0].get("name"));
      *     System.out.println("\tname: " + consumers[0].get("name"));
@@ -1348,8 +1347,7 @@ public interface StreamBaseCommands {
      * }
      * }</pre>
      */
-    CompletableFuture<Map<String, Object>[]> xinfoConsumers(
-            @NonNull String key, @NonNull String groupName);
+    CompletableFuture<Map<String, Object>[]> xinfoConsumers(String key, String groupName);
 
     /**
      * Returns the list of all consumers and their attributes for the given consumer group of the
@@ -1358,11 +1356,11 @@ public interface StreamBaseCommands {
      * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The consumer group name.
-     * @return An <code>Array</code> of mappings, where each mapping contains the attributes of a
-     *     consumer for the given consumer group of the stream at <code>key</code>.
+     * @return An <code>Array</code> of <code>Maps</code>, where each mapping contains the attributes
+     *     of a consumer for the given consumer group of the stream at <code>key</code>.
      * @example
      *     <pre>{@code
-     * Map[] consumers = client.xinfoConsumers(key, groupName1).get();
+     * Map[] consumers = client.xinfoConsumers(gs("key"), gs("groupName")).get();
      * for (int i = 0; i < consumers.length; i ++) {
      *     System.out.println("Info of consumer: " + consumers[0].get("name"));
      *     System.out.println("\tname: " + consumers[0].get("name"));
@@ -1373,5 +1371,5 @@ public interface StreamBaseCommands {
      * }</pre>
      */
     CompletableFuture<Map<GlideString, Object>[]> xinfoConsumers(
-            @NonNull GlideString key, @NonNull GlideString groupName);
+            GlideString key, GlideString groupName);
 }

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -4052,10 +4052,10 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *
      * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
      * @param key The key of the stream.
-     * @return Command Response - An <code>Array</code> of mappings, where each mapping represents the
-     *     attributes of a consumer group for the stream at <code>key</code>.
+     * @return Command Response - An <code>Array</code> of <code>Maps</code>, where each mapping
+     *     represents the attributes of a consumer group for the stream at <code>key</code>.
      */
-    public T xinfoGroups(@NonNull String key) {
+    public <ArgType> T xinfoGroups(@NonNull String key) {
         protobufTransaction.addCommands(buildCommand(XInfoGroups, newArgsBuilder().add(key)));
         return getThis();
     }
@@ -4067,10 +4067,11 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
      * @param key The key of the stream.
      * @param groupName The consumer group name.
-     * @return Command Response - An <code>Array</code> of mappings, where each mapping contains the
-     *     attributes of a consumer for the given consumer group of the stream at <code>key</code>.
+     * @return Command Response - An <code>Array</code> of <code>Maps</code>, where each mapping
+     *     contains the attributes of a consumer for the given consumer group of the stream at <code>
+     *     key</code>.
      */
-    public T xinfoConsumers(@NonNull String key, @NonNull String groupName) {
+    public <ArgType> T xinfoConsumers(@NonNull String key, @NonNull String groupName) {
         protobufTransaction.addCommands(
                 buildCommand(XInfoConsumers, newArgsBuilder().add(key).add(groupName)));
         return getThis();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -170,6 +170,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsu
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoConsumers;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoGroups;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -4041,6 +4043,35 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
                                 .add(ids)
                                 .add(options.toArgs())
                                 .add(JUST_ID_REDIS_API)));
+        return getThis();
+    }
+
+    /**
+     * Returns the list of all consumer groups and their attributes for the stream stored at <code>key
+     * </code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-groups/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @return Command Response - An <code>Array</code> of mappings, where each mapping represents the
+     *     attributes of a consumer group for the stream at <code>key</code>.
+     */
+    public T xinfoGroups(@NonNull String key) {
+        protobufTransaction.addCommands(buildCommand(XInfoGroups, buildArgs(key)));
+        return getThis();
+    }
+
+    /**
+     * Returns the list of all consumers and their attributes for the given consumer group of the
+     * stream stored at <code>key</code>.
+     *
+     * @see <a href="https://valkey.io/commands/xinfo-consumers/">valkey.io</a> for details.
+     * @param key The key of the stream.
+     * @param groupName The consumer group name.
+     * @return Command Response - An <code>Array</code> of mappings, where each mapping contains the
+     *     attributes of a consumer for the given consumer group of the stream at <code>key</code>.
+     */
+    public T xinfoConsumers(@NonNull String key, @NonNull String groupName) {
+        protobufTransaction.addCommands(buildCommand(XInfoConsumers, buildArgs(key, groupName)));
         return getThis();
     }
 

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -4055,7 +4055,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      * @return Command Response - An <code>Array</code> of <code>Maps</code>, where each mapping
      *     represents the attributes of a consumer group for the stream at <code>key</code>.
      */
-    public <ArgType> T xinfoGroups(@NonNull String key) {
+    public <ArgType> T xinfoGroups(@NonNull ArgType key) {
         protobufTransaction.addCommands(buildCommand(XInfoGroups, newArgsBuilder().add(key)));
         return getThis();
     }
@@ -4071,7 +4071,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     contains the attributes of a consumer for the given consumer group of the stream at <code>
      *     key</code>.
      */
-    public <ArgType> T xinfoConsumers(@NonNull String key, @NonNull String groupName) {
+    public <ArgType> T xinfoConsumers(@NonNull ArgType key, @NonNull ArgType groupName) {
         protobufTransaction.addCommands(
                 buildCommand(XInfoConsumers, newArgsBuilder().add(key).add(groupName)));
         return getThis();

--- a/java/client/src/main/java/glide/api/models/BaseTransaction.java
+++ b/java/client/src/main/java/glide/api/models/BaseTransaction.java
@@ -4056,7 +4056,7 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     attributes of a consumer group for the stream at <code>key</code>.
      */
     public T xinfoGroups(@NonNull String key) {
-        protobufTransaction.addCommands(buildCommand(XInfoGroups, buildArgs(key)));
+        protobufTransaction.addCommands(buildCommand(XInfoGroups, newArgsBuilder().add(key)));
         return getThis();
     }
 
@@ -4071,7 +4071,8 @@ public abstract class BaseTransaction<T extends BaseTransaction<T>> {
      *     attributes of a consumer for the given consumer group of the stream at <code>key</code>.
      */
     public T xinfoConsumers(@NonNull String key, @NonNull String groupName) {
-        protobufTransaction.addCommands(buildCommand(XInfoConsumers, buildArgs(key, groupName)));
+        protobufTransaction.addCommands(
+                buildCommand(XInfoConsumers, newArgsBuilder().add(key).add(groupName)));
         return getThis();
     }
 

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -13296,17 +13296,17 @@ public class RedisClientTest {
         Map<GlideString, Object>[] mockResult =
                 new Map[] {
                     Map.of(
-                            "name",
-                            "groupName",
-                            "consumers",
+                            gs("name"),
+                            gs("groupName"),
+                            gs("consumers"),
                             2,
-                            "pending",
+                            gs("pending"),
                             2,
-                            "last-delivered-id",
-                            "1638126030001-0",
-                            "entries-read",
+                            gs("last-delivered-id"),
+                            gs("1638126030001-0"),
+                            gs("entries-read"),
                             2,
-                            "lag",
+                            gs("lag"),
                             2)
                 };
 
@@ -13365,7 +13365,15 @@ public class RedisClientTest {
         GlideString[] arguments = {key, groupName};
         Map<GlideString, Object>[] mockResult =
                 new Map[] {
-                    Map.of("name", "groupName", "pending", 2, "idle", 9104628, "inactive", 18104698)
+                    Map.of(
+                            gs("name"),
+                            gs("groupName"),
+                            gs("pending"),
+                            2,
+                            gs("idle"),
+                            9104628,
+                            gs("inactive"),
+                            18104698)
                 };
 
         CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -241,6 +241,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsu
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoConsumers;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoGroups;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -13243,5 +13245,74 @@ public class RedisClientTest {
         // Verify
         assertEquals(testResponse, response);
         assertEquals(expected, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xinfoGroups_returns_success() {
+        // setup
+        String key = "testKey";
+        String[] arguments = {key};
+        Map<String, Object>[] mockResult =
+                new Map[] {
+                    Map.of(
+                            "name",
+                            "groupName",
+                            "consumers",
+                            2,
+                            "pending",
+                            2,
+                            "last-delivered-id",
+                            "1638126030001-0",
+                            "entries-read",
+                            2,
+                            "lag",
+                            2)
+                };
+
+        CompletableFuture<Map<String, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(mockResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Object>[]>submitNewCommand(
+                        eq(XInfoGroups), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, Object>[]> response = service.xinfoGroups(key);
+        Map<String, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(mockResult, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xinfoConsumers_returns_success() {
+        // setup
+        String key = "testKey";
+        String groupName = "groupName";
+        String[] arguments = {key, groupName};
+        Map<String, Object>[] mockResult =
+                new Map[] {
+                    Map.of("name", "groupName", "pending", 2, "idle", 9104628, "inactive", 18104698)
+                };
+
+        CompletableFuture<Map<String, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(mockResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<String, Object>[]>submitNewCommand(
+                        eq(XInfoConsumers), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<String, Object>[]> response = service.xinfoConsumers(key, groupName);
+        Map<String, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(mockResult, payload);
     }
 }

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -13289,6 +13289,46 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void xinfoGroups_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        GlideString[] arguments = {key};
+        Map<GlideString, Object>[] mockResult =
+                new Map[] {
+                    Map.of(
+                            "name",
+                            "groupName",
+                            "consumers",
+                            2,
+                            "pending",
+                            2,
+                            "last-delivered-id",
+                            "1638126030001-0",
+                            "entries-read",
+                            2,
+                            "lag",
+                            2)
+                };
+
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(mockResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+                        eq(XInfoGroups), eq(arguments), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response = service.xinfoGroups(key);
+        Map<GlideString, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(mockResult, payload);
+    }
+
+    @SneakyThrows
+    @Test
     public void xinfoConsumers_returns_success() {
         // setup
         String key = "testKey";
@@ -13310,6 +13350,35 @@ public class RedisClientTest {
         // exercise
         CompletableFuture<Map<String, Object>[]> response = service.xinfoConsumers(key, groupName);
         Map<String, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(mockResult, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void xinfoConsumers_binary_returns_success() {
+        // setup
+        GlideString key = gs("testKey");
+        GlideString groupName = gs("groupName");
+        GlideString[] arguments = {key, groupName};
+        Map<GlideString, Object>[] mockResult =
+            new Map[] {
+                Map.of("name", "groupName", "pending", 2, "idle", 9104628, "inactive", 18104698)
+            };
+
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(mockResult);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+            eq(XInfoConsumers), eq(arguments), any()))
+            .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response = service.xinfoConsumers(key, groupName);
+        Map<GlideString, Object>[] payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -13364,17 +13364,17 @@ public class RedisClientTest {
         GlideString groupName = gs("groupName");
         GlideString[] arguments = {key, groupName};
         Map<GlideString, Object>[] mockResult =
-            new Map[] {
-                Map.of("name", "groupName", "pending", 2, "idle", 9104628, "inactive", 18104698)
-            };
+                new Map[] {
+                    Map.of("name", "groupName", "pending", 2, "idle", 9104628, "inactive", 18104698)
+                };
 
         CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
         testResponse.complete(mockResult);
 
         // match on protobuf request
         when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
-            eq(XInfoConsumers), eq(arguments), any()))
-            .thenReturn(testResponse);
+                        eq(XInfoConsumers), eq(arguments), any()))
+                .thenReturn(testResponse);
 
         // exercise
         CompletableFuture<Map<GlideString, Object>[]> response = service.xinfoConsumers(key, groupName);

--- a/java/client/src/test/java/glide/api/models/TransactionTests.java
+++ b/java/client/src/test/java/glide/api/models/TransactionTests.java
@@ -196,6 +196,8 @@ import static redis_request.RedisRequestOuterClass.RequestType.XGroupCreateConsu
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDelConsumer;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupDestroy;
 import static redis_request.RedisRequestOuterClass.RequestType.XGroupSetId;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoConsumers;
+import static redis_request.RedisRequestOuterClass.RequestType.XInfoGroups;
 import static redis_request.RedisRequestOuterClass.RequestType.XLen;
 import static redis_request.RedisRequestOuterClass.RequestType.XPending;
 import static redis_request.RedisRequestOuterClass.RequestType.XRange;
@@ -951,6 +953,12 @@ public class TransactionTests {
                                 "5",
                                 FORCE_REDIS_API,
                                 JUST_ID_REDIS_API)));
+
+        transaction.xinfoGroups("key");
+        results.add(Pair.of(XInfoGroups, buildArgs("key")));
+
+        transaction.xinfoConsumers("key", "groupName");
+        results.add(Pair.of(XInfoConsumers, buildArgs("key", "groupName")));
 
         transaction.time();
         results.add(Pair.of(Time, buildArgs()));

--- a/java/integTest/src/test/java/glide/SharedCommandTests.java
+++ b/java/integTest/src/test/java/glide/SharedCommandTests.java
@@ -5463,9 +5463,9 @@ public class SharedCommandTests {
         assertEquals(streamId1_2, group1Info.get("last-delivered-id"));
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             assertEquals(
-                3L, group1Info.get("entries-read")); // We have read stream entries 1-0, 1-1, and 1-2
+                    3L, group1Info.get("entries-read")); // We have read stream entries 1-0, 1-1, and 1-2
             assertEquals(
-                1L, group1Info.get("lag")); // We still have not read one entry in the stream, entry 1-3
+                    1L, group1Info.get("lag")); // We still have not read one entry in the stream, entry 1-3
         }
 
         // Verify xgroup_set_id effects the returned value from xinfo_groups

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -76,25 +76,19 @@ public class TransactionTestUtilities {
     /** Generate test samples for parametrized tests. Could be routed to random node. */
     public static Stream<Arguments> getCommonTransactionBuilders() {
         return Stream.of(
-                                Arguments.of(
-                                        "Generic Commands", (TransactionBuilder)
-                 TransactionTestUtilities::genericCommands),
-                                Arguments.of(
-                                        "String Commands", (TransactionBuilder)
-                 TransactionTestUtilities::stringCommands),
-                                Arguments.of("Hash Commands", (TransactionBuilder)
-                 TransactionTestUtilities::hashCommands),
-                                Arguments.of("List Commands", (TransactionBuilder)
-                 TransactionTestUtilities::listCommands),
-                                Arguments.of("Set Commands", (TransactionBuilder)
-                 TransactionTestUtilities::setCommands),
-                                Arguments.of(
-                                        "Sorted Set Commands",
-                                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
-                                Arguments.of(
-                                        "HyperLogLog Commands",
-                                        (TransactionBuilder)
-                 TransactionTestUtilities::hyperLogLogCommands),
+                Arguments.of(
+                        "Generic Commands", (TransactionBuilder) TransactionTestUtilities::genericCommands),
+                Arguments.of(
+                        "String Commands", (TransactionBuilder) TransactionTestUtilities::stringCommands),
+                Arguments.of("Hash Commands", (TransactionBuilder) TransactionTestUtilities::hashCommands),
+                Arguments.of("List Commands", (TransactionBuilder) TransactionTestUtilities::listCommands),
+                Arguments.of("Set Commands", (TransactionBuilder) TransactionTestUtilities::setCommands),
+                Arguments.of(
+                        "Sorted Set Commands",
+                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
+                Arguments.of(
+                        "HyperLogLog Commands",
+                        (TransactionBuilder) TransactionTestUtilities::hyperLogLogCommands),
                 Arguments.of(
                         "Stream Commands", (TransactionBuilder) TransactionTestUtilities::streamCommands),
                 Arguments.of(

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -76,25 +76,25 @@ public class TransactionTestUtilities {
     /** Generate test samples for parametrized tests. Could be routed to random node. */
     public static Stream<Arguments> getCommonTransactionBuilders() {
         return Stream.of(
-                //                Arguments.of(
-                //                        "Generic Commands", (TransactionBuilder)
-                // TransactionTestUtilities::genericCommands),
-                //                Arguments.of(
-                //                        "String Commands", (TransactionBuilder)
-                // TransactionTestUtilities::stringCommands),
-                //                Arguments.of("Hash Commands", (TransactionBuilder)
-                // TransactionTestUtilities::hashCommands),
-                //                Arguments.of("List Commands", (TransactionBuilder)
-                // TransactionTestUtilities::listCommands),
-                //                Arguments.of("Set Commands", (TransactionBuilder)
-                // TransactionTestUtilities::setCommands),
-                //                Arguments.of(
-                //                        "Sorted Set Commands",
-                //                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
-                //                Arguments.of(
-                //                        "HyperLogLog Commands",
-                //                        (TransactionBuilder)
-                // TransactionTestUtilities::hyperLogLogCommands),
+                                Arguments.of(
+                                        "Generic Commands", (TransactionBuilder)
+                 TransactionTestUtilities::genericCommands),
+                                Arguments.of(
+                                        "String Commands", (TransactionBuilder)
+                 TransactionTestUtilities::stringCommands),
+                                Arguments.of("Hash Commands", (TransactionBuilder)
+                 TransactionTestUtilities::hashCommands),
+                                Arguments.of("List Commands", (TransactionBuilder)
+                 TransactionTestUtilities::listCommands),
+                                Arguments.of("Set Commands", (TransactionBuilder)
+                 TransactionTestUtilities::setCommands),
+                                Arguments.of(
+                                        "Sorted Set Commands",
+                                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
+                                Arguments.of(
+                                        "HyperLogLog Commands",
+                                        (TransactionBuilder)
+                 TransactionTestUtilities::hyperLogLogCommands),
                 Arguments.of(
                         "Stream Commands", (TransactionBuilder) TransactionTestUtilities::streamCommands),
                 Arguments.of(

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -76,19 +76,25 @@ public class TransactionTestUtilities {
     /** Generate test samples for parametrized tests. Could be routed to random node. */
     public static Stream<Arguments> getCommonTransactionBuilders() {
         return Stream.of(
-                Arguments.of(
-                        "Generic Commands", (TransactionBuilder) TransactionTestUtilities::genericCommands),
-                Arguments.of(
-                        "String Commands", (TransactionBuilder) TransactionTestUtilities::stringCommands),
-                Arguments.of("Hash Commands", (TransactionBuilder) TransactionTestUtilities::hashCommands),
-                Arguments.of("List Commands", (TransactionBuilder) TransactionTestUtilities::listCommands),
-                Arguments.of("Set Commands", (TransactionBuilder) TransactionTestUtilities::setCommands),
-                Arguments.of(
-                        "Sorted Set Commands",
-                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
-                Arguments.of(
-                        "HyperLogLog Commands",
-                        (TransactionBuilder) TransactionTestUtilities::hyperLogLogCommands),
+                //                Arguments.of(
+                //                        "Generic Commands", (TransactionBuilder)
+                // TransactionTestUtilities::genericCommands),
+                //                Arguments.of(
+                //                        "String Commands", (TransactionBuilder)
+                // TransactionTestUtilities::stringCommands),
+                //                Arguments.of("Hash Commands", (TransactionBuilder)
+                // TransactionTestUtilities::hashCommands),
+                //                Arguments.of("List Commands", (TransactionBuilder)
+                // TransactionTestUtilities::listCommands),
+                //                Arguments.of("Set Commands", (TransactionBuilder)
+                // TransactionTestUtilities::setCommands),
+                //                Arguments.of(
+                //                        "Sorted Set Commands",
+                //                        (TransactionBuilder) TransactionTestUtilities::sortedSetCommands),
+                //                Arguments.of(
+                //                        "HyperLogLog Commands",
+                //                        (TransactionBuilder)
+                // TransactionTestUtilities::hyperLogLogCommands),
                 Arguments.of(
                         "Stream Commands", (TransactionBuilder) TransactionTestUtilities::streamCommands),
                 Arguments.of(
@@ -818,6 +824,13 @@ public class TransactionTestUtilities {
         final String consumer1 = "{consumer}-1-" + UUID.randomUUID();
         final String streamKey2 = "{streamKey}-2-" + UUID.randomUUID();
         final String groupName3 = "{groupName}-2-" + UUID.randomUUID();
+        final HashMap xinfoGroupsExpected = new HashMap();
+        xinfoGroupsExpected.put("last-delivered-id", "0-2");
+        xinfoGroupsExpected.put("lag", 1L);
+        xinfoGroupsExpected.put("pending", 0L);
+        xinfoGroupsExpected.put("name", groupName1);
+        xinfoGroupsExpected.put("consumers", 0L);
+        xinfoGroupsExpected.put("entries-read", null);
 
         transaction
                 .xadd(streamKey1, Map.of("field1", "value1"), StreamAddOptions.builder().id("0-1").build())
@@ -832,6 +845,8 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
                 .xgroupCreate(streamKey1, groupName1, "0-2")
+                .xinfoGroups(streamKey1)
+                .xinfoConsumers(streamKey1, groupName1)
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
                 .xgroupCreateConsumer(streamKey1, groupName1, consumer1)
@@ -898,6 +913,8 @@ public class TransactionTestUtilities {
                     "0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1", 1l)
             1L, // xtrim(streamKey1, new MinId(true, "0-2"))
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
+            new Map[] {xinfoGroupsExpected}, // .xinfoGroups(streamKey1)
+            new Map[] {}, // .xinfoConsumers(streamKey1, groupName1)
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
             OK, // xgroupSetId(streamKey1, groupName1, "0-2")

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -813,18 +813,12 @@ public class TransactionTestUtilities {
 
     private static Object[] streamCommands(BaseTransaction<?> transaction) {
         final String streamKey1 = "{streamKey}-1-" + UUID.randomUUID();
+        final String streamKey2 = "{streamKey}-2-" + UUID.randomUUID();
+        final String streamKey3 = "{streamKey}-3-" + UUID.randomUUID();
         final String groupName1 = "{groupName}-1-" + UUID.randomUUID();
         final String groupName2 = "{groupName}-2-" + UUID.randomUUID();
-        final String consumer1 = "{consumer}-1-" + UUID.randomUUID();
-        final String streamKey2 = "{streamKey}-2-" + UUID.randomUUID();
         final String groupName3 = "{groupName}-2-" + UUID.randomUUID();
-        final HashMap xinfoGroupsExpected = new HashMap();
-        xinfoGroupsExpected.put("last-delivered-id", "0-2");
-        xinfoGroupsExpected.put("lag", 1L);
-        xinfoGroupsExpected.put("pending", 0L);
-        xinfoGroupsExpected.put("name", groupName1);
-        xinfoGroupsExpected.put("consumers", 0L);
-        xinfoGroupsExpected.put("entries-read", null);
+        final String consumer1 = "{consumer}-1-" + UUID.randomUUID();
 
         transaction
                 .xadd(streamKey1, Map.of("field1", "value1"), StreamAddOptions.builder().id("0-1").build())
@@ -839,7 +833,6 @@ public class TransactionTestUtilities {
                 .xrevrange(streamKey1, IdBound.of("0-1"), IdBound.of("0-1"), 1L)
                 .xtrim(streamKey1, new MinId(true, "0-2"))
                 .xgroupCreate(streamKey1, groupName1, "0-2")
-                .xinfoGroups(streamKey1)
                 .xinfoConsumers(streamKey1, groupName1)
                 .xgroupCreate(
                         streamKey1, groupName2, "0-0", StreamGroupOptions.builder().makeStream().build())
@@ -878,7 +871,10 @@ public class TransactionTestUtilities {
                 .xgroupDelConsumer(streamKey1, groupName1, consumer1)
                 .xgroupDestroy(streamKey1, groupName1)
                 .xgroupDestroy(streamKey1, groupName2)
-                .xdel(streamKey1, new String[] {"0-3", "0-5"});
+                .xdel(streamKey1, new String[] {"0-3", "0-5"})
+                .xadd(streamKey3, Map.of("f0", "v0"), StreamAddOptions.builder().id("1-0").build())
+                .xgroupCreate(streamKey3, groupName3, "0")
+                .xinfoGroups(streamKey1);
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {
             transaction
@@ -907,7 +903,6 @@ public class TransactionTestUtilities {
                     "0-1", new String[][] {{"field1", "value1"}}), // .xrevrange(streamKey1, "0-1", "0-1", 1l)
             1L, // xtrim(streamKey1, new MinId(true, "0-2"))
             OK, // xgroupCreate(streamKey1, groupName1, "0-0")
-            new Map[] {xinfoGroupsExpected}, // .xinfoGroups(streamKey1)
             new Map[] {}, // .xinfoConsumers(streamKey1, groupName1)
             OK, // xgroupCreate(streamKey1, groupName1, "0-0", options)
             true, // xgroupCreateConsumer(streamKey1, groupName1, consumer1)
@@ -936,7 +931,11 @@ public class TransactionTestUtilities {
             0L, // xgroupDelConsumer(streamKey1, groupName1, consumer1)
             true, // xgroupDestroy(streamKey1, groupName1)
             true, // xgroupDestroy(streamKey1, groupName2)
-            1L, // .xdel(streamKey1, new String[] {"0-1", "0-5"});
+            1L, // .xdel(streamKey1, new String[] {"0-1", "0-5"})
+            "1-0", // xadd(streamKey3, Map.of("f0", "v0"), id("1-0"))
+            OK, // xgroupCreate(streamKey3, groupName3, "0")
+            new Map[] {}, // xinfoGroups(streamKey3)
+
         };
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {

--- a/java/integTest/src/test/java/glide/TransactionTestUtilities.java
+++ b/java/integTest/src/test/java/glide/TransactionTestUtilities.java
@@ -935,7 +935,6 @@ public class TransactionTestUtilities {
             "1-0", // xadd(streamKey3, Map.of("f0", "v0"), id("1-0"))
             OK, // xgroupCreate(streamKey3, groupName3, "0")
             new Map[] {}, // xinfoGroups(streamKey3)
-
         };
 
         if (REDIS_VERSION.isGreaterThanOrEqualTo("7.0.0")) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://valkey.io/commands/xinfo-groups/
https://valkey.io/commands/xinfo-consumers/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
