### PR TITLE
Add function list binary output support

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -126,7 +126,7 @@ jobs:
                     - 17
         runs-on: ubuntu-latest
         container: amazonlinux:latest
-        timeout-minutes: 15
+        timeout-minutes: 20
         steps:
             - name: Install git
               run: |

--- a/java/client/src/main/java/glide/api/BaseClient.java
+++ b/java/client/src/main/java/glide/api/BaseClient.java
@@ -640,6 +640,18 @@ public abstract class BaseClient
         return data;
     }
 
+    /** Process a <code>FUNCTION LIST</code> standalone response. */
+    @SuppressWarnings("unchecked")
+    protected Map<GlideString, Object>[] handleFunctionListResponseBinary(Object[] response) {
+        Map<GlideString, Object>[] data = castArray(response, Map.class);
+        for (Map<GlideString, Object> libraryInfo : data) {
+            Object[] functions = (Object[]) libraryInfo.get(gs("functions"));
+            var functionInfo = castArray(functions, Map.class);
+            libraryInfo.put(gs("functions"), functionInfo);
+        }
+        return data;
+    }
+
     /** Process a <code>FUNCTION STATS</code> standalone response. */
     protected Map<String, Map<String, Object>> handleFunctionStatsResponse(
             Map<String, Map<String, Object>> response) {

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -296,7 +296,7 @@ public class RedisClient extends BaseClient
     public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                new ArgsBuilder().addIf(WITH_CODE_REDIS_API, withCode).toArray(),
                 response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 
@@ -316,11 +316,11 @@ public class RedisClient extends BaseClient
             @NonNull GlideString libNamePattern, boolean withCode) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode
-                        ? new GlideString[] {
-                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
-                        }
-                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                new ArgsBuilder()
+                        .add(LIBRARY_NAME_REDIS_API)
+                        .add(libNamePattern)
+                        .addIf(WITH_CODE_REDIS_API, withCode)
+                        .toArray(),
                 response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 

--- a/java/client/src/main/java/glide/api/RedisClient.java
+++ b/java/client/src/main/java/glide/api/RedisClient.java
@@ -292,6 +292,14 @@ public class RedisClient extends BaseClient
     }
 
     @Override
+    public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
+    }
+
+    @Override
     public CompletableFuture<Map<String, Object>[]> functionList(
             @NonNull String libNamePattern, boolean withCode) {
         return commandManager.submitNewCommand(
@@ -300,6 +308,19 @@ public class RedisClient extends BaseClient
                         ? new String[] {LIBRARY_NAME_REDIS_API, libNamePattern, WITH_CODE_REDIS_API}
                         : new String[] {LIBRARY_NAME_REDIS_API, libNamePattern},
                 response -> handleFunctionListResponse(handleArrayResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(
+            @NonNull GlideString libNamePattern, boolean withCode) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode
+                        ? new GlideString[] {
+                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
+                        }
+                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -579,12 +579,39 @@ public class RedisClusterClient extends BaseClient
         }
     }
 
+    /** Process a <code>FUNCTION LIST</code> cluster response. */
+    protected ClusterValue<Map<GlideString, Object>[]> handleFunctionListResponseBinary(
+            Response response, Route route) {
+        if (route instanceof SingleNodeRoute) {
+            Map<GlideString, Object>[] data =
+                    handleFunctionListResponseBinary(handleArrayResponseBinary(response));
+            return ClusterValue.ofSingleValue(data);
+        } else {
+            // each `Object` is a `Map<GlideString, Object>[]` actually
+            Map<GlideString, Object> info = handleBinaryStringMapResponse(response);
+            Map<GlideString, Map<GlideString, Object>[]> data = new HashMap<>();
+            for (var nodeInfo : info.entrySet()) {
+                data.put(
+                        nodeInfo.getKey(), handleFunctionListResponseBinary((Object[]) nodeInfo.getValue()));
+            }
+            return ClusterValue.ofMultiValueBinary(data);
+        }
+    }
+
     @Override
     public CompletableFuture<Map<String, Object>[]> functionList(boolean withCode) {
         return commandManager.submitNewCommand(
                 FunctionList,
                 withCode ? new String[] {WITH_CODE_REDIS_API} : new String[0],
                 response -> handleFunctionListResponse(handleArrayResponse(response)));
+    }
+
+    @Override
+    public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 
     @Override
@@ -599,6 +626,19 @@ public class RedisClusterClient extends BaseClient
     }
 
     @Override
