### PR TITLE
Java: Try to fix log_to_file test flakiness

### DIFF
--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import glide.api.logging.Logger;
 import java.io.File;
 import java.util.Scanner;
+import java.util.UUID;
 import lombok.SneakyThrows;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public class LoggerTests {
@@ -36,8 +36,10 @@ public class LoggerTests {
     }
 
     @SneakyThrows
-    @RepeatedTest(1000)
+    @Test
     public void log_to_file() {
+        String logFileIdentifier = UUID.randomUUID().toString();
+
         String infoIdentifier = "Info";
         String infoMessage = "foo";
         String warnIdentifier = "Warn";
@@ -49,7 +51,9 @@ public class LoggerTests {
         String traceIdentifier = "Trace";
         String traceMessage = "squawk";
 
-        Logger.setLoggerConfig(Logger.Level.INFO, "log.txt");
+        String filename = logFileIdentifier + "log.txt";
+
+        Logger.setLoggerConfig(Logger.Level.INFO, filename);
         Logger.log(Logger.Level.INFO, infoIdentifier, infoMessage);
         Logger.log(Logger.Level.WARN, warnIdentifier, warnMessage);
         Logger.log(Logger.Level.ERROR, errorIdentifier, errorMessage);
@@ -67,25 +71,26 @@ public class LoggerTests {
         Logger.setLoggerConfig(Logger.Level.DEFAULT, "dummy.txt");
 
         File logFolder = new File("glide-logs");
-        File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith("log.txt."));
+        File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith(filename + "."));
         assertNotNull(logFiles);
         File logFile = logFiles[0];
-        logFile.deleteOnExit();
-        Scanner reader = new Scanner(logFile);
-        String infoLine = reader.nextLine();
-        String warnLine = reader.nextLine();
-        String errorLine = reader.nextLine();
-        String infoLineLazy = reader.nextLine();
-        String warnLineLazy = reader.nextLine();
-        String errorLineLazy = reader.nextLine();
-        assertFalse(reader.hasNextLine());
-        reader.close();
+        try (Scanner reader = new Scanner(logFile)) {
+            String infoLine = reader.nextLine();
+            String warnLine = reader.nextLine();
+            String errorLine = reader.nextLine();
+            String infoLineLazy = reader.nextLine();
+            String warnLineLazy = reader.nextLine();
+            String errorLineLazy = reader.nextLine();
+            assertFalse(reader.hasNextLine());
 
-        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
-        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
-        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
-        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
-        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
-        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
+            assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
+            assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
+            assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
+            assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
+            assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
+            assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
+        } finally {
+            logFile.delete();
+        }
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -67,10 +67,15 @@ public class LoggerTests {
         Logger.log(Logger.Level.DEBUG, debugIdentifier, () -> debugMessage);
         Logger.log(Logger.Level.TRACE, traceIdentifier, () -> traceMessage);
 
-        // Initialize a new logger to force closing of existing files
-        Logger.setLoggerConfig(Logger.Level.DEFAULT, "dummy.txt");
-
         File logFolder = new File("glide-logs");
+
+        // Initialize a new logger to force closing of existing files
+        String dummyFilename = "dummy.txt";
+        Logger.setLoggerConfig(Logger.Level.DEFAULT, dummyFilename);
+        File[] dummyLogFiles = logFolder.listFiles((dir, name) -> name.startsWith(dummyFilename + "."));
+        assertNotNull(dummyLogFiles);
+        File dummyLogFile = dummyLogFiles[0];
+
         File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith(filename + "."));
         assertNotNull(logFiles);
         File logFile = logFiles[0];
@@ -91,6 +96,8 @@ public class LoggerTests {
             assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
         } finally {
             logFile.delete();
+            dummyLogFile.delete();
+            logFolder.delete();
         }
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -62,9 +62,6 @@ public class LoggerTests {
         Logger.log(Logger.Level.DEBUG, debugIdentifier, () -> debugMessage);
         Logger.log(Logger.Level.TRACE, traceIdentifier, () -> traceMessage);
 
-        // Initialize a new logger to force closing of existing files
-        Logger.setLoggerConfig(Logger.Level.DEFAULT, "dummy.txt");
-
         File logFolder = new File("glide-logs");
         File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith("log.txt."));
         assertNotNull(logFiles);
@@ -72,19 +69,18 @@ public class LoggerTests {
         logFile.deleteOnExit();
         Scanner reader = new Scanner(logFile);
         String infoLine = reader.nextLine();
+        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
         String warnLine = reader.nextLine();
+        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
         String errorLine = reader.nextLine();
+        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
         String infoLineLazy = reader.nextLine();
+        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
         String warnLineLazy = reader.nextLine();
+        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
         String errorLineLazy = reader.nextLine();
+        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
         assertFalse(reader.hasNextLine());
         reader.close();
-
-        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
-        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
-        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
-        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
-        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
-        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -63,6 +63,9 @@ public class LoggerTests {
         Logger.log(Logger.Level.DEBUG, debugIdentifier, () -> debugMessage);
         Logger.log(Logger.Level.TRACE, traceIdentifier, () -> traceMessage);
 
+        // Initialize a new logger to force closing of existing files
+        Logger.setLoggerConfig(Logger.Level.DEFAULT, "dummy.txt");
+
         File logFolder = new File("glide-logs");
         File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith("log.txt."));
         assertNotNull(logFiles);
@@ -70,18 +73,19 @@ public class LoggerTests {
         logFile.deleteOnExit();
         Scanner reader = new Scanner(logFile);
         String infoLine = reader.nextLine();
-        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
         String warnLine = reader.nextLine();
-        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
         String errorLine = reader.nextLine();
-        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
         String infoLineLazy = reader.nextLine();
-        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
         String warnLineLazy = reader.nextLine();
-        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
         String errorLineLazy = reader.nextLine();
-        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
         assertFalse(reader.hasNextLine());
         reader.close();
+
+        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
+        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
+        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
+        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
+        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
+        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -62,6 +62,9 @@ public class LoggerTests {
         Logger.log(Logger.Level.DEBUG, debugIdentifier, () -> debugMessage);
         Logger.log(Logger.Level.TRACE, traceIdentifier, () -> traceMessage);
 
+        // Initialize a new logger to force closing of existing files
+        Logger.setLoggerConfig(Logger.Level.DEFAULT, "dummy.txt");
+
         File logFolder = new File("glide-logs");
         File[] logFiles = logFolder.listFiles((dir, name) -> name.startsWith("log.txt."));
         assertNotNull(logFiles);
@@ -69,18 +72,19 @@ public class LoggerTests {
         logFile.deleteOnExit();
         Scanner reader = new Scanner(logFile);
         String infoLine = reader.nextLine();
-        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
         String warnLine = reader.nextLine();
-        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
         String errorLine = reader.nextLine();
-        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
         String infoLineLazy = reader.nextLine();
-        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
         String warnLineLazy = reader.nextLine();
-        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
         String errorLineLazy = reader.nextLine();
-        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
         assertFalse(reader.hasNextLine());
         reader.close();
+
+        assertTrue(infoLine.contains(infoIdentifier + " - " + infoMessage));
+        assertTrue(warnLine.contains(warnIdentifier + " - " + warnMessage));
+        assertTrue(errorLine.contains(errorIdentifier + " - " + errorMessage));
+        assertTrue(infoLineLazy.contains(infoIdentifier + " - " + infoMessage));
+        assertTrue(warnLineLazy.contains(warnIdentifier + " - " + warnMessage));
+        assertTrue(errorLineLazy.contains(errorIdentifier + " - " + errorMessage));
     }
 }

--- a/java/integTest/src/test/java/glide/LoggerTests.java
+++ b/java/integTest/src/test/java/glide/LoggerTests.java
@@ -10,6 +10,7 @@ import glide.api.logging.Logger;
 import java.io.File;
 import java.util.Scanner;
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 public class LoggerTests {
@@ -35,7 +36,7 @@ public class LoggerTests {
     }
 
     @SneakyThrows
-    @Test
+    @RepeatedTest(1000)
     public void log_to_file() {
         String infoIdentifier = "Info";
         String infoMessage = "foo";


### PR DESCRIPTION
*Issue #, if available:*
N/A

This change moves assertions to the end of log_to_file and also initializes a new logger to try and close existing files.

I also tested by running it 100 times using @RepeatedTest to make sure it wasn't still failing with the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
