### PR TITLE
 Enable pubsub tests, change python build CI to only use python 3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,10 +58,6 @@ jobs:
             matrix:
                 engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
                 python:
-                  - "3.8"
-                  - "3.9"
-                  - "3.10"
-                  - "3.11"
                   - "3.12"
 
         steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
             matrix:
                 engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
                 python:
-                  - "3.12"
+                  - "3.10"
 
         steps:
             - uses: actions/checkout@v4
@@ -105,7 +105,7 @@ jobs:
             - name: Type check with mypy
               working-directory: ./python
               run: |
-                  # The type check should run inside the virtual envirnment to get
+                  # The type check should run inside the virtual env to get
                   # all installed dependencies and build files
                   source .env/bin/activate
                   pip install mypy types-protobuf

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -105,7 +105,7 @@ jobs:
             - name: Type check with mypy
               working-directory: ./python
               run: |
-                  # The type check should run inside the virtual env to get
+                  # The type check should run inside the virtual envirnment to get
                   # all installed dependencies and build files
                   source .env/bin/activate
                   pip install mypy types-protobuf

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
             matrix:
                 engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
                 python:
-                  - "3.12"
+                  - "3.10"
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
             matrix:
                 engine: ${{ fromJson(needs.load-engine-matrix.outputs.matrix) }}
                 python:
-                  - "3.10"
+                  - "3.12"
 
         steps:
             - uses: actions/checkout@v4

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
 markers =
     smoke_test: mark a test as a build verification testing.
-# TODO: Remove pubsub exclusion after the flakey tests are fixed
-addopts = -k "not redis_modules and not pubsub"
+addopts = -k "not redis_modules"

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -390,7 +390,6 @@ class BaseClient(CoreCommands):
         push_notification = cast(
             Dict[str, Any], value_from_pointer(response.resp_pointer)
         )
-        print(f"recieved push_notification={push_notification}")
         message_kind = push_notification["kind"]
         if message_kind == "Disconnection":
             ClientLogger.log(

--- a/python/python/glide/glide_client.py
+++ b/python/python/glide/glide_client.py
@@ -390,6 +390,7 @@ class BaseClient(CoreCommands):
         push_notification = cast(
             Dict[str, Any], value_from_pointer(response.resp_pointer)
         )
+        print(f"recieved push_notification={push_notification}")
         message_kind = push_notification["kind"]
         if message_kind == "Disconnection":
             ClientLogger.log(


### PR DESCRIPTION
Changes summary:
- Change python build CI to only use python 3.10. ATM we're seeing some flakeyness with pubsub tests in different python versions. Until we'll finish debugging the issue, we will revert our CI to run only against py3.10.
- Enable pubsub tests