+    public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(
+            @NonNull GlideString libNamePattern, boolean withCode) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode
+                        ? new GlideString[] {
+                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
+                        }
+                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
+    }
+
+    @Override
     public CompletableFuture<ClusterValue<Map<String, Object>[]>> functionList(
             boolean withCode, @NonNull Route route) {
         return commandManager.submitNewCommand(
@@ -606,6 +646,15 @@ public class RedisClusterClient extends BaseClient
                 withCode ? new String[] {WITH_CODE_REDIS_API} : new String[0],
                 route,
                 response -> handleFunctionListResponse(response, route));
+    }
+
+    public CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> functionListBinary(
+            boolean withCode, @NonNull Route route) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                route,
+                response -> handleFunctionListResponseBinary(response, route));
     }
 
     @Override
@@ -618,6 +667,19 @@ public class RedisClusterClient extends BaseClient
                         : new String[] {LIBRARY_NAME_REDIS_API, libNamePattern},
                 route,
                 response -> handleFunctionListResponse(response, route));
+    }
+
+    public CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> functionListBinary(
+            @NonNull GlideString libNamePattern, boolean withCode, @NonNull Route route) {
+        return commandManager.submitNewCommand(
+                FunctionList,
+                withCode
+                        ? new GlideString[] {
+                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
+                        }
+                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                route,
+                response -> handleFunctionListResponseBinary(response, route));
     }
 
     @Override

--- a/java/client/src/main/java/glide/api/RedisClusterClient.java
+++ b/java/client/src/main/java/glide/api/RedisClusterClient.java
@@ -611,7 +611,7 @@ public class RedisClusterClient extends BaseClient
     public CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                new ArgsBuilder().addIf(WITH_CODE_REDIS_API, withCode).toArray(),
                 response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 
@@ -631,11 +631,11 @@ public class RedisClusterClient extends BaseClient
             @NonNull GlideString libNamePattern, boolean withCode) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode
-                        ? new GlideString[] {
-                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
-                        }
-                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                new ArgsBuilder()
+                        .add(LIBRARY_NAME_REDIS_API)
+                        .add(libNamePattern)
+                        .addIf(WITH_CODE_REDIS_API, withCode)
+                        .toArray(),
                 response -> handleFunctionListResponseBinary(handleArrayResponseBinary(response)));
     }
 
@@ -653,7 +653,7 @@ public class RedisClusterClient extends BaseClient
             boolean withCode, @NonNull Route route) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode ? new GlideString[] {gs(WITH_CODE_REDIS_API)} : new GlideString[0],
+                new ArgsBuilder().addIf(WITH_CODE_REDIS_API, withCode).toArray(),
                 route,
                 response -> handleFunctionListResponseBinary(response, route));
     }
@@ -674,11 +674,11 @@ public class RedisClusterClient extends BaseClient
             @NonNull GlideString libNamePattern, boolean withCode, @NonNull Route route) {
         return commandManager.submitNewCommand(
                 FunctionList,
-                withCode
-                        ? new GlideString[] {
-                            gs(LIBRARY_NAME_REDIS_API), libNamePattern, gs(WITH_CODE_REDIS_API)
-                        }
-                        : new GlideString[] {gs(LIBRARY_NAME_REDIS_API), libNamePattern},
+                new ArgsBuilder()
+                        .add(LIBRARY_NAME_REDIS_API)
+                        .add(libNamePattern)
+                        .addIf(WITH_CODE_REDIS_API, withCode)
+                        .toArray(),
                 route,
                 response -> handleFunctionListResponseBinary(response, route));
     }

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsClusterCommands.java
@@ -130,6 +130,32 @@ public interface ScriptingAndFunctionsClusterCommands {
      *
      * @since Redis 7.0 and above.
      * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @return Info about all libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * Map<GlideString, Object>[] response = client.functionList(true).get();
+     * for (Map<GlideString, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get(gs("library_name")), libraryInfo.get(gs("engine")));
+     *     Map<GlideString, Object>[] functions = (Map<GlideString, Object>[]) libraryInfo.get(gs("functions"));
+     *     for (Map<GlideString, Object> function : functions) {
+     *         Set<GlideString> flags = (Set<GlideString>) function.get(gs("flags"));
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get(gs("name")), gs(String.join(", ", flags)), function.get(gs("description")));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get(gs("library_code")));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode);
+
+    /**
+     * Returns information about the functions and libraries.<br>
+     * The command will be routed to a random node.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
      * @param libNamePattern A wildcard pattern for matching library names.
      * @param withCode Specifies whether to request the library code from the server or not.
      * @return Info about queried libraries and their functions.
@@ -150,6 +176,34 @@ public interface ScriptingAndFunctionsClusterCommands {
      * }</pre>
      */
     CompletableFuture<Map<String, Object>[]> functionList(String libNamePattern, boolean withCode);
