### PR TITLE
Java: Remove use of non-ASCII characters in String literal in FfiTest

### DIFF
--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -9,6 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.ffi.resolvers.RedisValueResolver;
+import lombok.SneakyThrows;
+
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
@@ -87,10 +90,17 @@ public class FfiTest {
     }
 
     @Test
+    @SneakyThrows
     public void redisValueToJavaValue_BulkString() {
-        String input = "dummyString";
-        byte[] bulkString = input.getBytes();
+        // This is explicitly for testing non-ASCII UTF-8 byte sequences.
+        // Note that these can't be encoded as String literals without introducing compiler
+        // warnings and errors.
+
+        // This is the 'alpha' character.
+        byte[] bulkString = new byte[] { (byte)0xCE, (byte)0xB1 };
         long ptr = FfiTest.createLeakedBulkString(bulkString);
+        final String input;
+        input = new String(bulkString, StandardCharsets.UTF_8);
         Object bulkStringValue = RedisValueResolver.valueFromPointer(ptr);
         assertEquals(input, bulkStringValue);
     }

--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -9,11 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.ffi.resolvers.RedisValueResolver;
-import lombok.SneakyThrows;
-
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -97,7 +96,7 @@ public class FfiTest {
         // warnings and errors.
 
         // This is the 'alpha' character.
-        byte[] bulkString = new byte[] { (byte)0xCE, (byte)0xB1 };
+        byte[] bulkString = new byte[] {(byte) 0xCE, (byte) 0xB1};
         long ptr = FfiTest.createLeakedBulkString(bulkString);
         final String input;
         input = new String(bulkString, StandardCharsets.UTF_8);

--- a/java/client/src/test/java/glide/ffi/FfiTest.java
+++ b/java/client/src/test/java/glide/ffi/FfiTest.java
@@ -88,7 +88,7 @@ public class FfiTest {
 
     @Test
     public void redisValueToJavaValue_BulkString() {
-        String input = "😀\n💎\n🗿";
+        String input = "dummyString";
         byte[] bulkString = input.getBytes();
         long ptr = FfiTest.createLeakedBulkString(bulkString);
         Object bulkStringValue = RedisValueResolver.valueFromPointer(ptr);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix compiler warning/error about non-ASCII characters in FfiTest.java

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