+
+    /**
+     * Returns information about the functions and libraries.<br>
+     * The command will be routed to a random node.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param libNamePattern A wildcard pattern for matching library names.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @return Info about queried libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * Map<GlideString, Object>[] response = client.functionList(gs("myLib?_backup"), true).get();
+     * for (Map<GlideString, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get(gs("library_name")), libraryInfo.get(gs("engine")));
+     *     Map<GlideString, Object>[] functions = (Map<GlideString, Object>[]) libraryInfo.get(gs("functions"));
+     *     for (Map<GlideString, Object> function : functions) {
+     *         Set<GlideString> flags = (Set<GlideString>) function.get(gs("flags"));
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get(gs("name")), gs(String.join(", ", flags)), function.get(gs("description")));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get(gs("library_code")));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> functionListBinary(
+            GlideString libNamePattern, boolean withCode);
 
     /**
      * Returns information about the functions and libraries.
@@ -186,6 +240,36 @@ public interface ScriptingAndFunctionsClusterCommands {
      *
      * @since Redis 7.0 and above.
      * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @param route Specifies the routing configuration for the command. The client will route the
+     *     command to the nodes defined by <code>route</code>.
+     * @return Info about all libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * ClusterValue<Map<GlideString, Object>[]> response = client.functionList(true, ALL_NODES).get();
+     * for (String node : response.getMultiValue().keySet()) {
+     *   for (Map<GlideString, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get(gs("library_name")), libraryInfo.get(gs("engine")));
+     *     Map<GlideString, Object>[] functions = (Map<GlideString, Object>[]) libraryInfo.get(gs("functions"));
+     *     for (Map<GlideString, Object> function : functions) {
+     *         Set<GlideString> flags = (Set<GlideString>) function.get(gs("flags"));
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get(gs("name")), gs(String.join(", ", flags)), function.get(gs("description")));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get(gs("library_code")));
+     *   }
+     * }
+     * }</pre>
+     */
+    CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> functionListBinary(
+            boolean withCode, Route route);
+
+    /**
+     * Returns information about the functions and libraries.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
      * @param libNamePattern A wildcard pattern for matching library names.
      * @param withCode Specifies whether to request the library code from the server or not.
      * @param route Specifies the routing configuration for the command. The client will route the
@@ -211,6 +295,37 @@ public interface ScriptingAndFunctionsClusterCommands {
      */
     CompletableFuture<ClusterValue<Map<String, Object>[]>> functionList(
             String libNamePattern, boolean withCode, Route route);
+
+    /**
+     * Returns information about the functions and libraries.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param libNamePattern A wildcard pattern for matching library names.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @param route Specifies the routing configuration for the command. The client will route the
+     *     command to the nodes defined by <code>route</code>.
+     * @return Info about queried libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * ClusterValue<Map<String, Object>[]> response = client.functionList(gs("myLib?_backup"), true, ALL_NODES).get();
+     * for (String node : response.getMultiValue().keySet()) {
+     *   for (Map<GlideString, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get(gs("library_name")), libraryInfo.get(gs("engine")));
+     *     Map<GlideString, Object>[] functions = (Map<GlideString, Object>[]) libraryInfo.get(gs("functions"));
+     *     for (Map<GlideString, Object> function : functions) {
+     *         Set<GlideString> flags = (Set<GlideString>) function.get(gs("flags"));
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get(gs("name")), gs(String.join(", ", flags)), function.get(gs("description")));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get(gs("library_code")));
+     *   }
+     * }
+     * }</pre>
+     */
+    CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> functionListBinary(
+            GlideString libNamePattern, boolean withCode, Route route);
 
     /**
      * Deletes all function libraries.<br>

--- a/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
+++ b/java/client/src/main/java/glide/api/commands/ScriptingAndFunctionsCommands.java
@@ -82,6 +82,31 @@ public interface ScriptingAndFunctionsCommands {
      *
      * @since Redis 7.0 and above.
      * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @return Info about all libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * Map<String, Object>[] response = client.functionList(true).get();
+     * for (Map<String, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get("library_name"), libraryInfo.get("engine"));
+     *     Map<String, Object>[] functions = (Map<String, Object>[]) libraryInfo.get("functions");
+     *     for (Map<String, Object> function : functions) {
+     *         Set<String> flags = (Set<String>) function.get("flags");
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get("name"), String. join(", ", flags), function.get("description"));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get("library_code"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> functionListBinary(boolean withCode);
+
+    /**
+     * Returns information about the functions and libraries.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
      * @param libNamePattern A wildcard pattern for matching library names.
      * @param withCode Specifies whether to request the library code from the server or not.
      * @return Info about queried libraries and their functions.
@@ -102,6 +127,33 @@ public interface ScriptingAndFunctionsCommands {
      * }</pre>
      */
     CompletableFuture<Map<String, Object>[]> functionList(String libNamePattern, boolean withCode);
+
+    /**
+     * Returns information about the functions and libraries.
+     *
+     * @since Redis 7.0 and above.
+     * @see <a href="https://valkey.io/commands/function-list/">valkey.io</a> for details.
+     * @param libNamePattern A wildcard pattern for matching library names.
+     * @param withCode Specifies whether to request the library code from the server or not.
+     * @return Info about queried libraries and their functions.
+     * @example
+     *     <pre>{@code
+     * Map<String, Object>[] response = client.functionList("myLib?_backup", true).get();
+     * for (Map<String, Object> libraryInfo : response) {
+     *     System.out.printf("Server has library '%s' which runs on %s engine%n",
+     *         libraryInfo.get("library_name"), libraryInfo.get("engine"));
+     *     Map<String, Object>[] functions = (Map<String, Object>[]) libraryInfo.get("functions");
+     *     for (Map<String, Object> function : functions) {
+     *         Set<String> flags = (Set<String>) function.get("flags");
+     *         System.out.printf("Library has function '%s' with flags '%s' described as %s%n",
+     *             function.get("name"), String. join(", ", flags), function.get("description"));
+     *     }
+     *     System.out.printf("Library code:%n%s%n", libraryInfo.get("library_code"));
+     * }
+     * }</pre>
+     */
+    CompletableFuture<Map<GlideString, Object>[]> functionListBinary(
+            GlideString libNamePattern, boolean withCode);
 
     /**
      * Deletes all function libraries.

--- a/java/client/src/test/java/glide/api/RedisClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClientTest.java
@@ -8611,6 +8611,30 @@ public class RedisClientTest {
 
     @SneakyThrows
     @Test
+    public void functionList_binary_returns_success() {
+        // setup
+        GlideString[] args = new GlideString[0];
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+                        eq(FunctionList), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response = service.functionListBinary(false);
+        Map<GlideString, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
     public void functionList_with_pattern_returns_success() {
         // setup
         String pattern = "*";
@@ -8627,6 +8651,33 @@ public class RedisClientTest {
         // exercise
         CompletableFuture<Map<String, Object>[]> response = service.functionList(pattern, true);
         Map<String, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void functionList_binary_with_pattern_returns_success() {
+        // setup
+        GlideString pattern = gs("*");
+        GlideString[] args =
+                new GlideString[] {gs(LIBRARY_NAME_REDIS_API), pattern, gs(WITH_CODE_REDIS_API)};
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+                        eq(FunctionList), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response =
+                service.functionListBinary(pattern, true);
+        Map<GlideString, Object>[] payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/client/src/test/java/glide/api/RedisClusterClientTest.java
+++ b/java/client/src/test/java/glide/api/RedisClusterClientTest.java
@@ -1534,6 +1534,30 @@ public class RedisClusterClientTest {
 
     @SneakyThrows
     @Test
+    public void functionList_binary_returns_success() {
+        // setup
+        GlideString[] args = new GlideString[0];
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+                        eq(FunctionList), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response = service.functionListBinary(false);
+        Map<GlideString, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
     public void functionList_with_pattern_returns_success() {
         // setup
         String pattern = "*";
@@ -1550,6 +1574,33 @@ public class RedisClusterClientTest {
         // exercise
         CompletableFuture<Map<String, Object>[]> response = service.functionList(pattern, true);
         Map<String, Object>[] payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload);
+    }
+
+    @SneakyThrows
+    @Test
+    public void functionList_binary_with_pattern_returns_success() {
+        // setup
+        GlideString pattern = gs("*");
+        GlideString[] args =
+                new GlideString[] {gs(LIBRARY_NAME_REDIS_API), pattern, gs(WITH_CODE_REDIS_API)};
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<Map<GlideString, Object>[]> testResponse = new CompletableFuture<>();
+        testResponse.complete(value);
+
+        // match on protobuf request
+        when(commandManager.<Map<GlideString, Object>[]>submitNewCommand(
+                        eq(FunctionList), eq(args), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<Map<GlideString, Object>[]> response =
+                service.functionListBinary(pattern, true);
+        Map<GlideString, Object>[] payload = response.get();
 
         // verify
         assertEquals(testResponse, response);
@@ -1583,6 +1634,32 @@ public class RedisClusterClientTest {
 
     @SneakyThrows
     @Test
+    public void functionList_binary_with_route_returns_success() {
+        // setup
+        GlideString[] args = new GlideString[] {gs(WITH_CODE_REDIS_API)};
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> testResponse =
+                new CompletableFuture<>();
+        testResponse.complete(ClusterValue.ofSingleValue(value));
+
+        // match on protobuf request
+        when(commandManager.<ClusterValue<Map<GlideString, Object>[]>>submitNewCommand(
+                        eq(FunctionList), eq(args), eq(RANDOM), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> response =
+                service.functionListBinary(true, RANDOM);
+        ClusterValue<Map<GlideString, Object>[]> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload.getSingleValue());
+    }
+
+    @SneakyThrows
+    @Test
     public void functionList_with_pattern_and_route_returns_success() {
         // setup
         String pattern = "*";
@@ -1601,6 +1678,33 @@ public class RedisClusterClientTest {
         CompletableFuture<ClusterValue<Map<String, Object>[]>> response =
                 service.functionList(pattern, false, RANDOM);
         ClusterValue<Map<String, Object>[]> payload = response.get();
+
+        // verify
+        assertEquals(testResponse, response);
+        assertEquals(value, payload.getSingleValue());
+    }
+
+    @SneakyThrows
+    @Test
+    public void functionList_binary_with_pattern_and_route_returns_success() {
+        // setup
+        GlideString pattern = gs("*");
+        GlideString[] args = new GlideString[] {gs(LIBRARY_NAME_REDIS_API), pattern};
+        @SuppressWarnings("unchecked")
+        Map<GlideString, Object>[] value = new Map[0];
+        CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> testResponse =
+                new CompletableFuture<>();
+        testResponse.complete(ClusterValue.ofSingleValue(value));
+
+        // match on protobuf request
+        when(commandManager.<ClusterValue<Map<GlideString, Object>[]>>submitNewCommand(
+                        eq(FunctionList), eq(args), eq(RANDOM), any()))
+                .thenReturn(testResponse);
+
+        // exercise
+        CompletableFuture<ClusterValue<Map<GlideString, Object>[]>> response =
+                service.functionListBinary(pattern, false, RANDOM);
+        ClusterValue<Map<GlideString, Object>[]> payload = response.get();
 
         // verify
         assertEquals(testResponse, response);

--- a/java/integTest/src/test/java/glide/TestUtilities.java
+++ b/java/integTest/src/test/java/glide/TestUtilities.java
@@ -167,6 +167,56 @@ public class TestUtilities {
         assertTrue(hasLib);
     }
 
+    private <T> void assertSetsEqual(Set<T> expected, Set<T> actual) {
+        // Convert both sets to lists. It is needed due to issue that rust return the flags as string
+        List<GlideString> expectedList =
+                expected.stream().sorted().map(GlideString::of).collect(Collectors.toList());
+        List<GlideString> actualList =
+                actual.stream().sorted().map(GlideString::of).collect(Collectors.toList());
+
+        assertEquals(expectedList, actualList);
+    }
+
+    /**
+     * Validate whether `FUNCTION LIST` response contains required info.
+     *
+     * @param response The response from redis.
+     * @param libName Expected library name.
+     * @param functionDescriptions Expected function descriptions. Key - function name, value -
+     *     description.
+     * @param functionFlags Expected function flags. Key - function name, value - flags set.
+     * @param libCode Expected library to check if given.
+     */
+    @SuppressWarnings("unchecked")
+    public static void checkFunctionListResponseBinary(
+            Map<GlideString, Object>[] response,
+            GlideString libName,
+            Map<GlideString, GlideString> functionDescriptions,
+            Map<GlideString, Set<GlideString>> functionFlags,
+            Optional<GlideString> libCode) {
+        assertTrue(response.length > 0);
+        boolean hasLib = false;
+        for (var lib : response) {
+            hasLib = lib.containsValue(libName);
+            if (hasLib) {
+                var functions = (Object[]) lib.get(gs("functions"));
+                assertEquals(functionDescriptions.size(), functions.length);
+                for (var functionInfo : functions) {
+                    var function = (Map<GlideString, Object>) functionInfo;
+                    var functionName = (GlideString) function.get(gs("name"));
+                    assertEquals(functionDescriptions.get(functionName), function.get(gs("description")));
+                    assertSetsEqual(
+                            functionFlags.get(functionName), (Set<GlideString>) function.get(gs("flags")));
+                }
+                if (libCode.isPresent()) {
+                    assertEquals(libCode.get(), lib.get(gs("library_code")));
+                }
+                break;
+            }
+        }
+        assertTrue(hasLib);
+    }
+
     /**
      * Validate whether `FUNCTION STATS` response contains required info.
      *

--- a/java/integTest/src/test/java/glide/cluster/CommandTests.java
+++ b/java/integTest/src/test/java/glide/cluster/CommandTests.java
@@ -4,6 +4,7 @@ package glide.cluster;
 import static glide.TestConfiguration.REDIS_VERSION;
 import static glide.TestUtilities.assertDeepEquals;
 import static glide.TestUtilities.checkFunctionListResponse;
+import static glide.TestUtilities.checkFunctionListResponseBinary;
 import static glide.TestUtilities.checkFunctionStatsResponse;
 import static glide.TestUtilities.commonClusterClientConfig;
 import static glide.TestUtilities.createLuaLibWithLongRunningFunction;
@@ -1176,47 +1177,39 @@ public class CommandTests {
         }
 
         var expectedDescription =
-                new HashMap<String, String>() {
+                new HashMap<GlideString, GlideString>() {
                     {
-                        put(funcName.toString(), null);
+                        put(funcName, null);
                     }
                 };
         var expectedFlags =
-                new HashMap<String, Set<String>>() {
+                new HashMap<GlideString, Set<GlideString>>() {
                     {
-                        put(funcName.toString(), Set.of("no-writes"));
+                        put(funcName, Set.of(gs("no-writes")));
                     }
                 };
 
-        var response = clusterClient.functionList(false, route).get();
+        var response = clusterClient.functionListBinary(false, route).get();
         if (singleNodeRoute) {
             var flist = response.getSingleValue();
-            checkFunctionListResponse(
-                    flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+            checkFunctionListResponseBinary(
+                    flist, libName, expectedDescription, expectedFlags, Optional.empty());
         } else {
             for (var flist : response.getMultiValue().values()) {
-                checkFunctionListResponse(
-                        flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+                checkFunctionListResponseBinary(
+                        flist, libName, expectedDescription, expectedFlags, Optional.empty());
             }
         }
 
-        response = clusterClient.functionList(true, route).get();
+        response = clusterClient.functionListBinary(true, route).get();
         if (singleNodeRoute) {
             var flist = response.getSingleValue();
-            checkFunctionListResponse(
-                    flist,
-                    libName.toString(),
-                    expectedDescription,
-                    expectedFlags,
-                    Optional.of(code.toString()));
+            checkFunctionListResponseBinary(
+                    flist, libName, expectedDescription, expectedFlags, Optional.of(code));
         } else {
             for (var flist : response.getMultiValue().values()) {
-                checkFunctionListResponse(
-                        flist,
-                        libName.toString(),
-                        expectedDescription,
-                        expectedFlags,
-                        Optional.of(code.toString()));
+                checkFunctionListResponseBinary(
+                        flist, libName, expectedDescription, expectedFlags, Optional.of(code));
             }
         }
 
@@ -1239,18 +1232,18 @@ public class CommandTests {
 
         assertEquals(libName, clusterClient.functionLoad(newCode, true, route).get());
 
-        expectedDescription.put(newFuncName.toString(), null);
-        expectedFlags.put(newFuncName.toString(), Set.of("no-writes"));
+        expectedDescription.put(newFuncName, null);
+        expectedFlags.put(newFuncName, Set.of(gs("no-writes")));
 
-        response = clusterClient.functionList(false, route).get();
+        response = clusterClient.functionListBinary(false, route).get();
         if (singleNodeRoute) {
             var flist = response.getSingleValue();
-            checkFunctionListResponse(
-                    flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+            checkFunctionListResponseBinary(
+                    flist, libName, expectedDescription, expectedFlags, Optional.empty());
         } else {
             for (var flist : response.getMultiValue().values()) {
-                checkFunctionListResponse(
-                        flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+                checkFunctionListResponseBinary(
+                        flist, libName, expectedDescription, expectedFlags, Optional.empty());
             }
         }
 
@@ -1268,23 +1261,15 @@ public class CommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
         assertTrue(executionException.getMessage().contains("Library not found"));
 
-        response = clusterClient.functionList(true, route).get();
+        response = clusterClient.functionListBinary(true, route).get();
         if (singleNodeRoute) {
             var flist = response.getSingleValue();
-            checkFunctionListResponse(
-                    flist,
-                    libName.toString(),
-                    expectedDescription,
-                    expectedFlags,
-                    Optional.of(newCode.toString()));
+            checkFunctionListResponseBinary(
+                    flist, libName, expectedDescription, expectedFlags, Optional.of(newCode));
         } else {
             for (var flist : response.getMultiValue().values()) {
-                checkFunctionListResponse(
-                        flist,
-                        libName.toString(),
-                        expectedDescription,
-                        expectedFlags,
-                        Optional.of(newCode.toString()));
+                checkFunctionListResponseBinary(
+                        flist, libName, expectedDescription, expectedFlags, Optional.of(newCode));
             }
         }
 
@@ -1418,29 +1403,25 @@ public class CommandTests {
                 "one",
                 clusterClient.fcallReadOnly(funcName, new GlideString[] {gs("one"), gs("two")}).get());
 
-        var flist = clusterClient.functionList(false).get();
+        var flist = clusterClient.functionListBinary(false).get();
         var expectedDescription =
-                new HashMap<String, String>() {
+                new HashMap<GlideString, GlideString>() {
                     {
-                        put(funcName.toString(), null);
+                        put(funcName, null);
                     }
                 };
         var expectedFlags =
-                new HashMap<String, Set<String>>() {
+                new HashMap<GlideString, Set<GlideString>>() {
                     {
-                        put(funcName.toString(), Set.of("no-writes"));
+                        put(funcName, Set.of(gs("no-writes")));
                     }
                 };
-        checkFunctionListResponse(
-                flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.empty());
 
-        flist = clusterClient.functionList(true).get();
-        checkFunctionListResponse(
-                flist,
-                libName.toString(),
-                expectedDescription,
-                expectedFlags,
-                Optional.of(code.toString()));
+        flist = clusterClient.functionListBinary(true).get();
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.of(code));
 
         // re-load library without overwriting
         var executionException =
@@ -1473,19 +1454,15 @@ public class CommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
         assertTrue(executionException.getMessage().contains("Library not found"));
 
-        flist = clusterClient.functionList(libName.toString(), false).get();
-        expectedDescription.put(newFuncName.toString(), null);
-        expectedFlags.put(newFuncName.toString(), Set.of("no-writes"));
-        checkFunctionListResponse(
-                flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+        flist = clusterClient.functionListBinary(libName, false).get();
+        expectedDescription.put(newFuncName, null);
+        expectedFlags.put(newFuncName, Set.of(gs("no-writes")));
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.empty());
 
-        flist = clusterClient.functionList(libName.toString(), true).get();
-        checkFunctionListResponse(
-                flist,
-                libName.toString(),
-                expectedDescription,
-                expectedFlags,
-                Optional.of(newCode.toString()));
+        flist = clusterClient.functionListBinary(libName, true).get();
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.of(newCode));
 
         assertEquals(
                 2L, clusterClient.fcall(newFuncName, new GlideString[] {gs("one"), gs("two")}).get());

--- a/java/integTest/src/test/java/glide/standalone/CommandTests.java
+++ b/java/integTest/src/test/java/glide/standalone/CommandTests.java
@@ -4,6 +4,7 @@ package glide.standalone;
 import static glide.TestConfiguration.REDIS_VERSION;
 import static glide.TestUtilities.assertDeepEquals;
 import static glide.TestUtilities.checkFunctionListResponse;
+import static glide.TestUtilities.checkFunctionListResponseBinary;
 import static glide.TestUtilities.checkFunctionStatsResponse;
 import static glide.TestUtilities.commonClientConfig;
 import static glide.TestUtilities.createLuaLibWithLongRunningFunction;
@@ -604,29 +605,25 @@ public class CommandTests {
                         .get();
         assertEquals("one", functionResult);
 
-        var flist = regularClient.functionList(false).get();
+        var flist = regularClient.functionListBinary(false).get();
         var expectedDescription =
-                new HashMap<String, String>() {
+                new HashMap<GlideString, GlideString>() {
                     {
-                        put(funcName.toString(), null);
+                        put(funcName, null);
                     }
                 };
         var expectedFlags =
-                new HashMap<String, Set<String>>() {
+                new HashMap<GlideString, Set<GlideString>>() {
                     {
-                        put(funcName.toString(), Set.of("no-writes"));
+                        put(funcName, Set.of(gs("no-writes")));
                     }
                 };
-        checkFunctionListResponse(
-                flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.empty());
 
-        flist = regularClient.functionList(true).get();
-        checkFunctionListResponse(
-                flist,
-                libName.toString(),
-                expectedDescription,
-                expectedFlags,
-                Optional.of(code.toString()));
+        flist = regularClient.functionListBinary(true).get();
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.of(code));
 
         // re-load library without overwriting
         var executionException =
@@ -658,19 +655,15 @@ public class CommandTests {
         assertInstanceOf(RequestException.class, executionException.getCause());
         assertTrue(executionException.getMessage().contains("Library not found"));
 
-        flist = regularClient.functionList(libName.toString(), false).get();
-        expectedDescription.put(newFuncName.toString(), null);
-        expectedFlags.put(newFuncName.toString(), Set.of("no-writes"));
-        checkFunctionListResponse(
-                flist, libName.toString(), expectedDescription, expectedFlags, Optional.empty());
+        flist = regularClient.functionListBinary(libName, false).get();
+        expectedDescription.put(newFuncName, null);
+        expectedFlags.put(newFuncName, Set.of(gs("no-writes")));
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.empty());
 
-        flist = regularClient.functionList(libName.toString(), true).get();
-        checkFunctionListResponse(
-                flist,
-                libName.toString(),
-                expectedDescription,
-                expectedFlags,
-                Optional.of(newCode.toString()));
+        flist = regularClient.functionListBinary(libName, true).get();
+        checkFunctionListResponseBinary(
+                flist, libName, expectedDescription, expectedFlags, Optional.of(newCode));
 
         functionResult =
                 regularClient


### PR DESCRIPTION
Add function list binary output support

1. Add new API to get pattern as GlideString
2. Add new function handleFunctionListResponseBinary to handle binary output
3. Add new test utility to validate binary output

Note: there is a bug where the flags set always return as string. for now I fix the assert of the set with my own assert assertSetsEqual that convert to GlideString.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
